### PR TITLE
Alter AccessPathSelectors to allow an empty AccessPathSelectors object.

### DIFF
--- a/src/ir/access_path_selectors.h
+++ b/src/ir/access_path_selectors.h
@@ -28,6 +28,10 @@ namespace raksha::ir {
 // 3. The name AccessPathSelectors is a bit more self-documenting.
 class AccessPathSelectors {
  public:
+  // Allow constructing an empty AccessPathSelectors object. This represents
+  // an empty access path, such as one involving only a primitive type.
+  explicit AccessPathSelectors() = default;
+
   // Create a leaf AccessPathSelectors from a single leaf selector.
   explicit AccessPathSelectors(Selector leaf) {
     reverse_selectors_.push_back(std::move(leaf));

--- a/src/ir/access_path_selectors_test.cc
+++ b/src/ir/access_path_selectors_test.cc
@@ -24,7 +24,7 @@ static AccessPathSelectors MakeSelectorAccessPathFromString(
 
   // Start with an empty path and add all Selectors as parents.
   AccessPathSelectors result;
-  for ( auto iter = selector_strs.rbegin();
+  for (auto iter = selector_strs.rbegin();
         iter != selector_strs.rend(); ++iter) {
     result = AccessPathSelectors(
         Selector(FieldSelector(std::move(*iter))), std::move(result));


### PR DESCRIPTION
I initially did not allow an empty AccessPathSelectors object, but it is
useful for simplifying the generation of AccessPathSelectorsSets.
Specifically, an empty AccessPathSelector can represent the AccessPath
generated by a PrimitiveType.