### PR TITLE
Convert taint.dl to be more header-like.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bazel-bin
+bazel-out
+bazel-raksha
+bazel-testlogs
+**/*.swp

--- a/build_defs/BUILD
+++ b/build_defs/BUILD
@@ -1,1 +1,1 @@
-licenses("[notice]")
+licenses(["notice"])

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -28,6 +28,10 @@
 // paths. For the time being, we will use a `symbol` to represent access paths.
 // However, in the long term, it would make sense to define an ADT for this.
 //
+
+#ifndef SRC_ANALYSIS_SOUFFLE_TAINT_DL_
+#define SRC_ANALYSIS_SOUFFLE_TAINT_DL_
+
 .type AccessPath <: symbol
 
 // A symbol representing a taint (or information flow) tag. These would be
@@ -74,4 +78,4 @@ path(from, to) :- edge(from, intermediate), path(intermediate, to).
 mayHaveTag(tgt, tag) :- claimHasTag(tgt, tag).
 mayHaveTag(tgt, tag) :- edge(src, tgt), mayHaveTag(src, tag).
 
-.output mayHaveTag
+#endif // SRC_ANALYSIS_SOUFFLE_TAINT_DL_


### PR DESCRIPTION
In particular, add a #ifndef guard and remove the .output directive. Although Souffle datalog doesn't seem to have a standard convention for this, we should consider creating our own convention for distinguishing between files that act like C header files and files that act like compilation units.

I think Datalog header files should be guarded by include guards and should contain no .input nor .output directives. The reason for this is that, as headers, they should be includable into multiple different forms of Datalog analysis which may want to report different things. The .input and .output directives tie a file to gathering particular types of evidence from the outside and reporting certain types of evidence, respectively.

Although it may require some editor configuration, I think it might be valuable to name these kinds of files .dlh and .dlc (for header and compilation unit). Want feedback on that though, so haven't made the filename change here yet.