### PR TITLE
Move AccessPathSelectors factory CreateFromString to class, allow empty.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -21,8 +21,6 @@ cc_test(
         ":ir",
         "//src/common/testing:gtest",
         "@absl//absl/hash",
-        "@absl//absl/status",
-        "@absl//absl/status:statusor",
         "@absl//absl/hash:hash_testing",
         "@absl//absl/strings",
     ],

--- a/src/ir/access_path_selectors.cc
+++ b/src/ir/access_path_selectors.cc
@@ -1,0 +1,30 @@
+#include "src/ir/access_path_selectors.h"
+
+#include "absl/strings/str_split.h"
+
+namespace raksha::ir {
+
+// This is a bit simplified right now, as it only splits on '.', the field
+// separator character. However, this could easily be generalized to handle
+// other forms of separators later.
+AccessPathSelectors AccessPathSelectors::CreateFromString(std::string str) {
+  const std::vector<std::string> selector_strs =
+      absl::StrSplit(std::move(str), '.', absl::SkipEmpty());
+
+  // Create an empty leaf selector.
+  AccessPathSelectors access_path_selectors;
+
+  // Add all selectors as parents, in reverse order of the reversed vector.
+  for (
+      auto rev_iter = selector_strs.rbegin();
+      rev_iter != selector_strs.rend();
+      ++rev_iter) {
+    access_path_selectors = AccessPathSelectors(
+        Selector(FieldSelector(*rev_iter)),
+        std::move(access_path_selectors));
+  }
+
+  return access_path_selectors;
+}
+
+}  // namespace raksha::ir

--- a/src/ir/access_path_selectors.h
+++ b/src/ir/access_path_selectors.h
@@ -28,11 +28,24 @@ namespace raksha::ir {
 // 3. The name AccessPathSelectors is a bit more self-documenting.
 class AccessPathSelectors {
  public:
+
+  // Given a string representation of an AccessPathSelectors object, return
+  // the equivalent structured representation.
+  static AccessPathSelectors CreateFromString(std::string str);
+
+  // Default empty constructor creates an access path with no Selectors. This
+  // would correspond to a type tree consisting of a primitive type at the
+  // root.
+  AccessPathSelectors() = default;
+
   // Create a leaf AccessPathSelectors from a single leaf selector.
   explicit AccessPathSelectors(Selector leaf) {
     reverse_selectors_.push_back(std::move(leaf));
   }
 
+  // Create a new AccessPathSelectors object from a Selector and an
+  // AccessPathSelectors object, with the Selector added as the parent of the
+  // path elements of the AccessPathSelectors object.
   AccessPathSelectors(Selector parent_selector, AccessPathSelectors child_path)
     : AccessPathSelectors(std::move(child_path))
   {


### PR DESCRIPTION
Making an AccessPathSelectors object from its string representation is
something that seems potentially useful in the future, so this PR moves
it from being a test utility to being a class member. In addition,
AccessPathSelectors is changed slightly to allow both the empty string
and an empty AccessPathSelectors.