### PR TITLE
Tighten up member rule by requiring base to start at index 0 of member.

### DIFF
--- a/src/analysis/souffle/fact_test_helper.dl
+++ b/src/analysis/souffle/fact_test_helper.dl
@@ -51,5 +51,14 @@ testFails(testAspectName) :- allTests(testAspectName), !testPasses(testAspectNam
   allTestsAndCaseNum(test_aspect_name, $) :- 1 = 1. \
   testPasses(test_aspect_name)
 
+#define CHECK_TAG_PRESENT(access_path, tag) \
+  isAccessPath(access_path). \
+  TEST_CASE(cat(cat(cat("is_", tag), "_present_in_"), access_path)) :- \
+    isAccessPath(access_path), mayHaveTag(access_path, tag)
+
+#define CHECK_TAG_NOT_PRESENT(access_path, tag) \
+  isAccessPath(access_path). \
+  TEST_CASE(cat(cat(cat("is_", tag), "_not_present_in_"), access_path)) :- \
+    isAccessPath(access_path), !mayHaveTag(access_path, tag)
 
 #endif // SRC_ANALYSIS_SOUFFLE_ANALYZE_TAG_CHECKS_TEST_HELPER_DL_

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -58,6 +58,17 @@ isAccessPath(path) :- mayHaveTag(path, _).
 isTag(tag) :- claimHasTag(_, tag).
 isTag(tag) :- mayHaveTag(_, tag).
 
+// A pair of (base, member) is in this set if the base access path is a non-trivial subpath of the
+// member access path.
+.decl isMemberOf(base: AccessPath, member: AccessPath)
+
+// The member is a member of the base if it starts with the base plus '.'.
+isMemberOf(base, member) :-
+  isAccessPath(base),
+  isAccessPath(member),
+  strlen(base) + 1 < strlen(member),
+  cat(base, ".") = substr(member, 0, strlen(base) + 1).
+
 // An access path may have a tag if some subpath to a member field has that tag. This allows
 // checking for some inner node in the access path whether any leaf node of that node might have
 // a particular tag.
@@ -65,6 +76,6 @@ mayHaveTag(base, tag) :-
   isAccessPath(base),
   isAccessPath(member),
   mayHaveTag(member, tag),
-  contains(cat(base, "."), member).
+  isMemberOf(base, member).
 
 #endif // SRC_ANALYSIS_SOUFFLE_TAINT_DL_

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
@@ -25,15 +25,14 @@
 claimHasTag("R.P1.foo.a", "userSelection").
 claimHasTag("R.P1.foo.b", "screenContent").
 
-edge("R.P1.foo", "R.h.Foo").
 edge("R.P1.foo.a", "R.h.Foo.a").
 edge("R.P1.foo.b", "R.h.Foo.b").
 
-edge("R.h.Foo", "R.P2.foo").
 edge("R.h.Foo.a", "R.P2.foo.a").
 edge("R.h.Foo.b", "R.P2.foo.b").
 
-TEST_CASE("subpath_tag_userSelection_in_subpath_a") :- mayHaveTag("R.P2.foo.a", "userSelection").
-TEST_CASE("subpath_tag_screenContent_in_subpath_b") :- mayHaveTag("R.P2.foo.b", "screenContent").
-TEST_CASE("subpath_tags_in_parent") :-
-  mayHaveTag("R.P2.foo", "userSelection"), mayHaveTag("R.P2.foo", "screenContent").
+CHECK_TAG_PRESENT("R.P2.foo.a", "userSelection").
+CHECK_TAG_PRESENT("R.P2.foo.b", "screenContent").
+
+CHECK_TAG_PRESENT("R.P2.foo", "userSelection").
+CHECK_TAG_PRESENT("R.P2.foo", "screenContent").

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
@@ -25,5 +25,5 @@ claimHasTag("R.P1.foo", "userSelection").
 edge("R.P1.foo", "R.h.Foo").
 edge("R.h.Foo", "R.P2.bar").
 
-TEST_CASE("should_not_be_tagged_with_trusted") :- !mayHaveTag("R.P2.bar", "screenContent").
-TEST_CASE("should_be_tagged_with_notTrusted") :- mayHaveTag("R.P2.bar", "userSelection").
+CHECK_TAG_NOT_PRESENT("R.P2.bar", "screenContent").
+CHECK_TAG_PRESENT("R.P2.bar", "userSelection").

--- a/src/analysis/souffle/tests/arcs_fact_tests/is_member_of_unit_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/is_member_of_unit_test.dl
@@ -1,0 +1,55 @@
+#include "taint.dl"
+#include "fact_test_helper.dl"
+
+claimHasTag("R.foo.a", "userSelection").
+edge("R.foo.a", "R.bar.a").
+edge("R.foo.b", "R.bar.b").
+edge("R.foobaz.a", "R.bar.c").
+
+// Make R, R.foo, and R.foobaz checked access paths, but not foo.bar
+isAccessPath("R").
+isAccessPath("R.foo").
+isAccessPath("R.foobaz").
+
+// We use this to ensure that we select exactly the (base, member) pairs we expect to see in
+// isMemberOf.
+.decl expectedIsMemberOf(base: AccessPath, member: AccessPath)
+
+expectedIsMemberOf("R", "R.foo").
+expectedIsMemberOf("R", "R.foobaz").
+
+expectedIsMemberOf("R", "R.foo.a").
+expectedIsMemberOf("R", "R.foo.b").
+
+expectedIsMemberOf("R.foo", "R.foo.a").
+expectedIsMemberOf("R.foo", "R.foo.b").
+
+expectedIsMemberOf("R", "R.bar.a").
+expectedIsMemberOf("R", "R.bar.b").
+expectedIsMemberOf("R", "R.bar.c").
+
+expectedIsMemberOf("R", "R.foobaz.a").
+expectedIsMemberOf("R.foobaz", "R.foobaz.a").
+
+// Used to report expectations that went unmatched.
+.decl unmatched(base: AccessPath, member: AccessPath, from: symbol)
+
+// Useful to make these output relations if things fail.
+.output isAccessPath(IO=stdout, delimiter=",")
+.output unmatched(IO=stdout, delimiter=",")
+.output isMemberOf(IO=stdout, delimiter=",")
+
+unmatched(base, member, "expected") :-
+  expectedIsMemberOf(base, member), !isMemberOf(base, member).
+
+unmatched(base, member, "actual") :-
+  !expectedIsMemberOf(base, member), isMemberOf(base, member).
+
+TEST_CASE("unmatched_is_empty") :- count : { unmatched(_, _, _) } = 0.
+
+TEST_CASE("size_of_expected_and_actual_match_and_not_zero") :-
+  count_expected = count : { expectedIsMemberOf(_, _) },
+  count_actual = count : { isMemberOf(_, _) },
+  count_expected != 0,
+  count_actual != 0,
+  count_expected = count_actual.

--- a/src/analysis/souffle/tests/arcs_fact_tests/is_member_of_unit_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/is_member_of_unit_test.dl
@@ -1,6 +1,8 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
+// Note: these claims and edges are just used to introduce access paths in a fashion that is
+// similar to what we might see in the wild.
 claimHasTag("R.foo.a", "userSelection").
 edge("R.foo.a", "R.bar.a").
 edge("R.foo.b", "R.bar.b").

--- a/src/analysis/souffle/tests/arcs_fact_tests/is_member_of_unit_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/is_member_of_unit_test.dl
@@ -1,14 +1,18 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-// Note: these claims and edges are just used to introduce access paths in a fashion that is
-// similar to what we might see in the wild.
-claimHasTag("R.foo.a", "userSelection").
-edge("R.foo.a", "R.bar.a").
-edge("R.foo.b", "R.bar.b").
-edge("R.foobaz.a", "R.bar.c").
+// Leaf AccessPaths: These are AccessPaths to leaf fields, similar to what we expect might be
+// introduced by a claim or an edge.
+isAccessPath("R.foo.a").
+isAccessPath("R.foo.b").
 
-// Make R, R.foo, and R.foobaz checked access paths, but not foo.bar
+isAccessPath("R.bar.a").
+isAccessPath("R.bar.b").
+isAccessPath("R.bar.c").
+
+isAccessPath("R.foobaz.a").
+
+// Inner node AccessPaths. Make R, R.foo, and R.foobaz checked access paths, but not foo.bar.
 isAccessPath("R").
 isAccessPath("R.foo").
 isAccessPath("R.foobaz").

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
@@ -33,4 +33,4 @@ edge("R.P2.foo", "R.h2.Foo").
 edge("R.h2.Foo", "R.P3.bar").
 
 // This test passes if R.P3.bar has the trusted tag.
-TEST_CASE("ok_claim_propagates") :- mayHaveTag("R.P3.bar", "userSelection").
+CHECK_TAG_PRESENT("R.P3.bar", "userSelection").


### PR DESCRIPTION
Originally, I used "contains" to check whether base was the base
of member when propagating taint from members to base paths. That isn't
the full story though: we want to propagate taint only when the base is
a prefix of the member starting at index 0. This distinction seems to
not matter when edges only start at leaf fields, but better to be
precise.