### PR TITLE
Switch testPasses -> testFails; allow multiple testFails rules.

### DIFF
--- a/src/analysis/souffle/fact_test_helper.dl
+++ b/src/analysis/souffle/fact_test_helper.dl
@@ -3,15 +3,11 @@
 
 #include "taint.dl"
 
-.type TestName <: symbol
+.type TestAspectName <: symbol
 
-// If a test has something in this relation, then it has passed. If not, then it has failed. Each
-// test in arcs_fact_tests must provide a rule that populates this relation indicating the
-// expectations that must be met for the test to pass. We check for whether this relation has
-// non-zero size in the test driver to decide whether to pass or fail the test. Although the test
-// driver does not care about the contents of this relation, we use the test name as the parameter
-// so printing the relation provides some useful information.
-.decl testPasses(testName: TestName)
-.output testPasses(IO=stdout, delimiter=",")
+// If a the testFails relation has any contents, then the test has failed. If not, it has passed.
+// Tests should create rules indicating what should not be true of the test for it to pass.
+.decl testFails(testAspectName: TestAspectName)
+.output testFails(IO=stdout, delimiter=",")
 
 #endif // SRC_ANALYSIS_SOUFFLE_ANALYZE_TAG_CHECKS_TEST_HELPER_DL_

--- a/src/analysis/souffle/tests/arcs_fact_tests/BUILD
+++ b/src/analysis/souffle/tests/arcs_fact_tests/BUILD
@@ -5,12 +5,16 @@ load(
 
 licenses(["notice"])
 
-DL_TEST_FILES = glob(["*.dl"])
+FAILURE_DL_TEST_FILES = glob(["*_expect_fails.dl"])
 
-filegroup(
-    name = "test_dl_scripts",
-    srcs = DL_TEST_FILES
-)
+ALL_DL_TEST_FILES = glob(["*.dl"])
+
+[sh_test(
+    name = dl_script.replace(".dl", "_contains_test_fails"),
+    srcs = ["contains_test_fails.sh"],
+    args = ["$(location {})".format(dl_script)],
+    data = [dl_script],
+) for dl_script in ALL_DL_TEST_FILES]
 
 [souffle_cc_library(
     name = dl_script.replace(".dl", "_souffle_cc_library"),
@@ -19,7 +23,7 @@ filegroup(
         "//src/analysis/souffle:fact_test_helper.dl",
     ],
     src = dl_script,
-) for dl_script in DL_TEST_FILES]
+) for dl_script in ALL_DL_TEST_FILES]
 
 [cc_test(
     name = dl_script.replace(".dl", "_test"),
@@ -33,10 +37,16 @@ filegroup(
         dl_script.replace(".dl", "_souffle_cc_library"),
     ],
     linkopts = ["-pthread"],
-    args = [dl_script.replace(".dl", "")],
-) for dl_script in DL_TEST_FILES]
+    args = [
+        dl_script.replace(".dl", ""),
+        "invert" if dl_script in FAILURE_DL_TEST_FILES else ""
+    ],
+) for dl_script in ALL_DL_TEST_FILES]
 
 test_suite(
     name = "arcs_fact_tests",
-    tests = [dl_script.replace(".dl", "_test") for dl_script in DL_TEST_FILES],
+    tests = [dl_script.replace(".dl", "_test")
+             for dl_script in ALL_DL_TEST_FILES] +
+            [dl_script.replace(".dl", "_contains_test_fails")
+             for dl_script in ALL_DL_TEST_FILES],
 )

--- a/src/analysis/souffle/tests/arcs_fact_tests/contains_test_fails.sh
+++ b/src/analysis/souffle/tests/arcs_fact_tests/contains_test_fails.sh
@@ -1,0 +1,2 @@
+set -e
+grep 'testFails' "$1"

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
@@ -22,6 +22,5 @@ claimHasTag("R.P1.foo", "notTrusted").
 edge("R.P1.foo", "R.h.Foo").
 edge("R.h.Foo", "R.P2.bar").
 
-testPasses("fail_different_tag") :-
-  !mayHaveTag("R.P2.bar", "trusted"),
-  mayHaveTag("R.P2.bar", "notTrusted").
+testFails("should_not_be_tagged_with_trusted") :- mayHaveTag("R.P2.bar", "trusted").
+testFails("should_be_tagged_with_notTrusted") :- !mayHaveTag("R.P2.bar", "notTrusted").

--- a/src/analysis/souffle/tests/arcs_fact_tests/not_failing_passes.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/not_failing_passes.dl
@@ -1,0 +1,5 @@
+// Used to ensure that a test which has a testFails requirement which is unmet will pass.
+#include "taint.dl"
+#include "fact_test_helper.dl"
+
+testFails("not_failing_passes") :- 1 = 2.

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
@@ -31,4 +31,4 @@ edge("R.P2.foo", "R.h2.Foo").
 edge("R.h2.Foo", "R.P3.bar").
 
 // This test passes if R.P3.bar has the trusted tag.
-testPasses("ok_claim_propagates") :- mayHaveTag("R.P3.bar", "trusted").
+testFails("ok_claim_propagates") :- !mayHaveTag("R.P3.bar", "trusted").

--- a/src/analysis/souffle/tests/arcs_fact_tests/one_pass_one_fail_expect_fails.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/one_pass_one_fail_expect_fails.dl
@@ -1,0 +1,7 @@
+// Used to ensure that a test with multiple failure conditions that fails at least one of those
+// conditions fails.
+#include "taint.dl"
+#include "fact_test_helper.dl"
+
+testFails("non_passing_test") :- 1 = 1.
+testFails("passing_test") :- 1 = 2.

--- a/src/analysis/souffle/tests/arcs_fact_tests/simple_fail_expect_fails.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/simple_fail_expect_fails.dl
@@ -1,0 +1,5 @@
+// Used to ensure that a test which has a testFails requirement which is met will pass.
+#include "taint.dl"
+#include "fact_test_helper.dl"
+
+testFails("simple_fail") :- 1 = 1.


### PR DESCRIPTION
Initially, I created tests using a relation called testPasses for two
reasons:

1. To allow tests to state what they want rather than the opposite of
   what they want.
2. To have a natural check that we included a test predicate at all.

@bgogul pointed out that we might want to add multiple rules stating the
requirements of the test and fail if any one of those rules failed. This
was not possible to do with testPasses. This commit switches to using
testFails, which naturally allows for expressing multiple requirements
in multiple rules.

This, however, opens us up to the possibility that someone might forget
to put a testFails at the bottom of a test entirely. I could not find
a good way to fix this in datalog, so as a very crude guardrail, I added a
shell test that just greps each file for testFails.