### PR TITLE
Allow translating ir Selectors from/to arcs manifest proto Selectors.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -8,6 +8,8 @@ cc_library(
     ),
     hdrs = glob(["*.h"]),
     deps = [
+        "//src/common/logging",
+        "//third_party/arcs/proto:manifest_cc_proto",
         "@absl//absl/container:flat_hash_set",
         "@absl//absl/hash",
         "@absl//absl/strings",

--- a/src/ir/field_selector.h
+++ b/src/ir/field_selector.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "absl/strings/str_cat.h"
+#include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
 
@@ -20,6 +21,13 @@ class FieldSelector {
   // Two fields selectors are equal exactly when their names are equal.
   bool operator==(const FieldSelector &other) const {
     return field_name_ == other.field_name_;
+  }
+
+  // Make a Manifest proto Selector from this FieldSelector.
+  arcs::AccessPathProto_Selector MakeProto() const {
+    arcs::AccessPathProto_Selector selector;
+    selector.set_field(field_name_);
+    return selector;
   }
 
   template<typename H>

--- a/src/ir/selector_test.cc
+++ b/src/ir/selector_test.cc
@@ -1,5 +1,8 @@
 #include "src/ir/selector.h"
 
+#include <google/protobuf/util/message_differencer.h>
+#include <google/protobuf/text_format.h>
+
 #include "absl/hash/hash_testing.h"
 #include "src/common/testing/gtest.h"
 
@@ -90,5 +93,33 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(
         testing::ValuesIn(example_selectors),
         testing::ValuesIn(example_selectors)));
+
+class RoundTripSelectorProtoTest :
+ public testing::TestWithParam<std::tuple<std::string, std::string>> {};
+
+TEST_P(RoundTripSelectorProtoTest, RoundTripSelectorProtoTest) {
+  arcs::AccessPathProto_Selector orig_selector_proto;
+  const std::string &selector_as_textproto = std::get<0>(GetParam());
+  const std::string &expected_selector_to_string = std::get<1>(GetParam());
+  google::protobuf::TextFormat::ParseFromString(
+      selector_as_textproto, &orig_selector_proto);
+  Selector selector = Selector::CreateFromProto(orig_selector_proto);
+  EXPECT_EQ(selector.ToString(), expected_selector_to_string);
+  arcs::AccessPathProto_Selector result_selector_proto = selector.MakeProto();
+  ASSERT_TRUE(
+      google::protobuf::util::MessageDifferencer::Equals(
+          orig_selector_proto, result_selector_proto));
+}
+
+static const std::tuple<std::string, std::string>
+  selector_proto_and_tostring_pairs[] = {
+    { "field: \"foo\"", ".foo" },
+    { "field: \"x\"", ".x" },
+    { "field: \"bar\"", ".bar"}
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    RoundTripSelectorProtoTest, RoundTripSelectorProtoTest,
+    testing::ValuesIn(selector_proto_and_tostring_pairs));
 
 }  // namespace raksha::ir


### PR DESCRIPTION
This involves adding a CreateFromProto and MakeProto method to move
between the two forms.