### PR TITLE
Adds a souffle_cc_library rule.

### DIFF
--- a/build_defs/souffle.bzl
+++ b/build_defs/souffle.bzl
@@ -1,0 +1,47 @@
+#-----------------------------------------------------------------------------
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-----------------------------------------------------------------------------
+
+def souffle_cc_library(name, src, visibility = None):
+    """Generates a C++ interface for the given datalog file.
+
+    Args:
+      name: String; Name of the library.
+      src: String; The datalog program.
+      visibility: List; List of visibilities.
+    """
+    cc_file = src + ".cpp"
+    native.genrule(
+        name = name + "_cpp",
+        srcs = [src],
+        outs = [cc_file],
+        cmd = "$(location @souffle//:souffle) -g $@ $<",
+        tools = ["@souffle//:souffle"],
+        visibility = visibility,
+    )
+    native.cc_library(
+        name = name,
+        srcs = [cc_file],
+        copts = [
+            "-Iexternal/souffle/src/include/souffle",
+            "-std=c++17",
+        ],
+        defines = [
+            "__EMBEDDED_SOUFFLE__",
+        ],
+        deps = ["@souffle//:souffle_lib"],
+        alwayslink = True,
+        visibility = visibility,
+    )

--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -1,3 +1,8 @@
+load(
+    "//build_defs:souffle.bzl",
+    "souffle_cc_library",
+)
+
 licenses(["notice"])
 
 cc_binary(
@@ -7,5 +12,13 @@ cc_binary(
         "-Iexternal/souffle/src/include/souffle",
         "-std=c++17",
     ],
-    deps = ["@souffle//:souffle_lib"],
+    deps = [
+        "@souffle//:souffle_lib",
+        ":taint_dl"
+    ],
+)
+
+souffle_cc_library(
+    name = "taint_dl",
+    src = "taint.dl",
 )

--- a/src/analysis/souffle/cpp_interface.cc
+++ b/src/analysis/souffle/cpp_interface.cc
@@ -17,12 +17,15 @@
 // Just a simple example to check that we can use the Souffle C++ interface.
 //
 #include <iostream>
+#include <memory>
 
 #include "souffle/SouffleInterface.h"
 
 int main() {
-  souffle::SouffleProgram* prog = souffle::ProgramFactory::newInstance("test");
-  assert(prog == nullptr);
-  std::cout << "prog is nullptr as expected.\n";
+  std::unique_ptr<souffle::SouffleProgram> prog(
+      souffle::ProgramFactory::newInstance("taint"));
+  assert(prog != nullptr);
+  std::cout << "Found taint program as expected.\n";
+  prog->run();
   return 0;
 }


### PR DESCRIPTION
This allows us to create a cc_library that corresponds to the c++ interface of a `.dl` file. See `cpp_interface.cc` for an example of how this can be used.