### PR TITLE
Prototyping a conventional IFC labelcheck

### DIFF
--- a/datalog-prototyping/setMemberFlowsTo.dl
+++ b/datalog-prototyping/setMemberFlowsTo.dl
@@ -1,0 +1,36 @@
+#include "flatModules.dl"
+
+#ifndef SET_MEMBER_LABELS
+#define SET_MEMBER_LABELS
+
+.type labelElt <: symbol
+.type label <: symbol
+
+.decl isMember(le: labelElt, l: label)
+
+.decl notSubset(l1: label, l2: label)
+.decl flowsTo(l1: label, l2: label)
+
+.decl groundedLabelElt(le: labelElt)
+.decl groundedLabel(l: label)
+
+notSubset(l1, l2) :-
+    groundedLabel(l2),
+    groundedLabelElt(le),
+    isMember(le, l1),
+    !isMember(le, l2).
+
+flowsTo(l1, l2) :- 
+    groundedLabel(l1),
+    groundedLabel(l2),
+    !notSubset(l1, l2).
+
+// universe axiom (universe is "secret", emptyset is "public")
+groundedLabel("universe").
+groundedLabel("emptyset").
+isMember(le, "universe") :- groundedLabelElt(le).
+
+// ---- ground lowering
+groundedLabelElt(le) :- isMember(le, _).
+
+#endif //SET_MEMBER_LABELS

--- a/datalog-prototyping/setMemberLabelCheck.dl
+++ b/datalog-prototyping/setMemberLabelCheck.dl
@@ -1,0 +1,63 @@
+#include "flatModules.dl"
+#include "setMemberFlowsTo.dl"
+
+#ifndef SET_MEMBER_LABEL_CHECK
+#define SET_MEMBER_LABEL_CHECK
+
+.decl moduleLabelChecks(m: flatModule)
+.decl notModuleLabelChecks(m: flatModule)
+
+.decl fieldHasLabel(f: fieldName, l: label)
+
+// Intuitively, the label of a module is the join
+// over the label of its inputs, and it label checks
+// if the label of the module flows to each of its outputs.
+// We do not have universal quantifiers, though.
+
+// With ADT labels, we know how to compute the join
+// over a set of labels, but we don't have a way to get the normal form for ADT 
+// labels in datalog. (I saw some resources for how to do this in prolog). 
+// SetMember labels get around the need for a normal form
+
+// Two strategies to try:
+//  - compute join over fields using isMember labels
+//  - avoid computing this join over sets of labels by instead writing a 
+//  relation for "notLabelChecks"
+
+// We also eventually need rules that cover downgrading and non-downgrading 
+// cases.
+
+// // ---- Strategy 1: join over isMember labels
+// .decl fieldListHasLabel(f: fieldList, l: label)
+// 
+// fieldListLabelChecks($Nil(), "emptyset").
+// fieldListLabelChecks($Cons(f, fl), l) :-
+//     fieldListLabelChecks(fl, l1),
+//     hasLabel(f, l2),
+//     flowsTo(l1, l),
+//     flowsTo(l2, l).
+// 
+// moduleLabelChecks(FlatMod {readFields, writtenFields}) :-
+//     fieldListLabelChecks(readFields, l),
+//     // need to either compute meet over writtenFields (set intersection?)
+//     // or do "notLabelChecks" anyway 
+
+///---- Strategy2: Not labelChecks
+// A module does not labelcheck if there are fields
+// in the input/output lists such that the input label
+// does not flow to the output label
+notModuleLabelChecks($FlatMod (readFields, writtenFields)) :-
+    groundedList(readFields), groundedList(writtenFields),
+    fieldListContains(readFields, fr),
+    fieldListContains(writtenFields, fw),
+    fieldHasLabel(fr, lr), fieldHasLabel(fw, lw),
+    notSubset(lr, lw).
+
+moduleLabelChecks($FlatMod (readFields, writtenFields)) :- 
+    groundedList(readFields), groundedList(writtenFields),
+    !notModuleLabelChecks($FlatMod(readFields, writtenFields)).
+
+// ---- ground lowering
+groundedLabel(l) :- fieldHasLabel(_, l).
+
+#endif // SET_MEMBER_LABEL_CHECK

--- a/datalog-prototyping/test_setMemberLabelCheck.dl
+++ b/datalog-prototyping/test_setMemberLabelCheck.dl
@@ -1,0 +1,73 @@
+#include "setMemberLabelCheck.dl"
+
+// Module 1
+//      reads: 
+//          some_struct{ a, b }
+//          other_input
+//      writes:
+//          mod1out
+groundedFlatMod($FlatMod(
+    $Cons("some_struct.a", $Cons("some_struct.b",
+        $Cons("other_input", $Nil()))),
+    $Cons("mod1out", $Nil())
+)).
+
+// the label of "other_input" is the empty set (which makes it public).
+// so it has no label elements
+
+// Module 2
+//     reads:
+//         mod1out
+//         input4
+//     writes:
+//         mod2out 
+groundedFlatMod($FlatMod(
+    $Cons("mod1out", $Cons("input4", $Nil())),
+    $Cons("mod2out", $Nil())
+)).
+
+// Every struct just gets a label with its name
+fieldHasLabel("some_struct.a", "some_struct.a_label").
+fieldHasLabel("some_struct.b", "some_struct.b_label").
+fieldHasLabel("other_input", "other_input_label").
+fieldHasLabel("mod1out", "mod1out_label").
+fieldHasLabel("input4", "input4_label").
+fieldHasLabel("mod2out", "mod2out_label").
+
+// Manually fill in elements of labels
+// (otherwise DFA might try to guess the ones
+// that are not filled in)
+
+// Module 1 should label check
+isMember("raw_video", "some_struct.a_label").
+isMember("user_selection", "some_struct.b_label").
+    // other_input is public
+isMember("user_selection", "mod1out_label").
+isMember("raw_video", "mod1out_label").
+
+
+// Module 2 should not label check
+isMember("proprietary_data", "input4_label").
+isMember("raw_video", "mod2out_label").
+isMember("proprietary_data", "mod2out_label").
+// uncommenting this makes it label-check
+// isMember("user_selection", "mod2out_label").
+
+.decl test_label_checks(x: number)
+
+test_label_checks(1) :- moduleLabelChecks(
+    $FlatMod(
+        $Cons("some_struct.a", $Cons("some_struct.b",
+            $Cons("other_input", $Nil()))),
+        $Cons("mod1out", $Nil())
+    )
+).
+
+test_label_checks(2) :- moduleLabelChecks(
+    $FlatMod(
+        $Cons("mod1out", $Cons("input4", $Nil())),
+        $Cons("mod2out", $Nil())
+    )
+).
+
+.output test_label_checks


### PR DESCRIPTION
This code prototypes a conventional IFC label check to determine if there are
information leaks in any of the modules in a graph. A relational representation
of the lattice over sets using subset as the set operator. To get around
the need for either computing join over a set of labels (in other words \bigcup join),
a relation "notLabelChecks" is used to find a single counter-example
among input-output pairs and a module label checks if it not
notLabelChecks.

It looks like this is also amenable to separating the
rules into a dataflow analysis pass for label inference and for the
check -- the inference would fill in "fieldHasLabel".

It should also be possible to support downgrading using two sets
of rules for notLabelCheck, but this also needs to be tried.