### PR TITLE
Initial commit of Arcs manifest tests from original Arcs repo.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,13 @@ jobs:
         run: sudo apt-get install autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev
 
       # Runs a single command using the runners shell
-      - name: Run a one-line script
+      - name: Run all tests
         run: bazel test //src/...
 
       # Verifies that the Arcs parser works
       - name: Verify that Arcs parser works.
         run: bazel build //third_party/arcs/examples:consume
+
+      # Verifies that Arcs manifest tests that we do not yet handle parse correctly.
+      - name: Verify that disabled Arcs manifest tests build.
+        run: bazel build //src/analysis/souffle/tests/arcs_manifest_tests_todo/...

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/BUILD
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/BUILD
@@ -6,7 +6,10 @@ BUILD_ERROR_ARCS_MANIFEST_PATTERNS = [
     "*ok_join_simple_with_nullables.arcs",
 ]
 
-BUILDING_ARCS_MANIFESTS = glob(["*.arcs"], BUILD_ERROR_ARCS_MANIFEST_PATTERNS)
+BUILDING_ARCS_MANIFESTS = glob(
+    ["*.arcs"],
+    exclude = BUILD_ERROR_ARCS_MANIFEST_PATTERNS
+)
 
 [arcs_manifest_proto(
     name = manifest.replace(".arcs", "_proto"),

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/BUILD
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/BUILD
@@ -1,0 +1,15 @@
+load("//build_defs:arcs.bzl", "arcs_manifest_proto")
+
+# TODO(Issue #61): Enable translating these manifests to proto once manifest2proto can parse them.
+BUILD_ERROR_ARCS_MANIFEST_PATTERNS = [
+    "*fail_field_nullable_inline_entity_direct.arcs",
+    "*ok_join_simple_with_nullables.arcs",
+]
+
+BUILDING_ARCS_MANIFESTS = glob(["*.arcs"], BUILD_ERROR_ARCS_MANIFEST_PATTERNS)
+
+[arcs_manifest_proto(
+    name = manifest.replace(".arcs", "_proto"),
+    src = manifest,
+ ) for manifest in BUILDING_ARCS_MANIFESTS]
+

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/README
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/README
@@ -1,0 +1,3 @@
+These tests are imported from the original Arcs repo. They are here because we do not yet correctly
+handle the end-to-end process of parsing them, converting them to protos, converting those protos
+to Datalog, and running the dataflow analysis on them.

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/README
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/README
@@ -1,3 +1,7 @@
 These tests are imported from the original Arcs repo. They are here because we do not yet correctly
 handle the end-to-end process of parsing them, converting them to protos, converting those protos
 to Datalog, and running the dataflow analysis on them.
+
+At the time of this writing, these tests are exact copies of the tests from the Arcs repo.
+Unfortunately, these tests contain a lot of duplicated code; we should condense them somehow in the
+future (tracked by Issue #64).

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_check_multiple_or_tags.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_check_multiple_or_tags.arcs
@@ -1,0 +1,20 @@
+// fails when a check including multiple tags isn't met
+// #Ingress: P1
+// #Ingress: P2
+// #Fail: hc:P3.bar is (tag1 or tag2)
+particle P1
+  foo: writes Foo {}
+  claim foo is tag1
+particle P2
+  foo: writes Foo {}
+  claim foo is someOtherTag
+particle P3
+  bar: reads Foo {}
+  check bar is tag1 or is tag2
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: writes h
+  P3
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_check_on_subpaths.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_check_on_subpaths.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo is trusted
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is loggable
+particle P2
+  foo: reads Foo {a: Text, b: Number}
+  check foo is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_cycle_overlapping_a.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_cycle_overlapping_a.arcs
@@ -1,0 +1,51 @@
+// tags propagate throughout overlapping cycles'
+// Two cycles: P1-P2-P3 and P1-P2-P4. One cycle is tagged with a, the
+// other is tagged with b. All paths should be a or b, but not all paths
+// are a, and not all paths are b.
+// #Ingress: P1
+// #Fail: hc:P1.input1 is a
+// #Fail: hc:P1.input2 is a
+// #Fail: hc:P2.input2 is a
+// #Fail: hc:P3.input is a
+// #Fail: hc:P4.input is a
+particle P1
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  check input1 is a
+  check input2 is a
+  claim output1 is a
+  claim output2 is b
+particle P2
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  check input1 is a
+  check input2 is a
+particle P3
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is a
+particle P4
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is a
+recipe R
+  P1
+    input1: reads h3
+    input2: reads h6
+    output1: writes h1
+    output2: writes h4
+  P2
+    input1: reads h1
+    input2: reads h5
+    output1: writes h2
+    output2: writes h6
+  P3
+    input: reads h2
+    output: writes h3
+  P4
+    input: reads h4
+    output: writes h5

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_cycle_overlapping_b.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_cycle_overlapping_b.arcs
@@ -1,0 +1,50 @@
+// tags propagate throughout overlapping cycles'
+// Two cycles: P1-P2-P3 and P1-P2-P4. One cycle is tagged with a, the
+// other is tagged with b. All paths should be a or b, but not all paths
+// are a, and not all paths are b.
+// #Ingress: P1
+// #Fail: hc:P1.input1 is b
+// #Fail: hc:P1.input2 is b
+// #Fail: hc:P2.input1 is b
+// #Fail: hc:P3.input is b
+particle P1
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  check input1 is b
+  check input2 is b
+  claim output1 is a
+  claim output2 is b
+particle P2
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  check input1 is b
+  check input2 is b
+particle P3
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is b
+particle P4
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is b
+recipe R
+  P1
+    input1: reads h3
+    input2: reads h6
+    output1: writes h1
+    output2: writes h4
+  P2
+    input1: reads h1
+    input2: reads h5
+    output1: writes h2
+    output2: writes h6
+  P3
+    input: reads h2
+    output: writes h3
+  P4
+    input: reads h4
+    output: writes h5

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_cycle_remove_tag.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_cycle_remove_tag.arcs
@@ -1,0 +1,19 @@
+// tags can be removed in a simple cycle
+// #Ingress: P1
+// #Fail: hc:P1.input is trusted
+particle P1
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is trusted
+  claim output is trusted
+particle P2
+  input: reads Foo {}
+  output: writes Foo {}
+  claim output is not trusted
+recipe R
+  P1
+    input: reads h1
+    output: writes h2
+  P2
+    input: reads h2
+    output: writes h1

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_cycle_remove_tag_in_chain.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_cycle_remove_tag_in_chain.arcs
@@ -1,0 +1,28 @@
+// tags can be removed by a cycle along a chain
+// We have a chain of particles P1-P2-P3, through which a tag gets
+// propagated. However, we also have a small cycle from P2.output ->
+// P2.input, which removes the tag. A check at P3 should fail.
+// #Ingress: P1
+// #Fail: hc:P3.input is trusted
+particle P1
+  output: writes Foo {}
+  claim output is trusted
+particle P2
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  claim output2 is not trusted
+particle P3
+  input: reads Foo {}
+  check input is trusted
+recipe R
+  P1
+    output: writes h1
+  P2
+    input1: reads h1
+    input2: reads h3
+    output1: writes h2
+    output2: writes h3
+  P3
+    input: reads h2

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_derives_from_cycle.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_derives_from_cycle.arcs
@@ -1,0 +1,17 @@
+// supports breaking cycles using 'derives from' claims
+// #Ingress: P
+// #Fail: hc:P.input2 is a
+particle P
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  claim output1 derives from input1 and is a
+  claim output2 derives from input2 and is b
+  check input2 is a
+recipe R
+  P
+    input1: reads h1
+    input2: reads h2
+    output1: writes h1
+    output2: writes h2

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_derives_from_multiple.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_derives_from_multiple.arcs
@@ -1,0 +1,34 @@
+// #Ingress: P1
+// #Fail: hc:P3.examples is ((fooData or barData) and not bazData)
+
+particle P1
+  foo: writes Foo {}
+  bar: writes Bar {}
+  baz: writes Baz {}
+  claim foo is fooData
+  claim bar is barData
+  claim baz is bazData
+
+particle P2
+  foo: reads Foo {}
+  bar: reads Bar {}
+  baz: reads Baz {}
+  examples: writes Example {}
+  claim examples derives from foo and derives from baz
+
+particle P3
+  examples: reads Example {}
+  check examples (is fooData or is barData) and is not bazData
+
+recipe R
+  P1
+    foo: writes fooHandle
+    bar: writes barHandle
+    baz: writes bazHandle
+  P2
+    foo: reads fooHandle
+    bar: reads barHandle
+    baz: reads bazHandle
+    examples: writes examplesHandle
+  P3
+    examples: reads examplesHandle

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_different_tag.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_different_tag.arcs
@@ -1,0 +1,14 @@
+// Fails when different tag is claimed.
+// #Ingress: P1
+// #Fail: hc:P2.bar is trusted
+particle P1
+  foo: writes Foo {}
+  claim foo is notTrusted
+particle P2
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_claim_propagates.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_claim_propagates.arcs
@@ -1,0 +1,27 @@
+// #Ingress: P1
+// #Fail: hc:P4.foo.b is untrusted
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads Foo {a: Text}
+  bar: writes Bar {b: Text}
+particle P3
+  baz: reads Bar {b: Text}
+  foo: writes [Foo {b: Number}]
+  check baz.b is trusted
+particle P4
+  foo: reads [Foo {b: Number}]
+  check foo.b is untrusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    foo: reads h1
+    bar: writes h2
+  P3
+    baz: reads h2
+    foo: writes h3
+  P4
+    foo: reads h3

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_claim_propagates_type_variables.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_claim_propagates_type_variables.arcs
@@ -1,0 +1,33 @@
+// #Ingress: P1
+// #Fail: hc:P4.foo.b is untrusted
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads ~a with {a: Text}  // Constraints
+  bar: writes Bar {b: Text}
+particle PassThrough
+  input: reads ~a
+  output: writes ~a
+particle P3
+  baz: reads Bar {b: Text}
+  foo: writes [Foo {b: Number}]
+  check baz.b is trusted
+particle P4
+  foo: reads [Foo {b: Number}]
+  check foo.b is untrusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    foo: reads h1
+    bar: writes passThrough
+  PassThrough
+    input: passThrough
+    output: h2
+  P3
+    baz: reads h2
+    foo: writes h3
+  P4
+    foo: reads h3

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_collection_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_collection_direct.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #Fail: hc:P2.foo.a is untrusted
+particle P1
+  foo: writes [Foo {a: Text, b: Number}]
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads [Foo {a: Text}]
+  check foo.a is untrusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_entity_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_entity_direct.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #Fail: hc:P2.foo.a is untrusted
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads Foo {a: Text}
+  check foo.a is untrusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_entity_ref_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_entity_ref_direct.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #Fail: hc:P2.foo.a is untrusted
+particle P1
+  foo: writes &Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads &Foo {a: Text}
+  check foo.a is untrusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_entity_ref_field.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_entity_ref_field.arcs
@@ -1,0 +1,38 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo is ((trusted or untrusted) or deep)
+// #FAIL: hc:P2.foo.untrusted is (untrusted or deep)
+particle P1
+  foo: writes &Foo {
+    trusted: Text,
+    untrusted: &Bar {
+       c: &Baz {
+         deep: Number,
+         sensitive: Text
+       }
+    }
+  }
+  claim foo.trusted is trusted
+  claim foo.untrusted is untrusted
+  claim foo.untrusted.c.deep is deep
+  claim foo.untrusted.c.sensitive is sensitive
+
+particle P2
+  foo: reads &Foo {
+    trusted: Text,
+    untrusted: &Bar {
+       c: &Baz {
+         deep: Number,
+         sensitive: Text // This should not be accessed.
+       }
+    }
+  }
+  check foo is trusted or is untrusted or is deep
+  check foo.trusted is trusted
+  check foo.untrusted is untrusted or is deep
+  check foo.untrusted.c.deep is deep
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_inline_entity_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_inline_entity_direct.arcs
@@ -1,0 +1,28 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo.a.c is untrusted
+// #FAIL: hc:P2.foo is trusted
+// #FAIL: hc:P2.foo.a.d is trusted
+particle P1
+  foo: writes Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }
+  }
+  claim foo.a.c is trusted
+  claim foo.a.d is trusted
+  claim foo.a.d.e is untrusted
+
+particle P2
+  foo: reads Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }
+  }
+  check foo.a.c is untrusted
+  // Labels on foo and foo.a.d is a combination of labels
+  // for foo.a.d.e and foo.a.d
+  check foo is trusted
+  check foo.a.d is trusted 
+  check foo.a.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_inline_entity_slicing.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_inline_entity_slicing.arcs
@@ -1,0 +1,32 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo is trusted
+particle P1
+  foo: writes FooList {
+    elements: List<inline Foo {
+      ok: Text,
+      notOk: Number,
+      mixed: inline Baz {
+        ok: Text,
+        notOk: Number,
+      }
+    }> 
+  }
+  claim foo.elements.ok is trusted
+  claim foo.elements.notOk is untrusted
+  claim foo.elements.mixed.ok is trusted
+  claim foo.elements.mixed.notOk is untrusted
+
+particle P2
+  foo: reads FooList {
+    elements: List<inline Foo {
+      ok: Text,
+      mixed: inline Baz { notOk: Number }
+    }>
+  }
+  check foo is trusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_list_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_list_direct.arcs
@@ -1,0 +1,29 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo.elements.c is untrusted
+// #FAIL: hc:P2.foo.elements.d is trusted
+
+schema FooList
+  elements: List<inline Foo {
+    c: Text,
+    d: inline Baz {e: Number}
+  }>
+
+particle P1
+  foo: writes FooList {elements}
+  claim foo.elements.c is trusted
+  claim foo.elements.d is trusted
+  claim foo.elements.d.e is untrusted
+
+particle P2
+  foo: reads FooList {elements}
+  check foo.elements.c is untrusted
+  // Label on foo.elements.d is the combination of labels for
+  // foo.elements.d.e and foo.elements.d
+  check foo.elements.d is trusted
+  check foo.elements.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_merge_multiple_paths.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_merge_multiple_paths.arcs
@@ -1,0 +1,50 @@
+// #Ingress: TrustedTextWriter
+// #Ingress: TrustedNumberWriter
+// #Fail: hc:BazReader.t.a is trusted
+particle TrustedTextWriter
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle TrustedNumberWriter
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is untrusted
+  claim foo.b is trusted
+particle TrustedNumberReader
+  foo: reads Foo {b: Number}
+  baz: writes Baz {a: Text}
+particle TrustedTextReader
+  foo: reads Foo {a: Text}
+  baz: writes Baz {a: Text}
+particle UntrustedTextReader
+  foo: reads Foo {a: Text}
+  baz: writes Baz {a: Text}
+particle UntrustedNumberReader
+  foo: reads Foo {b: Number}
+  baz: writes Baz {a: Text}
+particle BazReader
+  t: reads Baz {a: Text}
+  u: reads Baz {a: Text}
+  check t.a is trusted
+  check u.a is untrusted
+
+recipe R
+  TrustedTextWriter
+    foo: writes trustedTextHandle
+  TrustedNumberWriter
+    foo: writes trustedNumberHandle
+  UntrustedTextReader
+    foo: reads trustedNumberHandle
+    baz: writes untrustedHandle
+  TrustedTextReader
+    foo: reads trustedTextHandle
+    baz: writes trustedHandle
+  UntrustedNumberReader
+    foo: reads trustedTextHandle
+    baz: writes untrustedHandle
+  TrustedNumberReader
+    // should be read trustedNumberHandle
+    foo: reads trustedTextHandle
+    baz: writes trustedHandle
+  BazReader
+    t: reads trustedHandle
+    u: reads untrustedHandle

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_nullable_inline_entity_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_nullable_inline_entity_direct.arcs
@@ -1,0 +1,28 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo.a.c is untrusted
+// #FAIL: hc:P2.foo is trusted
+// #FAIL: hc:P2.foo.a.d is trusted
+particle P1
+  foo: writes Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }?
+  }
+  claim foo.a.c is trusted
+  claim foo.a.d is trusted
+  claim foo.a.d.e is untrusted
+
+particle P2
+  foo: reads Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }?
+  }
+  check foo.a.c is untrusted
+  // Labels on foo and foo.a.d is a combination of labels
+  // for foo.a.d.e and foo.a.d
+  check foo is trusted
+  check foo.a.d is trusted
+  check foo.a.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_tuple_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_field_tuple_direct.arcs
@@ -1,0 +1,34 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo.first.elements.c is untrusted
+// #FAIL: hc:P2.foo.first.elements.d is trusted
+// #FAIL: hc:P2.foo.second.b.e is trusted
+schema FooList
+  elements: List<inline Foo {
+    c: Text,
+    d: inline Baz {e: Number}
+  }>
+
+schema Bar
+  b: inline Baz {e: Number}
+
+particle P1
+  foo: writes (FooList, Bar)
+  claim foo.first.elements.c is trusted
+  claim foo.first.elements.d is trusted
+  claim foo.first.elements.d.e is untrusted
+  claim foo.second.b.e is public
+
+particle P2
+  foo: reads (FooList, Bar)
+  check foo.first.elements.c is untrusted
+  // Label on foo.first.elements.d is the combination of labels for
+  // foo.first.elements.d.e and foo.first.elements.d
+  check foo.first.elements.d is trusted
+  check foo.first.elements.d.e is untrusted
+  check foo.second.b.e is trusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_join_tuple_components.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_join_tuple_components.arcs
@@ -1,0 +1,46 @@
+// #Ingress: IngestPerson
+// #Ingress: IngestAddress
+// #Fail: hc:EgressPublic.info.info is not sensitive
+particle IngestPerson
+  person: writes [Person {name: Text, age: Number, education: Text}]
+  claim person.age is sensitive
+
+particle IngestAddress
+  address: writes [Address {name: Text, street: Text, city: Text}]
+  claim address.street is sensitive
+
+particle ReadJoinedData
+  details: reads [(
+    Person {name: Text, age: Number, education: Text},
+    Address {name: Text, street: Text, city: Text}
+  )]
+  sensitiveInfo: writes Info {info: Text}
+  publicInfo: writes Info {info: Text}
+  claim sensitiveInfo.info derives from details.first.age
+  claim publicInfo.info derives from details.first.name and derives from details.second.street
+
+particle EgressPublic
+  info: reads Info {info: Text}
+  check info.info is not sensitive
+
+particle EgressSensitive
+  info: reads Info {info: Text}
+
+recipe R
+  person: create
+  address: create
+  all: join (person, address)
+  publicInfo: create
+  sensitiveInfo: create
+  IngestPerson
+    person: person
+  IngestAddress
+    address: address
+  ReadJoinedData
+    details: all
+    publicInfo: publicInfo
+    sensitiveInfo: sensitiveInfo
+  EgressPublic
+    info: publicInfo
+  EgressSensitive
+    info: sensitiveInfo

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_mixer.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_mixer.arcs
@@ -1,0 +1,78 @@
+// #Ingress: IngestionAppName
+// #Ingress: IngestionLocation
+// #Fail: hc:Egress2.data is (packageName and coarseLocation)
+// #Fail: hc:Egress4.data is safeToLog
+// #Fail: hc:Egress5.data is ((packageName and safeToLog) or (coarseLocation and safeToLog))
+// #Fail: hc:Egress2.data.whoKnowsWhat is (packageName and coarseLocation)
+// #Fail: hc:Egress4.data.whoKnowsWhat is safeToLog
+// #Fail: hc:Egress5.data.whoKnowsWhat is ((packageName and safeToLog) or (coarseLocation and safeToLog))
+particle IngestionAppName
+  data: writes [AppName {
+    packageName: Text
+  }]
+  claim data.packageName is safeToLog and is packageName
+
+particle IngestionLocation
+  data: writes [Location {
+    location: Text
+  }]
+  claim data.location is coarseLocation
+
+particle Mixer
+  input1: reads [AppName {packageName: Text}]
+  input2: reads [Location {location: Text}]
+  output: writes [MixedData {whoKnowsWhat: Text}]
+
+// DFA Pass
+particle Egress1
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data.whoKnowsWhat is packageName or is coarseLocation
+  check data is packageName or is coarseLocation
+
+// DFA fail
+particle Egress2
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data.whoKnowsWhat is packageName and is coarseLocation
+  check data is packageName and is coarseLocation
+
+// DFA pass
+particle Egress3
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data.whoKnowsWhat is packageName or is coarseLocation or is safeToLog
+  check data is packageName or is coarseLocation or is safeToLog
+
+
+// DFA fail
+particle Egress4
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data.whoKnowsWhat is safeToLog
+  check data is safeToLog
+
+// DFA fail
+particle Egress5
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data.whoKnowsWhat (is packageName and is safeToLog) or (is coarseLocation and is safeToLog)
+  check data (is packageName and is safeToLog) or (is coarseLocation and is safeToLog)
+
+recipe Test
+  data: create
+  appName: create
+  location: create
+  IngestionAppName
+    data: appName
+  IngestionLocation
+    data: location
+  Mixer
+    input1: appName
+    input2: location
+    output: data
+  Egress1
+    data: data
+  Egress2
+    data: data
+  Egress3
+    data: data
+  Egress4
+    data: data 
+  Egress5
+    data: data

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_multiple_checks.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_multiple_checks.arcs
@@ -1,0 +1,21 @@
+// can detect failures for different checks'
+// #Ingress: P1
+// #Fail: hc:P2.bar1 is trusted
+// #Fail: hc:P2.bar2 is extraTrusted
+particle P1
+  foo1: writes Foo {}
+  foo2: writes Foo {}
+  claim foo1 is notTrusted
+  claim foo2 is trusted
+particle P2
+  bar1: reads Foo {}
+  bar2: reads Foo {}
+  check bar1 is trusted
+  check bar2 is extraTrusted
+recipe R
+  P1
+    foo1: writes h1
+    foo2: writes h2
+  P2
+    bar1: reads h1
+    bar2: reads h2

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_multiple_inputs_one_untagged.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_multiple_inputs_one_untagged.arcs
@@ -1,0 +1,20 @@
+// fails when handle has multiple inputs but one is untagged
+// #Ingress: P1
+// #Ingress: P2
+// #Fail: hc:P3.bar is trusted
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  foo: writes Foo {}
+particle P3
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: writes h
+  P3
+    bar: reads h
+

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_negated_tag_present.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_negated_tag_present.arcs
@@ -1,0 +1,14 @@
+// fails for a negated tag check when the tag is present
+// #Ingress: P1
+// #Fail: hc:P2.bar is not private
+ particle P1
+  foo: writes Foo {}
+  claim foo is private
+particle P2
+  bar: reads Foo {}
+  check bar is not private
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_no_claim_is_empty_labels.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_no_claim_is_empty_labels.arcs
@@ -1,0 +1,26 @@
+// This checks that DFA assumes empty labels when no claims are specified for
+// a field of an ingress handle.
+// #Ingress: Ingress
+// #FAIL: hc:Egress.egress.age is allowedToEgress
+
+schema Person
+  name: Text
+  age: Number
+
+particle Ingress
+  person: writes Person {name, age}
+  claim person.name is allowedToEgress
+
+particle Egress
+  egress: reads Person {name, age}
+  check egress.name is allowedToEgress
+  // Following should fail as egress.age should be empty
+  check egress.age is allowedToEgress
+
+recipe R
+  h: create
+  Ingress
+    person: h
+  Egress
+    egress: h
+

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_no_inputs.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_no_inputs.arcs
@@ -1,0 +1,9 @@
+// fails when handle has no inputs
+// #Ingress: P.bar
+// #Fail: hc:P.bar is trusted
+particle P
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_no_tags.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_no_tags.arcs
@@ -1,0 +1,13 @@
+// fails when no tag is claimed
+// #Ingress: P1
+// #Fail: hc:P2.bar is trusted
+particle P1
+  foo: writes Foo {}
+particle P2
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_not_tag_cancels.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_not_tag_cancels.arcs
@@ -1,0 +1,21 @@
+// fails when a "not tag" cancels a tag
+// #Ingress: P1
+// #Fail: hc:P3.bye is trusted
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  baz: writes Foo {}
+  claim baz is not trusted
+particle P3
+  bye: reads Foo {}
+  check bye is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h
+    baz: writes h1
+  P3
+    bye: reads h1

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_not_tag_claim.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_not_tag_claim.arcs
@@ -1,0 +1,14 @@
+// fails when a "not tag" is claimed and the tag is checked for
+// #Ingress: P1
+// #Fail: hc:P2.bar is trusted
+ particle P1
+  foo: writes Foo {}
+  claim foo is not trusted
+particle P2
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_read_write_mismatch_claim_check.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_read_write_mismatch_claim_check.arcs
@@ -1,0 +1,11 @@
+// fails when an inout handle claims a different tag from the one it checks
+// #Ingress: P
+// #Fail: hc:P.foo is t1
+particle P
+  foo: reads writes Foo {}
+  check foo is t1
+  claim foo is t2
+recipe R
+  P
+    foo: reads writes h
+

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables.arcs
@@ -1,0 +1,47 @@
+// #Ingress: Mixed
+// #Ingress: Meh
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Mixed
+  output: writes Mixed {good: Text, bad: Text}
+  claim output.good is good
+  claim output.bad is bad
+
+particle Meh
+  output: writes Meh {meh: Text}
+  claim output.meh is meh
+
+particle DoStuff
+  input1: reads ~a with {bad: Text}
+  input2: reads ~b with {*}
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff
+  // (which was not read).
+  check input.bad is bad or is meh
+  check input is good or is bad or is meh
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Mixed
+    output: mixed
+  Meh
+    output: meh
+  DoStuff
+    input1: mixed
+    input2: meh
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_collection.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_collection.arcs
@@ -1,0 +1,47 @@
+// #Ingress: Mixed
+// #Ingress: Meh
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Mixed
+  output: writes [Mixed {good: Text, bad: Text}]
+  claim output.good is good
+  claim output.bad is bad
+
+particle Meh
+  output: writes [Meh {meh: Text}]
+  claim output.meh is meh
+
+particle DoStuff
+  input1: reads [~a with {bad: Text}]
+  input2: reads [~b with {*}]
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff
+  // (which was not read).
+  check input.bad is bad or is meh
+  check input is good or is bad or is meh
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Mixed
+    output: mixed
+  Meh
+    output: meh
+  DoStuff
+    input1: mixed
+    input2: meh
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_multiple_constraints.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_multiple_constraints.arcs
@@ -1,0 +1,47 @@
+// #Ingress: Mixed
+// #Ingress: Meh
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Mixed
+  output: writes Mixed {good: Text, bad: Text, ugly: Text}
+  claim output.good is good
+  claim output.bad is bad
+  claim output.ugly is ugly
+
+particle Meh
+  output: writes Meh {meh: Text}
+  claim output.meh is meh
+
+particle DoStuff
+  input1: reads ~a with {bad: Text}
+  input2: reads ~a with {ugly: Text}
+  input3: reads ~b with {*}
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text, ugly: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  check input.bad is bad or is meh or is ugly
+  check input is good or is bad or is meh or is ugly
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text, ugly: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Mixed
+    output: mixed
+  Meh
+    output: meh
+  DoStuff
+    input1: mixed
+    input2: mixed
+    input3: meh
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_no_constraints.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_no_constraints.arcs
@@ -1,0 +1,69 @@
+// Tests that type variables with no constraints treats fields as inaccessible.
+// #Ingress: Mixed
+// #Ingress: Meh
+// #Ingress: Independent
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Mixed
+  output: writes Mixed {good: Text, bad: Text}
+  claim output.good is good
+  claim output.bad is bad
+
+particle Meh
+  output: writes Meh {meh: Text}
+  claim output.meh is meh
+
+particle Independent
+  output: writes Independent { data: Text }
+  claim output.data is independent
+
+particle DoStuff
+  input1: reads ~a with {bad: Text}
+  input2: reads ~b with {*}
+  input3: reads ~c
+  output: writes ~a
+
+particle PassThrough
+  input: reads ~a
+  output: writes ~a
+  check input is independent
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field and "indepenent" field  was not
+  // accessible to DoStuff and could not have been modified or read.
+  check input.good is good and is not independent
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff and
+  // independent stuff (which was not read).
+  check input.bad (is bad or is meh) and (is not independent)
+  check input (is good or is bad or is meh) and (is not independent)
+
+particle IndependentReader
+  input: reads Independent { data: Text }
+  check input is independent
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh and independent stuff.
+  check input.bad is bad
+  check input is not independent
+
+recipe
+  Mixed
+    output: mixed
+  Meh
+    output: meh
+  Independent
+    output: independent
+  DoStuff
+    input1: mixed
+    input2: meh
+    input3: independent
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff
+  IndependentReader
+    input: independent

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_tuples.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_tuples.arcs
@@ -1,0 +1,39 @@
+// #Ingress: Tupler
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Tupler
+  output: writes (Mixed {good: Text, bad: Text},  Meh {meh: Text})
+  claim output.first.good is good
+  claim output.first.bad is bad
+  claim output.second.meh is meh
+
+particle DoStuff
+  input: reads (~a with {bad: Text}, ~b with {*})
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff
+  // (which was not read).
+  check input.bad is bad or is meh
+  check input is good or is bad or is meh
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Tupler
+    output: tuple
+  DoStuff
+    input: tuple
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_tuples_collection.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/fail_type_variables_tuples_collection.arcs
@@ -1,0 +1,39 @@
+// #Ingress: Tupler
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Tupler
+  output: writes ([Mixed {good: Text, bad: Text}],  [Meh {meh: Text}])
+  claim output.first.good is good
+  claim output.first.bad is bad
+  claim output.second.meh is meh
+
+particle DoStuff
+  input: reads ([~a with {bad: Text}], [~b with {*}])
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff
+  // (which was not read).
+  check input.bad is bad or is meh
+  check input is good or is bad or is meh
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Tupler
+    output: tuple
+  DoStuff
+    input: tuple
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_check_multiple_and_single_claim.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_check_multiple_and_single_claim.arcs
@@ -1,0 +1,14 @@
+// succeeds when a check including multiple anded tags is met by a single claim
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is tag1 and is tag2
+particle P2
+  bar: reads Foo {}
+  check bar is tag1 and is tag2
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_check_multiple_or_single_claim.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_check_multiple_or_single_claim.arcs
@@ -1,0 +1,14 @@
+// succeeds when a check including multiple 'or'd tags is met by a single claim
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is tag1 and is tag2
+particle P2
+  bar: reads Foo {}
+  check bar is tag1 or is tag2
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_check_multiple_or_tags.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_check_multiple_or_tags.arcs
@@ -1,0 +1,20 @@
+// succeeds when a check includes multiple tags
+// #Ingress: P1
+// #Ingress: P2
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is tag1
+particle P2
+  foo: writes Foo {}
+  claim foo is tag2
+particle P3
+  bar: reads Foo {}
+  check bar is tag1 or is tag2
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: writes h
+  P3
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_check_on_subpaths.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_check_on_subpaths.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is loggable
+particle P2
+  foo: reads Foo {a: Text, b: Number}
+  check foo is trusted or is loggable
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_claim_not_overriden_later.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_claim_not_overriden_later.arcs
@@ -1,0 +1,21 @@
+// a claim made later in a chain of particles does not override claims made earlier
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  foo: writes Foo {}
+  claim foo is someOtherTag
+particle P3
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    bar: reads h1
+    foo: writes h2
+  P3
+    bar: reads h2

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_claim_propagates.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_claim_propagates.arcs
@@ -1,0 +1,20 @@
+// claim propagates through a chain of particles
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  foo: writes Foo {}
+particle P3
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    bar: reads h1
+    foo: writes h2
+  P3
+    bar: reads h2

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_claim_propagates.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_claim_propagates.arcs
@@ -1,0 +1,33 @@
+// A simple cycle doesn't prevent claims from propagating
+// This test is a simple chain of particles, where the start of the chain
+// makes a claim and the end of the chain checks it, but with a cycle in
+// the middle of it. The cycle shouldn't stop the claim from propagating.
+// #Ingress: P1
+// #OK
+particle P1
+  output: writes Foo {}
+  claim output is trusted
+particle P2
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output: writes Foo {}
+particle P3
+  input: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+particle P4
+  input: reads Foo {}
+  check input is trusted
+recipe R
+  P1
+    output: writes h1
+  P2
+    input1: reads h1
+    input2: reads h4
+    output: writes h2
+  P3
+    input: reads h2
+    output1: writes h3
+    output2: writes h4
+  P4
+   input: reads h3

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_overlapping.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_overlapping.arcs
@@ -1,0 +1,47 @@
+// tags propagate throughout overlapping cycles'
+// Two cycles: P1-P2-P3 and P1-P2-P4. One cycle is tagged with a, the
+// other is tagged with b. All paths should be a or b, but not all paths
+// are a, and not all paths are b.
+// #Ingress: P1
+// #OK
+particle P1
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  check input1 is a or is b
+  check input2 is a or is b
+  claim output1 is a
+  claim output2 is b
+particle P2
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  check input1 is a or is b
+  check input2 is a or is b
+particle P3
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is a or is b
+particle P4
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is a or is b
+recipe R
+  P1
+    input1: reads h3
+    input2: reads h6
+    output1: writes h1
+    output2: writes h4
+  P2
+    input1: reads h1
+    input2: reads h5
+    output1: writes h2
+    output2: writes h6
+  P3
+    input: reads h2
+    output: writes h3
+  P4
+    input: reads h4
+    output: writes h5

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_single_particle.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_single_particle.arcs
@@ -1,0 +1,13 @@
+// supports tag checks in a single-particle cycle
+// #Ingress: P
+// #OK
+particle P
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is trusted
+  claim output is trusted
+
+recipe R
+  P
+    input: reads h
+    output: writes h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_two_origin.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_two_origin.arcs
@@ -1,0 +1,32 @@
+// two origin cycles can co-exist happily
+// A graph with two simple loops at the beginning (P2's outputs connected
+// to P1's inputs), each with ingress. The claim should flow through to
+// P3.
+// #Ingress: P1.input1
+// #Ingress: P1.input2
+// #OK
+particle P1
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output: writes Foo {}
+  claim output is a
+particle P2
+  input: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  output3: writes Foo {}
+particle P3
+  input: reads Foo {}
+  check input is a
+recipe R
+  P1
+    input1: reads h1
+    input2: reads h2
+    output: writes h3
+  P2
+    input: reads h3
+    output1: writes h1
+    output2: writes h2
+    output3: writes h4
+  P3
+    input: reads h4

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_two_particles.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_cycle_two_particles.arcs
@@ -1,0 +1,19 @@
+// works with simple two-particle cycles
+// #Ingress: P1
+// #OK
+particle P1
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is trusted
+  claim output is trusted
+particle P2
+  input: reads Foo {}
+  output: writes Foo {}
+  check input is trusted
+recipe R
+  P1
+    input: reads h1
+    output: writes h2
+  P2
+    input: reads h2
+    output: writes h1

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_derives_from_cycle.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_derives_from_cycle.arcs
@@ -1,0 +1,17 @@
+// supports breaking cycles using 'derives from' claims
+// #Ingress: P
+// #OK
+particle P
+  input1: reads Foo {}
+  input2: reads Foo {}
+  output1: writes Foo {}
+  output2: writes Foo {}
+  claim output1 derives from input1 and is a
+  claim output2 derives from input2 and is b
+  check input2 is b and is not a
+recipe R
+  P
+    input1: reads h1
+    input2: reads h2
+    output1: writes h1
+    output2: writes h2

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_derives_from_multiple.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_derives_from_multiple.arcs
@@ -1,0 +1,33 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {}
+  bar: writes Bar {}
+  baz: writes Baz {}
+  claim foo is fooData
+  claim bar is barData
+  claim baz is bazData
+
+particle P2
+  foo: reads Foo {}
+  bar: reads Bar {}
+  baz: reads Baz {}
+  examples: writes Example {}
+  claim examples derives from foo and derives from bar
+
+particle P3
+  examples: reads Example {}
+  check examples (is fooData or is barData) and is not bazData
+
+recipe R
+  P1
+    foo: writes fooHandle
+    bar: writes barHandle
+    baz: writes bazHandle
+  P2
+    foo: reads fooHandle
+    bar: reads barHandle
+    baz: reads bazHandle
+    examples: writes examplesHandle
+  P3
+    examples: reads examplesHandle

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_directly_satisfied.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_directly_satisfied.arcs
@@ -1,0 +1,14 @@
+// DFA succeeds when a check is satisfied directly
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_claim_propagates.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_claim_propagates.arcs
@@ -1,0 +1,27 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads Foo {a: Text}
+  bar: writes Bar {b: Text}
+particle P3
+  baz: reads Bar {b: Text}
+  foo: writes [Foo {b: Number}]
+  check baz.b is trusted
+particle P4
+  foo: reads [Foo {b: Number}]
+  check foo.b is trusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    foo: reads h1
+    bar: writes h2
+  P3
+    baz: reads h2
+    foo: writes h3
+  P4
+    foo: reads h3

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_claim_propagates_type_variables.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_claim_propagates_type_variables.arcs
@@ -1,0 +1,33 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads ~a with {a: Text} // Constraints
+  bar: writes Bar {b: Text}
+particle PassThrough
+  input: reads ~a
+  output: writes ~a
+particle P3
+  baz: reads Bar {b: Text}
+  foo: writes [Foo {b:Number}]
+  check baz.b is trusted
+particle P4
+  foo: reads [Foo {b: Number}]
+  check foo.b is trusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    foo: reads h1
+    bar: writes h2
+  PassThrough
+    input: passThrough
+    output: h2
+  P3
+    baz: reads h2
+    foo: writes h3
+  P4
+    foo: reads h3

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_collection_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_collection_direct.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes [Foo {a: Text, b: Number}]
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads [Foo {a: Text}]
+  check foo.a is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_entity_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_entity_direct.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads Foo {a: Text}
+  check foo.a is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_entity_ref_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_entity_ref_direct.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes &Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads &Foo {a: Text}
+  check foo.a is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_entity_ref_field.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_entity_ref_field.arcs
@@ -1,0 +1,37 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes &Foo {
+    trusted: Text,
+    untrusted: &Bar {
+       c: &Baz {
+         deep: Number,
+         sensitive: Text
+       }
+    }
+  }
+  claim foo.trusted is trusted
+  claim foo.untrusted is untrusted
+  claim foo.untrusted.c.deep is deep
+  claim foo.untrusted.c.sensitive is sensitive
+
+particle P2
+  foo: reads &Foo {
+    trusted: Text,
+    untrusted: &Bar {
+       c: &Baz {
+         deep: Number,
+         // sensitive: Text
+       }
+    }
+  }
+  check foo is trusted or is untrusted or is deep
+  check foo.trusted is trusted
+  check foo.untrusted is untrusted or is deep
+  check foo.untrusted.c.deep is deep
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_inline_entity_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_inline_entity_direct.arcs
@@ -1,0 +1,26 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }
+  }
+  claim foo.a.c is trusted
+  claim foo.a.d is trusted
+  claim foo.a.d.e is untrusted
+
+particle P2
+  foo: reads Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }
+  }
+  check foo.a.c is trusted
+  // Labels on foo and foo.a.d is the combination of labels
+  // for foo.a.d.e and foo.a.d
+  check foo is trusted or is untrusted
+  check foo.a.d is trusted or is untrusted
+  check foo.a.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_inline_entity_slicing.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_inline_entity_slicing.arcs
@@ -1,0 +1,32 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes FooList {
+    elements: List<inline Foo {
+      ok: Text,
+      notOk: Number,
+      mixed: inline Baz {
+        ok: Text,
+        notOk: Number,
+      }
+    }>
+  }
+  claim foo.elements.ok is trusted
+  claim foo.elements.notOk is untrusted
+  claim foo.elements.mixed.ok is trusted
+  claim foo.elements.mixed.notOk is untrusted
+
+particle P2
+  foo: reads FooList {
+    elements: List<inline Foo {
+      ok: Text,
+      mixed: inline Baz { ok: Text }
+    }>
+  }
+  check foo is trusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_list_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_list_direct.arcs
@@ -1,0 +1,27 @@
+// #Ingress: P1
+// #OK
+schema FooList
+  elements: List<inline Foo {
+    c: Text,
+    d: inline Baz {e: Number}
+  }>
+
+particle P1
+  foo: writes FooList {elements}
+  claim foo.elements.c is trusted
+  claim foo.elements.d is trusted
+  claim foo.elements.d.e is untrusted
+
+particle P2
+  foo: reads FooList {elements}
+  check foo.elements.c is trusted
+  // Label on foo.elements.d is the combination of labels for
+  // foo.elements.d.e and foo.elements.d
+  check foo.elements.d is trusted or is untrusted
+  check foo.elements.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_merge_multiple_paths.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_merge_multiple_paths.arcs
@@ -1,0 +1,49 @@
+// #Ingress: TrustedTextWriter
+// #Ingress: TrustedNumberWriter
+// #OK
+particle TrustedTextWriter
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle TrustedNumberWriter
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is untrusted
+  claim foo.b is trusted
+particle TrustedNumberReader
+  foo: reads Foo {b: Number}
+  baz: writes Baz {a: Text}
+particle TrustedTextReader
+  foo: reads Foo {a: Text}
+  baz: writes Baz {a: Text}
+particle UntrustedTextReader
+  foo: reads Foo {a: Text}
+  baz: writes Baz {a: Text}
+particle UntrustedNumberReader
+  foo: reads Foo {b: Number}
+  baz: writes Baz {a: Text}
+particle BazReader
+  t: reads Baz {a: Text}
+  u: reads Baz {a: Text}
+  check t.a is trusted
+  check u.a is untrusted
+
+recipe R
+  TrustedTextWriter
+    foo: writes trustedTextHandle
+  TrustedNumberWriter
+    foo: writes trustedNumberHandle
+  UntrustedTextReader
+    foo: reads trustedNumberHandle
+    baz: writes untrustedHandle
+  TrustedTextReader
+    foo: reads trustedTextHandle
+    baz: writes trustedHandle
+  UntrustedNumberReader
+    foo: reads trustedTextHandle
+    baz: writes untrustedHandle
+  TrustedNumberReader
+    foo: reads trustedNumberHandle
+    baz: writes trustedHandle
+  BazReader
+    t: reads trustedHandle
+    u: reads untrustedHandle

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_tuple_direct.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_field_tuple_direct.arcs
@@ -1,0 +1,32 @@
+// #Ingress: P1
+// #OK
+schema FooList
+  elements: List<inline Foo {
+    c: Text,
+    d: inline Baz {e: Number}
+  }>
+
+schema Bar
+  b: inline Baz {e: Number}
+
+particle P1
+  foo: writes (FooList, Bar)
+  claim foo.first.elements.c is trusted
+  claim foo.first.elements.d is trusted
+  claim foo.first.elements.d.e is untrusted
+  claim foo.second.b.e is public
+
+particle P2
+  foo: reads (FooList, Bar)
+  check foo.first.elements.c is trusted
+  // Label on foo.first.elements.d is the combination of labels for
+  // foo.first.elements.d.e and foo.first.elements.d
+  check foo.first.elements.d is trusted or is untrusted
+  check foo.first.elements.d.e is untrusted
+  check foo.second.b.e is public
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_join_simple.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_join_simple.arcs
@@ -1,0 +1,52 @@
+// #Ingress: IngestPerson
+// #Ingress: IngestAddress
+// #OK
+particle IngestPerson
+  person: writes [Person {name: Text, age: Number, education: Text}]
+  claim person.age is sensitive
+
+particle IngestAddress
+  address: writes [Address {name: Text, street: Text, city: Text}]
+  claim address.street is sensitive
+
+particle SensitiveInfo
+  details: reads [(
+    Person {name: Text, age: Number, education: Text},
+    Address {name: Text, street: Text, city: Text}
+  )]
+  info: writes Info {info: Text}
+
+particle PublicInfo
+  details: reads [(
+    Person {name: Text, education: Text},
+    Address {name: Text, city: Text}
+  )]
+  info: writes Info {info: Text}
+
+particle EgressPublic
+  info: reads Info {info: Text}
+  check info.info is not sensitive
+
+particle EgressSensitive
+  info: reads Info {info: Text}
+
+recipe R
+  person: create
+  address: create
+  all: join (person, address)
+  publicInfo: create
+  sensitiveInfo: create
+  IngestPerson
+    person: person
+  IngestAddress
+    address: address
+  PublicInfo
+    details: all
+    info: publicInfo
+  SensitiveInfo
+    details: all
+    info: sensitiveInfo
+  EgressPublic
+    info: publicInfo
+  EgressSensitive
+    info: sensitiveInfo

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_join_simple_with_nullables.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_join_simple_with_nullables.arcs
@@ -1,0 +1,52 @@
+// #Ingress: IngestPerson
+// #Ingress: IngestAddress
+// #OK
+particle IngestPerson
+  person: writes [Person {name: Text, age: Number, education: Text?}]
+  claim person.age is sensitive
+
+particle IngestAddress
+  address: writes [Address {name: Text?, street: Text, city: Text}]
+  claim address.street is sensitive
+
+particle SensitiveInfo
+  details: reads [(
+    Person {name: Text, age: Number, education: Text?},
+    Address {name: Text?, street: Text, city: Text}
+  )]
+  info: writes Info {info: Text}
+
+particle PublicInfo
+  details: reads [(
+    Person {name: Text, education: Text?},
+    Address {name: Text?, city: Text}
+  )]
+  info: writes Info {info: Text}
+
+particle EgressPublic
+  info: reads Info {info: Text}
+  check info.info is not sensitive
+
+particle EgressSensitive
+  info: reads Info {info: Text}
+
+recipe R
+  person: create
+  address: create
+  all: join (person, address)
+  publicInfo: create
+  sensitiveInfo: create
+  IngestPerson
+    person: person
+  IngestAddress
+    address: address
+  PublicInfo
+    details: all
+    info: publicInfo
+  SensitiveInfo
+    details: all
+    info: sensitiveInfo
+  EgressPublic
+    info: publicInfo
+  EgressSensitive
+    info: sensitiveInfo

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_join_tuple_components.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_join_tuple_components.arcs
@@ -1,0 +1,46 @@
+// #Ingress: IngestPerson
+// #Ingress: IngestAddress
+// #OK
+particle IngestPerson
+  person: writes [Person {name: Text, age: Number, education: Text}]
+  claim person.age is sensitive
+
+particle IngestAddress
+  address: writes [Address {name: Text, street: Text, city: Text}]
+  claim address.street is sensitive
+
+particle ReadJoinedData
+  details: reads [(
+    Person {name: Text, age: Number, education: Text},
+    Address {name: Text, street: Text, city: Text}
+  )]
+  sensitiveInfo: writes Info {info: Text}
+  publicInfo: writes Info {info: Text}
+  claim sensitiveInfo.info derives from details.first.age
+  claim publicInfo.info derives from details.first.name and derives from details.second.city
+
+particle EgressPublic
+  info: reads Info {info: Text}
+  check info.info is not sensitive
+
+particle EgressSensitive
+  info: reads Info {info: Text}
+
+recipe R
+  person: create
+  address: create
+  all: join (person, address)
+  publicInfo: create
+  sensitiveInfo: create
+  IngestPerson
+    person: person
+  IngestAddress
+    address: address
+  ReadJoinedData
+    details: all
+    publicInfo: publicInfo
+    sensitiveInfo: sensitiveInfo
+  EgressPublic
+    info: publicInfo
+  EgressSensitive
+    info: sensitiveInfo

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_multiple_inputs_correct_tags.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_multiple_inputs_correct_tags.arcs
@@ -1,0 +1,20 @@
+// succeeds when handle has multiple inputs with the right tags
+// #Ingress: P1
+// #Ingress: P2
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  foo: writes Foo {}
+  claim foo is trusted
+particle P3
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: writes h
+  P3
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_negated_missing_tag.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_negated_missing_tag.arcs
@@ -1,0 +1,9 @@
+// succeeds for a negated tag check when the tag is missing
+// #Ingress: P
+// #OK
+particle P
+  bar: reads Foo {}
+  check bar is not private
+recipe R
+  P
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_not_tag_claim_no_checks.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_not_tag_claim_no_checks.arcs
@@ -1,0 +1,13 @@
+// succeeds when a "not tag" is claimed and there are no checks
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is not trusted
+particle P2
+  bar: reads Foo {}
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_not_tag_claim_reclaimed.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_not_tag_claim_reclaimed.arcs
@@ -1,0 +1,28 @@
+// succeeds when a "not tag" cancels a tag that is reclaimed downstream
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  baz: writes Foo {}
+  claim baz is not trusted
+particle P3
+  bye: reads Foo {}
+  boy: writes Foo {}
+  claim boy is trusted
+particle P4
+  bit: reads Foo {}
+  check bit is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h
+    baz: writes h1
+  P3
+    bye: reads h1
+    boy: writes h2
+  P4
+    bit: reads h2

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_read_write_match_claim_check.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/ok_read_write_match_claim_check.arcs
@@ -1,0 +1,10 @@
+// succeeds when an inout handle claims the same tag it checks
+// #Ingress: P
+// #OK
+particle P
+  foo: reads writes Foo {}
+  check foo is t
+  claim foo is t
+recipe R
+  P
+    foo: reads writes h

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/policy_test.arcs
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/policy_test.arcs
@@ -1,0 +1,374 @@
+schema Action
+  id: Text
+  action: Text
+  timestampInMs: Number
+
+schema Selection
+  id: Text
+  selection: Text
+  sensitiveSelection: Text
+  timestampInMs: Number
+
+schema ActionAtSelection
+  id: Text
+  actionDetails: Text
+
+@intendedPurpose('Test the implementation of policy verification.')
+@egressType('TestEgressType')
+policy TestPolicy {
+
+  from Action access {
+    id
+    action,
+
+    @allowedUsage(label: 'truncatedToDays', usageType: '*')
+    timestampInMs,
+  }
+
+  from Selection access {
+    id,
+    selection,
+    // sensitiveSelection is not allowed
+
+    @allowedUsage(label: 'raw', usageType: 'join')
+    timestampInMs,
+  }
+}
+
+@isolated
+particle ActionTimestampToDays
+  // Should ideally be as follows, but we don't have information about
+  // type variables in DFA yet.
+  //
+  // input: reads [~a with {timestampInMs: Number}]
+  // output: writes [~a]
+  // claim output.timestampInMs is truncatedToDays
+  input: reads [Action {
+     id,
+     action,
+     timestampInMs}]
+  output: writes [Action {
+     id,
+     action,
+     timestampInMs}]
+  claim output.timestampInMs derives from input.timestampInMs and is truncatedToDays
+  // The following claims are not needed if we use type variables as mentioned above.
+  claim output.id derives from input.id
+  claim output.action derives from input.action
+
+@egress('TestEgressType')
+particle TestEgressParticle
+  joinData: reads [~a]
+
+@egress('TestEgressType')
+particle AnotherTestEgressParticle
+  joinData: reads [~a]
+
+@egress('SomeOtherEgress')
+particle ParticleWithWrongEgressType
+  joinData: reads [~a]
+
+particle ParticleWithMissingEgressType
+  joinData: reads [~a]
+
+//-----------------------------------------------------------
+// Complying by not having any egress particles.
+//-----------------------------------------------------------
+@ingress
+particle SomeIngressParticle
+  input: writes [Person {name: Text}]
+
+@isolated
+particle SomeIsolatedParticle
+  input: reads [~a]
+
+@policy('TestPolicy')
+recipe NoEgressParticles
+  input: create 'input'
+  SomeIngressParticle
+    input: input
+  SomeIsolatedParticle
+    input: input
+
+//-----------------------------------------------------------
+// Complying by not egressing restricted fields.
+//-----------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressUnrestrictedFields
+  action: reads [Action {id, action}]
+  selection: reads [Selection {id, selection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+@policy('TestPolicy')
+recipe EgressUnrestrictedFields
+  action: map 'action'
+  selection: map 'selection'
+  joinData: create
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+// Recipe that complies with policy even with multiple egresses.
+@policy('TestPolicy')
+recipe EgressAndLogUnrestrictedFields
+  action: map 'action'
+  selection: map 'selection'
+  joinData: create
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+  AnotherTestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------
+// Complying by redacting `timestampInMs` in `selection`.
+//-----------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressRedactedField
+  action: reads [Action {id, action, timestampInMs}]
+  selection: reads [Selection {id, selection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+@policy('TestPolicy')
+recipe EgressRedactedField
+  action: map 'action'
+  selection: map 'selection'
+  joinData: create
+  ActionTimestampToDays
+    input: action
+    output: actionRedacted
+  JoinActionSelection_EgressRedactedField
+    action: actionRedacted
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// No policy violation if data is not egressed even if accessing
+// `sensitiveSelection` in `Selection`.
+//-----------------------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressRestrictedFields
+  action: reads [Action {id, action, timestampInMs}]
+  selection: reads [Selection {id, selection, sensitiveSelection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+@policy('TestPolicy')
+recipe AccessRestrictedFieldsNoEgress
+  action: map 'action'
+  selection: map 'selection'
+  joinData: create
+  ActionTimestampToDays
+    input: action
+    output: actionRedacted
+  JoinActionSelection_EgressRestrictedFields
+    action: actionRedacted
+    selection: selection
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by using data from mapped handle of different type.
+//-----------------------------------------------------------------------
+schema CustomAction
+  data: Text
+
+@isolated
+particle CustomActionConverter
+  customAction: reads [CustomAction {data}]
+  action: writes [Action {id, action}]
+
+@policy('TestPolicy')
+recipe MappedHandleOfDifferentType
+  customAction: map 'customAction' // Has type CustomAction, which is not covered by policy.
+  selection: map 'selection'
+  action: create
+  joinData: create
+  CustomActionConverter
+    customAction: customAction
+    action: action
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by using data from ingress particle of different type.
+//-----------------------------------------------------------------------
+@ingress
+particle CustomActionProducer
+  customAction: writes [CustomAction {data}]
+
+@policy('TestPolicy')
+recipe IngressParticleOfDifferentType
+  customAction: create
+  selection: map 'selection'
+  action: create
+  joinData: create
+  CustomActionProducer
+    customAction: customAction
+  CustomActionConverter
+    customAction: customAction
+    action: action
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// No policy violation if ingress points of different types are unused.
+//-----------------------------------------------------------------------
+@policy('TestPolicy')
+recipe UnusedIngressPointsOfDifferentType
+  customAction: map 'customAction' // Ingress point, but ultimately unused
+  unused1: create
+  unused2: create
+  selection: map 'selection'
+  action: map 'action'
+  joinData: create
+  CustomActionProducer // Ingress point, but ultimately unused
+    customAction: unused1
+  CustomActionConverter
+    customAction: customAction
+    action: unused2
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by egressing `sensitiveSelection` in `Selection`.
+//-----------------------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressRestrictedFields
+  action: reads [Action {id, action, timestampInMs}]
+  selection: reads [Selection {id, selection, sensitiveSelection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+@policy('TestPolicy')
+recipe EgressRestrictedFields
+  action: map 'action'
+  selection: map 'selection'
+  joinData: create
+  ActionTimestampToDays
+    input: action
+    output: actionRedacted
+  JoinActionSelection_EgressRestrictedFields
+    action: actionRedacted
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by egressing `timestampInMs` in `Selection`,
+// which can only be used for joins.
+//-----------------------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressJoinOnlyField
+  action: reads [Action {id, action, timestampInMs}]
+  selection: reads [Selection {id, selection, sensitiveSelection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+@policy('TestPolicy')
+recipe EgressJoinOnlyField
+  action: map 'action'
+  selection: map 'selection'
+  joinData: create
+  ActionTimestampToDays
+    input: action
+    output: actionRedacted
+  JoinActionSelection_EgressJoinOnlyField
+    action: actionRedacted
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by not redacting `timestampInMs` in `Action`.
+//-----------------------------------------------------------------------
+@policy('TestPolicy')
+recipe EgressUnredactedField
+  action: map 'action'
+  selection: map 'selection'
+  joinData: create
+  JoinActionSelection_EgressRedactedField
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by not annotating an ingress particle appropriately.
+//-----------------------------------------------------------------------
+@isolated
+particle IngestAction
+  action: writes [Action]
+
+@policy('TestPolicy')
+recipe UnmarkedIngress
+  // `IngestAction` should have been for `action` to be matched with allowed usages
+  // in `TestPolicy`. As `IngestAction` is not marked as ingress, we assume that
+  // nothing can be done with the data on `action` handle.
+  // TODO(b/164153178): we simulate the absence of `@ingress` by not naming the
+  // store id as 'action`. When we have proper `@ingress` annotation, we should fix it.
+  action: create
+  selection: map 'selection'
+  joinData: create
+  IngestAction
+    action: action
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by having invalid egress particles.
+//-----------------------------------------------------------------------
+@policy('TestPolicy')
+recipe InvalidEgressParticles
+  action: map 'action'
+  selection: map 'selection'
+  joinData: create
+  JoinActionSelection_EgressRedactedField
+    action: action
+    selection: selection
+    joinData: joinData
+  ParticleWithWrongEgressType
+    joinData: joinData
+  ParticleWithMissingEgressType
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+  AnotherTestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by not having an @policy annotation.
+//-----------------------------------------------------------------------
+recipe MissingPolicyAnnotation
+
+//-----------------------------------------------------------------------
+// Policy violation by referring to a different policy.
+//-----------------------------------------------------------------------
+@egressType('Logging')
+policy SomeOtherPolicy {}
+
+@policy('SomeOtherPolicy')
+recipe DifferentPolicyName


### PR DESCRIPTION
This commit copies over manifest tests from the original Arcs repo.
Right now, all of these tests are in the directory
//src/analysis/souffle/tests/arcs_manifest_tests_todo , a new directory
for manifest tests that we cannot yet handle end to end. As we get these
tests working end to end, we should move them to a new
//src/analysis/souffle/tests/arcs_manifest_tests directory.