### PR TITLE
Add Abseil (and dependency rules_cc) to raksha; Format with buildifier.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # googletest
 #--------------------
 http_archive(
-  name = "com_google_googletest",
-  urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
-  strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
+    name = "com_google_googletest",
+    strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
+    urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
 )
 
 # Protobuf:
@@ -19,15 +19,20 @@ http_archive(
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/3.1.1.tar.gz"],
 )
 
-load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains", "rules_proto_grpc_repos")
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
+
 rules_proto_grpc_toolchains()
+
 rules_proto_grpc_repos()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()
 
 load("@rules_proto_grpc//cpp:repositories.bzl", rules_proto_grpc_cpp_repos = "cpp_repos")
+
 rules_proto_grpc_cpp_repos()
 
 #--------------------
@@ -51,10 +56,12 @@ rules_foreign_cc_dependencies()
 #--------------------
 http_archive(
     name = "rules_m4",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2/rules_m4-v0.2.tar.xz"],
     sha256 = "c67fa9891bb19e9e6c1050003ba648d35383b8cb3c9572f397ad24040fb7f0eb",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2/rules_m4-v0.2.tar.xz"],
 )
+
 load("@rules_m4//m4:m4.bzl", "m4_register_toolchains")
+
 m4_register_toolchains()
 
 #--------------------
@@ -62,10 +69,12 @@ m4_register_toolchains()
 #--------------------
 http_archive(
     name = "rules_flex",
-    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.2/rules_flex-v0.2.tar.xz"],
     sha256 = "f1685512937c2e33a7ebc4d5c6cf38ed282c2ce3b7a9c7c0b542db7e5db59d52",
+    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.2/rules_flex-v0.2.tar.xz"],
 )
+
 load("@rules_flex//flex:flex.bzl", "flex_register_toolchains")
+
 flex_register_toolchains()
 
 #--------------------
@@ -73,10 +82,12 @@ flex_register_toolchains()
 #--------------------
 http_archive(
     name = "rules_bison",
-    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2/rules_bison-v0.2.tar.xz"],
     sha256 = "6ee9b396f450ca9753c3283944f9a6015b61227f8386893fb59d593455141481",
+    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2/rules_bison-v0.2.tar.xz"],
 )
+
 load("@rules_bison//bison:bison.bzl", "bison_register_toolchains")
+
 bison_register_toolchains()
 
 #--------------------
@@ -90,22 +101,20 @@ http_archive(
     urls = ["https://github.com/libffi/libffi/releases/download/v3.3-rc2/libffi-3.3-rc2.tar.gz"],
 )
 
-
 #--------------------
 # Souffle:
 #--------------------
 http_archive(
     name = "souffle",
-    urls = ["https://github.com/souffle-lang/souffle/archive/fbb4c4b967bf58cccb7aca58e3d200a799218d98.zip"],
     build_file = "@//third_party/souffle:BUILD.souffle",
-    sha256 = "654c1b33b2b3f20fdc1f0983dfed562c24a0baa230fd431401cc0004464c6b4d",
-    strip_prefix = "souffle-fbb4c4b967bf58cccb7aca58e3d200a799218d98",
     patch_args = ["-p0"],
     patches = [
         "@//third_party/souffle:remove_config.patch",
     ],
+    sha256 = "654c1b33b2b3f20fdc1f0983dfed562c24a0baa230fd431401cc0004464c6b4d",
+    strip_prefix = "souffle-fbb4c4b967bf58cccb7aca58e3d200a799218d98",
+    urls = ["https://github.com/souffle-lang/souffle/archive/fbb4c4b967bf58cccb7aca58e3d200a799218d98.zip"],
 )
-
 
 #-------------------
 # nodejs
@@ -117,7 +126,23 @@ http_archive(
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
+
 # NOTE: this rule installs nodejs, npm, and yarn, but does NOT install
 # your npm dependencies into your node_modules folder.
 # You must still run the package manager to do this.
 node_repositories(package_json = ["//third_party/arcs/tools/manifest2proto:package.json"])
+
+# Note: Required for abseil.
+http_archive(
+    name = "rules_cc",
+    sha256 = "e4ab6ab1321977536835d9e66e24f869e0f02929a286b23f86b1ab97543f9007",
+    strip_prefix = "rules_cc-fb624ff008196216a86e958e98fbd1a2615d7bbe",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/fb624ff008196216a86e958e98fbd1a2615d7bbe.zip"],
+)
+
+http_archive(
+    name = "absl",
+    sha256 = "59b862f50e710277f8ede96f083a5bb8d7c9595376146838b9580be90374ee1f",
+    strip_prefix = "abseil-cpp-20210324.2",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.tar.gz"],
+)


### PR DESCRIPTION
    This commit adds Abseil to the external dependencies in WORKSPACE. We
    are using the 20210324.2 release because I am not brave enough to live
    at Abseil HEAD. Also adds the rules_cc external package because Abseil
    depends upon it. Also, performed some automatic reformatting from
    Buildifier on WORKSPACE.
