### PR TITLE
Ensure that each TEST_CASE must be provided a unique name.

### DIFF
--- a/src/analysis/souffle/fact_test_helper.dl
+++ b/src/analysis/souffle/fact_test_helper.dl
@@ -12,8 +12,22 @@
 
 // All test aspects tested by a particular test. Should usually be populated by TEST_CASE rather
 // than directly used.
+.decl allTestsAndCaseNum(testAspectName: TestAspectName, caseNum: number)
+
 .decl allTests(testAspectName: TestAspectName)
 .output allTests(IO=stdout, delimiter=",")
+
+allTests(testAspectName) :- allTestsAndCaseNum(testAspectName, _).
+
+.decl duplicateTestCaseNames(testAspectName: TestAspectName)
+.output duplicateTestCaseNames(IO=stdout, delimiter=",")
+
+// Catch if the user provides duplicate test aspect names. We can use this to print an error in the
+// test handler.
+duplicateTestCaseNames(testAspectName) :-
+  allTestsAndCaseNum(testAspectName, caseNum1),
+  allTestsAndCaseNum(testAspectName, caseNum2),
+  caseNum1 != caseNum2.
 
 // If the testFails relation has any contents, then the test has failed. Should not be populated
 // directly.
@@ -23,15 +37,18 @@
 testFails(testAspectName) :- allTests(testAspectName), !testPasses(testAspectName).
 
 // TEST_CASE is constructed so that it can take the place of a rule head. It "declares" a test
-// aspect via the allTests fact and sets up a testPasses head for the aspect in question. Example
-// usage:
+// aspect via the allTestsAndCaseNum fact and sets up a testPasses head for the aspect in question.
+// The $ functor used in the argument to allTestsAndCaseNum allows assigning each test case
+// a unique number, useful for catching if the user accidentally used the same name for two
+// different test cases.
+// Example usage:
 //
 // TEST_CASE("my_test_aspect") :- MyRelation(x), !MyOtherRelation(x).
 //
 // All recipes with a TEST_CASE head shall be seen as a condition that must be met for the test to
 // pass.
 #define TEST_CASE(test_aspect_name) \
-  allTests(test_aspect_name). \
+  allTestsAndCaseNum(test_aspect_name, $) :- 1 = 1. \
   testPasses(test_aspect_name)
 
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/duplicate_case_name_expect_fails.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/duplicate_case_name_expect_fails.dl
@@ -1,0 +1,8 @@
+// Used to ensure that a test with a duplicated test case name fails, even if both cases succeed.
+// This prevents us from having spurious successes due to a failing test having the same name as
+// a passing one.
+#include "taint.dl"
+#include "fact_test_helper.dl"
+
+TEST_CASE("one_equal_to_one") :- 1 = 1.
+TEST_CASE("one_equal_to_one") :- 2 = 2.

--- a/src/analysis/souffle/tests/arcs_fact_tests/duplicate_case_name_with_failure_expect_fails.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/duplicate_case_name_with_failure_expect_fails.dl
@@ -1,0 +1,9 @@
+// Used to ensure that a test with a duplicated test case name fails if one case fails and the
+// other succeeds. This matches closely the case we want to prevent from happening in the repo, as
+// if we did not take care to prevent this, one instance of the name would be added to the
+// testSucceeds set, masking the other failure.
+#include "taint.dl"
+#include "fact_test_helper.dl"
+
+TEST_CASE("one_equal_to_one") :- 1 = 1.
+TEST_CASE("one_equal_to_one") :- 1 = 2.

--- a/src/analysis/souffle/tests/arcs_fact_tests/fact_test_driver.cc
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fact_test_driver.cc
@@ -36,11 +36,14 @@ int run_test(std::string const &test_name) {
 
   souffle::Relation *test_failures = prog->getRelation("testFails");
   souffle::Relation *all_tests = prog->getRelation("allTests");
+  souffle::Relation *duplicate_test_case_names =
+    prog->getRelation("duplicateTestCaseNames");
 
   assert(test_failures != nullptr);
 
   bool const test_is_trivial = all_tests->size() == 0;
   bool const test_has_failures = test_failures->size() > 0;
+  bool const test_has_duplicate_names = duplicate_test_case_names->size() > 0;
 
   if (test_is_trivial) {
     std::cout
@@ -48,17 +51,20 @@ int run_test(std::string const &test_name) {
       << test_name
       << " does not have any test conditions."
       << std::endl;
-    prog->printAll();
-    return 1;
+  } else if (test_has_duplicate_names) {
+    std::cout
+      << "Test "
+      << test_name
+      << " has multiple test cases with the same name."
+      << std::endl;
   } else if (test_has_failures) {
     std::cout << "Test " << test_name << " failed." << std::endl;
-    prog->printAll();
-    return 1;
   } else {
     std::cout << "Test " << test_name << " succeeded." << std::endl;
     return 0;
   }
-  assert(false); // Should be unreachable.
+  prog->printAll();
+  return 1;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Before this, if someone provided two TEST_CASEs with the same name on
accident, and one failed, the test would still pass. This would occur
because the duplicated name would be added idempotently to allTests
twice, but to testSucceeds once, resulting in the condition for
testFails for that case not triggering. Adding a guaranteed-unique
number to each TEST_CASE as well with the $ functor allows us to catch
this case and error on it in the handler.