### PR TITLE
Split the Tag domain into Privacy, Integrity, and Claimed tags.

### DIFF
--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -25,7 +25,7 @@ souffle_cc_library(
     src = "taint.dl",
 )
 
-exports_files(["fact_test_helper.dl"])
+exports_files(["tags.dl", "fact_test_helper.dl"])
 
 test_suite(
     name = "all_tests",

--- a/src/analysis/souffle/tags.dl
+++ b/src/analysis/souffle/tags.dl
@@ -33,7 +33,7 @@
 .type IntegrityTag <: symbol
 
 // This is a tag that a user or some principal claims is present upon some accessPath. This
-// introduces *both* a privacy and integrity tag upon that accessPath, which will each
+// introduces *both* a secrecy and integrity tag upon that accessPath, which will each
 // independently spread through the graph from that point according to their different behavior
 // patterns.
 .type ClaimedTag <: symbol

--- a/src/analysis/souffle/tags.dl
+++ b/src/analysis/souffle/tags.dl
@@ -1,0 +1,41 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+// Definition of the base tag types that are used by this dataflow analysis.
+
+#ifndef SRC_ANALYSIS_SOUFFLE_TAGS_DL_
+#define SRC_ANALYSIS_SOUFFLE_TAGS_DL_
+
+// A symbol representing a taint tag. SecrecyTags indicate that the data upon which they are
+// annotated potentially contain information that should be handled with some sort of special care
+// and should not be exposed to some outside group. The conservative approximation for SecrecyTags
+// is, when you are in doubt whether a particular datum should have this tag, annotate it. This
+// causes these tags to spread like taint.
+.type SecrecyTag <: symbol
+
+// A symbol representing a guarantee tag. IntegrityTags indicate that the data upon which they are
+// annotated have some critical property that handlers must take care to preserve. The conservative
+// approximation for IntegrityTags is, when you are in doubt whether a particular datum should have
+// this tag, do not annotate it. This causes these tags to disappear unless carefully handled.
+.type IntegrityTag <: symbol
+
+// This is a tag that a user or some principal claims is present upon some accessPath. This
+// introduces *both* a privacy and integrity tag upon that accessPath, which will each
+// independently spread through the graph from that point according to their different behavior
+// patterns.
+.type ClaimedTag <: symbol
+
+#endif // SRC_ANALYSIS_SOUFFLE_TAGS_DL_

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -40,7 +40,7 @@
 // (Useful for scoping when negation is involved.)
 .decl isAccessPath(accessPath: AccessPath)
 
-// The set of all privacy tags.
+// The set of all secrecy tags.
 // (Useful for scoping when negation is involved.)
 .decl allSecrecyTags(secrecyTag: SecrecyTag)
 
@@ -68,7 +68,7 @@
 // If true, `accessPath` *definitely* has the integrity property indicated by tag at runtime.
 .decl mustHaveIntegrityTag(accessPath: AccessPath, integrityTag: IntegrityTag)
 
-// There is a claim that `accessPath` definitely has `tag`. This introduces *both* a privacy and
+// There is a claim that `accessPath` definitely has `tag`. This introduces *both* a secrecy and
 // integrity tag.
 .decl claimHasTag(accessPath: AccessPath, claimedTag: ClaimedTag)
 

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -34,12 +34,12 @@
 
 .type AccessPath <: symbol
 
-// A symbol representing a taint tag. PrivacyTags indicate that the data upon which they are
+// A symbol representing a taint tag. SecrecyTags indicate that the data upon which they are
 // annotated potentially contain information that should be handled with some sort of special care
-// and should not be exposed to some outside group. The conservative approximation for PrivacyTags
+// and should not be exposed to some outside group. The conservative approximation for SecrecyTags
 // is, when you are in doubt whether a particular datum should have this tag, annotate it. This
 // causes these tags to spread like taint.
-.type PrivacyTag <: symbol
+.type SecrecyTag <: symbol
 
 // A symbol representing a guarantee tag. IntegrityTags indicate that the data upon which they are
 // annotated have some critical property that handlers must take care to preserve. The conservative
@@ -59,7 +59,7 @@
 
 // The set of all privacy tags.
 // (Useful for scoping when negation is involved.)
-.decl allPrivacyTags(privacyTag: PrivacyTag)
+.decl allSecrecyTags(secrecyTag: SecrecyTag)
 
 // The set of all integrity tags.
 // (Useful for scoping when negation is involved.)
@@ -75,10 +75,10 @@
 // A direct or transitive data flow path.
 .decl path(src: AccessPath, tgt: AccessPath)
 
-// Declares that `accessPath` may have be tainted with `privacyTag`.
-// If false, `accessPath` *definitely* does not `privacyTag` taint at runtime.
-// If true, `accessPath` may have the `privacyTag` taint at runtime.
-.decl mayHavePrivacyTag(accessPath: AccessPath, privacyTag: PrivacyTag)
+// Declares that `accessPath` may have be tainted with `secrecyTag`.
+// If false, `accessPath` *definitely* does not `secrecyTag` taint at runtime.
+// If true, `accessPath` may have the `secrecyTag` taint at runtime.
+.decl mayHaveSecrecyTag(accessPath: AccessPath, secrecyTag: SecrecyTag)
 
 // Declares that `accessPath` must be tagged with `integrityTag`.
 // If false, `accessPath` may or may not have the integrity property indicated by tag at runtime.
@@ -95,8 +95,8 @@
 isAccessPath(x) :- edge(x, _).
 isAccessPath(y) :- edge(_, y).
 
-allPrivacyTags(as(claimedTag, PrivacyTag)) :- claimHasTag(_, claimedTag).
-allPrivacyTags(privacyTag) :- mayHavePrivacyTag(_, privacyTag).
+allSecrecyTags(as(claimedTag, SecrecyTag)) :- claimHasTag(_, claimedTag).
+allSecrecyTags(secrecyTag) :- mayHaveSecrecyTag(_, secrecyTag).
 
 allIntegrityTags(as(claimedTag, IntegrityTag)) :- claimHasTag(_, claimedTag).
 allIntegrityTags(integrityTag) :- mustHaveIntegrityTag(_, integrityTag).
@@ -105,8 +105,8 @@ allIntegrityTags(integrityTag) :- mustHaveIntegrityTag(_, integrityTag).
 path(from, to) :- edge(from, to).
 path(from, to) :- edge(from, intermediate), path(intermediate, to).
 
-mayHavePrivacyTag(tgt, as(claimedTag, PrivacyTag)) :- claimHasTag(tgt, claimedTag).
-mayHavePrivacyTag(tgt, privacyTag) :- edge(src, tgt), mayHavePrivacyTag(src, privacyTag).
+mayHaveSecrecyTag(tgt, as(claimedTag, SecrecyTag)) :- claimHasTag(tgt, claimedTag).
+mayHaveSecrecyTag(tgt, secrecyTag) :- edge(src, tgt), mayHaveSecrecyTag(src, secrecyTag).
 
 // TODO: Implement the rule that causes integrity tags to propagate. Right now, they are only
 // annotated where initially claimed.

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -32,26 +32,9 @@
 #ifndef SRC_ANALYSIS_SOUFFLE_TAINT_DL_
 #define SRC_ANALYSIS_SOUFFLE_TAINT_DL_
 
+#include "tags.dl"
+
 .type AccessPath <: symbol
-
-// A symbol representing a taint tag. SecrecyTags indicate that the data upon which they are
-// annotated potentially contain information that should be handled with some sort of special care
-// and should not be exposed to some outside group. The conservative approximation for SecrecyTags
-// is, when you are in doubt whether a particular datum should have this tag, annotate it. This
-// causes these tags to spread like taint.
-.type SecrecyTag <: symbol
-
-// A symbol representing a guarantee tag. IntegrityTags indicate that the data upon which they are
-// annotated have some critical property that handlers must take care to preserve. The conservative
-// approximation for IntegrityTags is, when you are in doubt whether a particular datum should have
-// this tag, do not annotate it. This causes these tags to disappear unless carefully handled.
-.type IntegrityTag <: symbol
-
-// This is a tag that a user or some principal claims is present upon some accessPath. This
-// introduces *both* a privacy and integrity tag upon that accessPath, which will each
-// independently spread through the graph from that point according to their different behavior
-// patterns.
-.type ClaimedTag <: symbol
 
 // Is this symbol an access path to some data?
 // (Useful for scoping when negation is involved.)

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -34,18 +34,40 @@
 
 .type AccessPath <: symbol
 
-// A symbol representing a taint (or information flow) tag. These would be
-// strings of the form "secret", "public", "timestampInMs", etc. Just like
-// `AccessPath`, it would make sense to define an ADT in the long term.
-.type Tag <: symbol
+// A symbol representing a taint tag. PrivacyTags indicate that the data upon which they are
+// annotated potentially contain information that should be handled with some sort of special care
+// and should not be exposed to some outside group. The conservative approximation for PrivacyTags
+// is, when you are in doubt whether a particular datum should have this tag, annotate it. This
+// causes these tags to spread like taint.
+.type PrivacyTag <: symbol
+
+// A symbol representing a guarantee tag. IntegrityTags indicate that the data upon which they are
+// annotated have some critical property that handlers must take care to preserve. The conservative
+// approximation for IntegrityTags is, when you are in doubt whether a particular datum should have
+// this tag, do not annotate it. This causes these tags to disappear unless carefully handled.
+.type IntegrityTag <: symbol
+
+// This is a tag that a user or some principal claims is present upon some accessPath. This
+// introduces *both* a privacy and integrity tag upon that accessPath, which will each
+// independently spread through the graph from that point according to their different behavior
+// patterns.
+.type ClaimedTag <: symbol
 
 // Is this symbol an access path to some data?
 // (Useful for scoping when negation is involved.)
 .decl isAccessPath(accessPath: AccessPath)
 
-// Is this a Tag?
+// The set of all privacy tags.
 // (Useful for scoping when negation is involved.)
-.decl isTag(tag: Tag)
+.decl allPrivacyTags(privacyTag: PrivacyTag)
+
+// The set of all integrity tags.
+// (Useful for scoping when negation is involved.)
+.decl allIntegrityTags(integrityTag: IntegrityTag)
+
+// The set of all claimed tags.
+// (Useful for scoping when negation is involved.)
+.decl allClaimedTags(claimedTag: ClaimedTag)
 
 // A data flow edge.
 .decl edge(src: AccessPath, tgt: AccessPath)
@@ -53,13 +75,19 @@
 // A direct or transitive data flow path.
 .decl path(src: AccessPath, tgt: AccessPath)
 
-// Declares that `accessPath` may have be tainted with `tag`.
-// If false, `accessPath` *definitely* does not `tag` taint at runtime.
-// If true, `accessPath` may have the `tag` taint at runtime.
-.decl mayHaveTag(accessPath: AccessPath, tag: Tag)
+// Declares that `accessPath` may have be tainted with `privacyTag`.
+// If false, `accessPath` *definitely* does not `privacyTag` taint at runtime.
+// If true, `accessPath` may have the `privacyTag` taint at runtime.
+.decl mayHavePrivacyTag(accessPath: AccessPath, privacyTag: PrivacyTag)
 
-// There is a claim that `accessPath` definitely has `tag` taint.
-.decl claimHasTag(accessPath: AccessPath, tag: Tag)
+// Declares that `accessPath` must be tagged with `integrityTag`.
+// If false, `accessPath` may or may not have the integrity property indicated by tag at runtime.
+// If true, `accessPath` *definitely* has the integrity property indicated by tag at runtime.
+.decl mustHaveIntegrityTag(accessPath: AccessPath, integrityTag: IntegrityTag)
+
+// There is a claim that `accessPath` definitely has `tag`. This introduces *both* a privacy and
+// integrity tag.
+.decl claimHasTag(accessPath: AccessPath, claimedTag: ClaimedTag)
 
 // Some inference rules
 
@@ -67,15 +95,21 @@
 isAccessPath(x) :- edge(x, _).
 isAccessPath(y) :- edge(_, y).
 
-// Symbols used in hasTag or mayHaveTag are tags
-isTag(tag) :- claimHasTag(_, tag).
-isTag(tag) :- mayHaveTag(_, tag).
+allPrivacyTags(as(claimedTag, PrivacyTag)) :- claimHasTag(_, claimedTag).
+allPrivacyTags(privacyTag) :- mayHavePrivacyTag(_, privacyTag).
+
+allIntegrityTags(as(claimedTag, IntegrityTag)) :- claimHasTag(_, claimedTag).
+allIntegrityTags(integrityTag) :- mustHaveIntegrityTag(_, integrityTag).
 
 // Transitive paths
 path(from, to) :- edge(from, to).
 path(from, to) :- edge(from, intermediate), path(intermediate, to).
 
-mayHaveTag(tgt, tag) :- claimHasTag(tgt, tag).
-mayHaveTag(tgt, tag) :- edge(src, tgt), mayHaveTag(src, tag).
+mayHavePrivacyTag(tgt, as(claimedTag, PrivacyTag)) :- claimHasTag(tgt, claimedTag).
+mayHavePrivacyTag(tgt, privacyTag) :- edge(src, tgt), mayHavePrivacyTag(src, privacyTag).
+
+// TODO: Implement the rule that causes integrity tags to propagate. Right now, they are only
+// annotated where initially claimed.
+mustHaveIntegrityTag(tgt, as(claimedTag, IntegrityTag)) :- claimHasTag(tgt, claimedTag).
 
 #endif // SRC_ANALYSIS_SOUFFLE_TAINT_DL_

--- a/src/analysis/souffle/tests/arcs_fact_tests/BUILD
+++ b/src/analysis/souffle/tests/arcs_fact_tests/BUILD
@@ -12,6 +12,7 @@ ALL_DL_TEST_FILES = glob(["*.dl"])
 [souffle_cc_library(
     name = dl_script.replace(".dl", "_souffle_cc_library"),
     included_dl_scripts = [
+        "//src/analysis/souffle:tags.dl",
         "//src/analysis/souffle:taint.dl",
         "//src/analysis/souffle:fact_test_helper.dl",
     ],

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
@@ -25,5 +25,20 @@ claimHasTag("R.P1.foo", "userSelection").
 edge("R.P1.foo", "R.h.Foo").
 edge("R.h.Foo", "R.P2.bar").
 
-TEST_CASE("should_not_be_tagged_with_trusted") :- !mayHaveTag("R.P2.bar", "screenContent").
-TEST_CASE("should_be_tagged_with_notTrusted") :- mayHaveTag("R.P2.bar", "userSelection").
+TEST_CASE("initial_should_have_user_selection_tags") :-
+  mayHavePrivacyTag("R.P1.foo", "userSelection"),
+  mustHaveIntegrityTag("R.P1.foo", "userSelection").
+
+TEST_CASE("initial_should_not_have_screen_content_tags") :-
+  !mayHavePrivacyTag("R.P1.foo", "screenContent"),
+  !mustHaveIntegrityTag("R.P1.foo", "screenContent").
+
+TEST_CASE("should_not_be_tagged_with_privacy_screenContent") :-
+  !mayHavePrivacyTag("R.P2.bar", "screenContent").
+TEST_CASE("should_be_tagged_with_privacy_userSelection") :-
+  mayHavePrivacyTag("R.P2.bar", "userSelection").
+
+TEST_CASE("should_not_be_tagged_with_integrity_screenContent") :-
+  !mustHaveIntegrityTag("R.P2.bar", "screenContent").
+TEST_CASE("should_not_be_tagged_with_integrity_userSelection") :-
+  !mustHaveIntegrityTag("R.P2.bar", "userSelection").

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
@@ -26,17 +26,17 @@ edge("R.P1.foo", "R.h.Foo").
 edge("R.h.Foo", "R.P2.bar").
 
 TEST_CASE("initial_should_have_user_selection_tags") :-
-  mayHavePrivacyTag("R.P1.foo", "userSelection"),
+  mayHaveSecrecyTag("R.P1.foo", "userSelection"),
   mustHaveIntegrityTag("R.P1.foo", "userSelection").
 
 TEST_CASE("initial_should_not_have_screen_content_tags") :-
-  !mayHavePrivacyTag("R.P1.foo", "screenContent"),
+  !mayHaveSecrecyTag("R.P1.foo", "screenContent"),
   !mustHaveIntegrityTag("R.P1.foo", "screenContent").
 
-TEST_CASE("should_not_be_tagged_with_privacy_screenContent") :-
-  !mayHavePrivacyTag("R.P2.bar", "screenContent").
-TEST_CASE("should_be_tagged_with_privacy_userSelection") :-
-  mayHavePrivacyTag("R.P2.bar", "userSelection").
+TEST_CASE("should_not_be_tagged_with_secrecy_screenContent") :-
+  !mayHaveSecrecyTag("R.P2.bar", "screenContent").
+TEST_CASE("should_be_tagged_with_secrecy_userSelection") :-
+  mayHaveSecrecyTag("R.P2.bar", "userSelection").
 
 TEST_CASE("should_not_be_tagged_with_integrity_screenContent") :-
   !mustHaveIntegrityTag("R.P2.bar", "screenContent").

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
@@ -32,9 +32,9 @@ edge("R.P2.bar", "R.P2.foo").
 edge("R.P2.foo", "R.h2.Foo").
 edge("R.h2.Foo", "R.P3.bar").
 
-TEST_CASE("initial_has_privacy") :- mayHavePrivacyTag("R.P1.foo", "userSelection").
+TEST_CASE("initial_has_secrecy") :- mayHaveSecrecyTag("R.P1.foo", "userSelection").
 TEST_CASE("initial_has_integrity") :- mustHaveIntegrityTag("R.P1.foo", "userSelection").
 // This test passes if R.P3.bar has the userSelection tag.
-TEST_CASE("ok_claim_propagates_privacy") :- mayHavePrivacyTag("R.P3.bar", "userSelection").
+TEST_CASE("ok_claim_propagates_secrecy") :- mayHaveSecrecyTag("R.P3.bar", "userSelection").
 TEST_CASE("ok_claim_not_propagates_integrity") :-
   allIntegrityTags("userSelection"), !mustHaveIntegrityTag("R.P3.bar", "userSelection").

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
@@ -32,5 +32,9 @@ edge("R.P2.bar", "R.P2.foo").
 edge("R.P2.foo", "R.h2.Foo").
 edge("R.h2.Foo", "R.P3.bar").
 
-// This test passes if R.P3.bar has the trusted tag.
-TEST_CASE("ok_claim_propagates") :- mayHaveTag("R.P3.bar", "userSelection").
+TEST_CASE("initial_has_privacy") :- mayHavePrivacyTag("R.P1.foo", "userSelection").
+TEST_CASE("initial_has_integrity") :- mustHaveIntegrityTag("R.P1.foo", "userSelection").
+// This test passes if R.P3.bar has the userSelection tag.
+TEST_CASE("ok_claim_propagates_privacy") :- mayHavePrivacyTag("R.P3.bar", "userSelection").
+TEST_CASE("ok_claim_not_propagates_integrity") :-
+  allIntegrityTags("userSelection"), !mustHaveIntegrityTag("R.P3.bar", "userSelection").


### PR DESCRIPTION
As discussions on Raksha have evolved, it has become clear that there is
no coherent notion of a simple, unqualified "tag". Privacy tags spread
like taint in a worst-case scenario, integrity tags disappear unless
properly handled, and the initial tag the user claims immediately splits
into each of the above kinds. It makes sense to ask whether a Privacy
tag "may" be present, but not whether it "must" be present; it does not
make sense to ask whether an Integrity tag "may" be present, but is
sensible to ask whether it "must" be present.

To address this reality, this commit introduces new base types for
Privacy, Integrity, and Claimed tags and places the appropriate type on
the appropriate "presence" queries.