### PR TITLE
Add AccessPath, representing a full path from root to leaf field.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -68,3 +68,12 @@ cc_test(
         "@absl//absl/strings",
     ],
 )
+
+cc_test(
+    name = "access_path_test",
+    srcs = ["access_path_test.cc"],
+    deps = [
+        ":ir",
+        "//src/common/testing:gtest",
+    ],
+)

--- a/src/ir/access_path.h
+++ b/src/ir/access_path.h
@@ -1,0 +1,31 @@
+#ifndef SRC_IR_ACCESS_PATH_H_
+#define SRC_IR_ACCESS_PATH_H_
+
+#include "absl/strings/str_cat.h"
+#include "src/ir/access_path_selectors.h"
+
+namespace raksha::ir {
+
+// An AccessPath is a fully-qualified path from the root of the data. At this
+// time, it is just an AccessPathSelectors, describing the path through the
+// type tree, and a root string, describing the path before that. More
+// structure may be added to the root in the future.
+class AccessPath {
+ public:
+  explicit AccessPath(
+      std::string root_string, AccessPathSelectors access_path_selectors)
+      : root_string_(std::move(root_string)),
+        access_path_selectors_(std::move(access_path_selectors)) {}
+
+  std::string ToString() const {
+    return absl::StrCat(root_string_, access_path_selectors_.ToString());
+  }
+
+ private:
+  std::string root_string_;
+  AccessPathSelectors access_path_selectors_;
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_ACCESS_PATH_H_

--- a/src/ir/access_path_test.cc
+++ b/src/ir/access_path_test.cc
@@ -1,0 +1,39 @@
+#include "src/common/testing/gtest.h"
+#include "src/ir/access_path.h"
+
+namespace raksha::ir {
+
+static Selector MakeFieldSelector(std::string field_name) {
+  return Selector(FieldSelector(field_name));
+}
+
+static const std::tuple<AccessPath, std::string>
+    access_path_and_expected_tostring_pairs[] = {
+    {AccessPath("a.b",
+             AccessPathSelectors(
+                 MakeFieldSelector("c"),
+                 AccessPathSelectors(
+                     MakeFieldSelector("d"), AccessPathSelectors()))),
+     "a.b.c.d" },
+    { AccessPath("foo", AccessPathSelectors()), "foo" },
+    { AccessPath(
+        "foo.bar",
+        AccessPathSelectors(
+            MakeFieldSelector("baz"), AccessPathSelectors())), "foo.bar.baz"}
+};
+
+class AccessPathToStringTest :
+ public testing::TestWithParam<std::tuple<AccessPath, std::string>> {};
+
+TEST_P(AccessPathToStringTest, AccessPathToStringTest) {
+  const AccessPath &access_path = std::get<0>(GetParam());
+  const std::string &expected_to_string = std::get<1>(GetParam());
+  EXPECT_EQ(access_path.ToString(), expected_to_string);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessPathToStringTest, AccessPathToStringTest,
+    testing::ValuesIn(access_path_and_expected_tostring_pairs));
+
+
+}  // namespace raksha::ir


### PR DESCRIPTION
Although this may seem like a pretty trivial addition on top of
AccessPathSelectors, this is useful for participating in data structures
that will eventually correspond to datalog facts, such as edges, claims,
and checks.