### PR TITLE
Add HandleConnectionSpec class and methods sending it to/from protos.

### DIFF
--- a/src/xform_to_datalog/arcs_manifest_tree/BUILD
+++ b/src/xform_to_datalog/arcs_manifest_tree/BUILD
@@ -1,0 +1,25 @@
+package(default_visibility = ["//src/xform_to_datalog:__subpackages__"])
+
+cc_library(
+    name = "arcs_manifest_tree",
+    srcs = glob(
+        ["*.cc"],
+        exclude = ["*_test.cc"],
+    ),
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//src/common/logging",
+        "//src/ir",
+        "//third_party/arcs/proto:manifest_cc_proto",
+        "@absl//absl/container:flat_hash_map",
+    ],
+)
+
+cc_test(
+    name = "handle_connection_spec_test",
+    srcs = ["handle_connection_spec_test.cc"],
+    deps = [
+        ":arcs_manifest_tree",
+        "//src/common/testing:gtest",
+    ],
+)

--- a/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.cc
@@ -1,0 +1,32 @@
+#include "src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.h"
+
+namespace src::xform_to_datalog::arcs_manifest_tree {
+
+HandleConnectionSpec HandleConnectionSpec::CreateFromProto(
+    const arcs::HandleConnectionSpecProto &handle_connection_spec_proto) {
+  const std::string &name = handle_connection_spec_proto.name();
+  CHECK(!name.empty()) << "Found connection spec without required name.";
+  bool reads = false;
+  bool writes = false;
+  switch (handle_connection_spec_proto.direction()) {
+    case arcs::HandleConnectionSpecProto_Direction_UNSPECIFIED:
+      LOG(FATAL)
+        << "Connection spec " << name << " has unspecified direction";
+    case arcs::HandleConnectionSpecProto_Direction_READS:
+      reads = true;
+      break;
+    case arcs::HandleConnectionSpecProto_Direction_WRITES:
+      writes = true;
+      break;
+    case arcs::HandleConnectionSpecProto_Direction_READS_WRITES:
+      reads = true;
+      writes = true;
+      break;
+    default:
+      LOG(FATAL)
+        << "Unimplemented direction in connection spec " << name << ".";
+  }
+  return HandleConnectionSpec(name, reads, writes);
+}
+
+}  // namespace src::xform_to_datalog::arcs_manifest_tree

--- a/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.h
+++ b/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.h
@@ -1,0 +1,59 @@
+#ifndef SRC_XFORM_TO_DATALOG_ARCS_MANIFEST_TREE_HANDLE_CONNECTION_SPEC_H_
+#define SRC_XFORM_TO_DATALOG_ARCS_MANIFEST_TREE_HANDLE_CONNECTION_SPEC_H_
+
+#include <string>
+
+#include "src/common/logging/logging.h"
+#include "third_party/arcs/proto/manifest.pb.h"
+
+namespace src::xform_to_datalog::arcs_manifest_tree {
+
+// A class used to gather information about HandleConnectionSpecs from the
+// equivalent ArcsManifestProtos. Currently, the only thing we care about
+// from these is the name of the handle connection and whether it reads
+// and/or writes the handle to which it is connected.
+class HandleConnectionSpec {
+ public:
+  // Factory creating a HandleConnectionSpec from an arcs
+  // HandleConnectionSpecProto.
+  static HandleConnectionSpec CreateFromProto(
+      const arcs::HandleConnectionSpecProto &handle_connection_spec_proto);
+
+  const std::string &name() const {
+    return name_;
+  }
+
+  bool reads() const {
+    return reads_;
+  }
+
+  bool writes() const {
+    return writes_;
+  }
+
+  // Make an arcs HandleConnectionSpecProto from this object.
+  arcs::HandleConnectionSpecProto MakeProto() const {
+    arcs::HandleConnectionSpecProto result;
+    result.set_direction(
+        (reads_ && writes_)
+        ? arcs::HandleConnectionSpecProto_Direction_READS_WRITES
+        : (reads_) ? arcs::HandleConnectionSpecProto_Direction_READS
+                   : arcs::HandleConnectionSpecProto_Direction_WRITES);
+    result.set_name(name_);
+    return result;
+  }
+
+ private:
+  HandleConnectionSpec(
+    const std::string name,
+    const bool reads,
+    const bool writes) : name_(name), reads_(reads), writes_(writes) {}
+
+  std::string name_;
+  bool reads_;
+  bool writes_;
+};
+
+}  // namespace src::xform_to_datalog::arcs_manifest_tree
+
+#endif  // SRC_XFORM_TO_DATALOG_ARCS_MANIFEST_TREE_HANDLE_CONNECTION_SPEC_H_

--- a/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec_test.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec_test.cc
@@ -1,0 +1,55 @@
+#include "src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.h"
+
+#include <google/protobuf/util/message_differencer.h>
+#include <google/protobuf/text_format.h>
+
+#include "src/common/testing/gtest.h"
+
+namespace src::xform_to_datalog::arcs_manifest_tree {
+
+struct ProtoStringAndExpectations {
+  std::string proto_str;
+  std::string expected_name;
+  bool expected_reads;
+  bool expected_writes;
+};
+
+class RoundTripHandleConnectionSpecProtoTest :
+    public testing::TestWithParam<ProtoStringAndExpectations> {};
+
+TEST_P(RoundTripHandleConnectionSpecProtoTest,
+       RoundTripHandleConnectionSpecProtoTest) {
+  ProtoStringAndExpectations info = GetParam();
+
+  arcs::HandleConnectionSpecProto original_proto;
+  google::protobuf::TextFormat::ParseFromString(
+      info.proto_str, &original_proto);
+  HandleConnectionSpec handle_connection_spec =
+      HandleConnectionSpec::CreateFromProto(original_proto);
+
+  EXPECT_EQ(handle_connection_spec.name(), info.expected_name);
+  EXPECT_EQ(handle_connection_spec.reads(), info.expected_reads);
+  EXPECT_EQ(handle_connection_spec.writes(), info.expected_writes);
+
+  arcs::HandleConnectionSpecProto result_proto =
+      handle_connection_spec.MakeProto();
+   ASSERT_TRUE(
+      google::protobuf::util::MessageDifferencer::Equals(
+          original_proto, result_proto));
+}
+
+static const ProtoStringAndExpectations string_and_expections_array[] = {
+    { .proto_str = "name: \"foo\" direction: READS", .expected_name = "foo",
+      .expected_reads = true, .expected_writes = false},
+    { .proto_str = "name: \"bar\" direction: WRITES", .expected_name = "bar",
+      .expected_reads = false, .expected_writes = true },
+    { .proto_str = "name: \"baz\" direction: READS_WRITES", .expected_name =
+    "baz", .expected_reads = true, .expected_writes = true}
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    RoundTripHandleConnectionSpecProtoTest,
+    RoundTripHandleConnectionSpecProtoTest,
+    testing::ValuesIn(string_and_expections_array));
+
+}  // namespace src::xform_to_datalog::arcs_manifest_tree


### PR DESCRIPTION
We only really need this at this point to link the name to
a HandleConnection and to determine whether it reads and/or writes.