### PR TITLE
Suppress warnings when building Souffle.

### DIFF
--- a/third_party/souffle/BUILD
+++ b/third_party/souffle/BUILD
@@ -35,7 +35,7 @@ genrule(
         "src/parser/parser.hh",
         "src/parser/stack.hh",
     ],
-    cmd = "M4=$(M4) $(BISON) -d --output=$(RULEDIR)/src/parser/parser.cc $<",
+    cmd = "M4=$(M4) $(BISON) -d --warnings=none --output=$(RULEDIR)/src/parser/parser.cc $<",
     toolchains = [
         "@rules_bison//bison:current_bison_toolchain",
         "@rules_m4//m4:current_m4_toolchain",
@@ -73,6 +73,9 @@ cc_library(
     hdrs = glob(["src/**/*.h"]) + [":parser_gen"],
     copts = [
         "-std=c++17",
+        # We don't care about non-critical issues in the third-party Souffle
+        # project.
+        "-w",
     ],
     includes = [
         "src",
@@ -93,7 +96,12 @@ cc_library(
 cc_binary(
     name = "souffle",
     srcs = ["src/main.cpp"],
-    copts = ["-std=c++17"],
+    copts = [
+        "-std=c++17",
+        # We don't care about non-critical issues in the third-party Souffle
+        # project.
+        "-w",
+    ],
     linkopts = ["-pthread"],
     deps = [":souffle_lib"],
 )

--- a/third_party/souffle/BUILD
+++ b/third_party/souffle/BUILD
@@ -98,8 +98,8 @@ cc_binary(
     srcs = ["src/main.cpp"],
     copts = [
         "-std=c++17",
-        # We don't care about non-critical issues in the third-party Souffle
-        # project.
+        # We don't want warnings in 3rd party packages to obscure issues in our
+        # own code that we are more likely to need to fix.
         "-w",
     ],
     linkopts = ["-pthread"],

--- a/third_party/souffle/BUILD
+++ b/third_party/souffle/BUILD
@@ -73,8 +73,8 @@ cc_library(
     hdrs = glob(["src/**/*.h"]) + [":parser_gen"],
     copts = [
         "-std=c++17",
-        # We don't care about non-critical issues in the third-party Souffle
-        # project.
+        # We don't want warnings in 3rd party packages to obscure issues in our
+        # own code that we are more likely to need to fix.
         "-w",
     ],
     includes = [


### PR DESCRIPTION
In a previous commit, I added options to suppress warnings while
building files generated by Souffle. This commit further suppresses
warnings in code that we will not directly fix by suppressing warnings
when building Souffle itself.