### PR TITLE
Add type information and GetAccessPaths to HandleConnectionSpec.

### DIFF
--- a/src/ir/access_path.h
+++ b/src/ir/access_path.h
@@ -53,6 +53,11 @@ class AccessPath {
     return AccessPath(std::move(new_root), access_path_selectors_);
   }
 
+  const AccessPathRoot &root() const { return root_; }
+
+  const AccessPathSelectors &selectors() const {
+    return access_path_selectors_;
+  }
 
  private:
   AccessPathRoot root_;

--- a/src/ir/access_path_root.h
+++ b/src/ir/access_path_root.h
@@ -65,6 +65,11 @@ class HandleConnectionSpecAccessPathRoot {
     return handle_connection_spec_name_;
   }
 
+  bool operator==(const HandleConnectionSpecAccessPathRoot &other) const {
+    return (particle_spec_name_ == other.particle_spec_name_) &&
+      (handle_connection_spec_name_ == other.handle_connection_spec_name_);
+  }
+
  private:
   std::string particle_spec_name_;
   std::string handle_connection_spec_name_;
@@ -92,6 +97,12 @@ class HandleConnectionAccessPathRoot {
   // A ConcreteAccessPathRoot is instantiated.
   bool IsInstantiated() const {
     return true;
+  }
+
+  bool operator==(const HandleConnectionAccessPathRoot &other) const {
+    return (recipe_name_ == other.recipe_name_) &&
+      (particle_name_ == other.particle_name_) &&
+      (handle_name_ == other.handle_name_);
   }
 
  private:
@@ -124,6 +135,10 @@ class AccessPathRoot {
      return absl::visit(
         [](const auto &variant){ return variant.IsInstantiated(); },
         specific_root_);
+  }
+
+  bool operator==(const AccessPathRoot &other) const {
+    return specific_root_ == other.specific_root_;
   }
 
  private:

--- a/src/ir/access_path_root_test.cc
+++ b/src/ir/access_path_root_test.cc
@@ -68,4 +68,72 @@ INSTANTIATE_TEST_SUITE_P(
     ConnectionSpecRootProtoTest, ConnectionSpecRootProtoTest,
     testing::ValuesIn(textproto_particle_spec_and_handle_connections));
 
+enum AccessPathRootKind {
+  kHandleConnectionSpec,
+  kHandleConnection
+};
+
+// An AccessPathRoot, an enum indicating which AccessPathRoot was
+// constructed, and a vector of strings used to construct the root. The roots
+// should be equal exactly when the enum and arg vectors are equal.
+struct AccessPathRootTypeAndArgs {
+  AccessPathRoot root;
+  AccessPathRootKind kind;
+  std::vector<std::string> arg_strings;
+};
+
+class AccessPathRootEqTest :
+ public testing::TestWithParam<
+  std::tuple<AccessPathRootTypeAndArgs, AccessPathRootTypeAndArgs>> {};
+
+TEST_P(AccessPathRootEqTest, AccessPathRootEqTest) {
+  const AccessPathRootTypeAndArgs &info1 = std::get<0>(GetParam());
+  const AccessPathRootTypeAndArgs &info2 = std::get<1>(GetParam());
+
+  bool kinds_equal = info1.kind == info2.kind;
+  bool args_equal = info1.arg_strings == info2.arg_strings;
+
+  ASSERT_EQ(info1.root == info2.root, kinds_equal && args_equal);
+}
+
+static AccessPathRootTypeAndArgs root_and_info_array[] = {
+    { .root = AccessPathRoot(HandleConnectionSpecAccessPathRoot(
+          "particle_spec1", "handle_connection")),
+      .kind = kHandleConnectionSpec,
+      .arg_strings = {"particle_spec1", "handle_connection"} },
+    { .root = AccessPathRoot(HandleConnectionSpecAccessPathRoot(
+          "particle_spec1", "handle_connection2")),
+      .kind = kHandleConnectionSpec,
+      .arg_strings = {"particle_spec1", "handle_connection2"} },
+    { .root = AccessPathRoot(HandleConnectionSpecAccessPathRoot(
+          "particle_spec2", "handle_connection")),
+      .kind = kHandleConnectionSpec,
+      .arg_strings = {"particle_spec2", "handle_connection"} },
+    { .root = AccessPathRoot(HandleConnectionSpecAccessPathRoot(
+          "handle_connection", "particle_spec1")),
+      .kind = kHandleConnectionSpec,
+      .arg_strings = {"handle_connection", "particle_spec1"} },
+    { .root = AccessPathRoot(HandleConnectionAccessPathRoot(
+        "recipe", "particle", "handle")),
+      .kind = kHandleConnection,
+      .arg_strings = {"recipe", "particle", "handle"}  },
+    { .root = AccessPathRoot(HandleConnectionAccessPathRoot(
+        "recipe2", "particle", "handle")),
+      .kind = kHandleConnection,
+      .arg_strings = {"recipe2", "particle", "handle"}  },
+    { .root = AccessPathRoot(HandleConnectionAccessPathRoot(
+        "recipe", "particle2", "handle")),
+      .kind = kHandleConnection,
+      .arg_strings = {"recipe", "particle2", "handle"}  },
+    { .root = AccessPathRoot(HandleConnectionAccessPathRoot(
+        "recipe", "particle", "handle2")),
+      .kind = kHandleConnection,
+      .arg_strings = {"recipe", "particle", "handle2"}  },
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessPathRootEqTest, AccessPathRootEqTest,
+    testing::Combine(testing::ValuesIn(root_and_info_array),
+                     testing::ValuesIn(root_and_info_array)));
+
 }  // namespace raksha::ir

--- a/src/ir/types/BUILD
+++ b/src/ir/types/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//src:__subpackages__"])
+
 cc_library(
     name = "types",
     srcs = glob(

--- a/src/xform_to_datalog/arcs_manifest_tree/BUILD
+++ b/src/xform_to_datalog/arcs_manifest_tree/BUILD
@@ -10,6 +10,7 @@ cc_library(
     deps = [
         "//src/common/logging",
         "//src/ir",
+        "//src/ir/types",
         "//third_party/arcs/proto:manifest_cc_proto",
         "@absl//absl/container:flat_hash_map",
     ],

--- a/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.cc
@@ -2,9 +2,11 @@
 
 namespace raksha::xform_to_datalog::arcs_manifest_tree {
 
+namespace types = raksha::ir::types;
+
 HandleConnectionSpec HandleConnectionSpec::CreateFromProto(
     const arcs::HandleConnectionSpecProto &handle_connection_spec_proto) {
-  const std::string &name = handle_connection_spec_proto.name();
+  std::string name = handle_connection_spec_proto.name();
   CHECK(!name.empty()) << "Found connection spec without required name.";
   bool reads = false;
   bool writes = false;
@@ -26,7 +28,11 @@ HandleConnectionSpec HandleConnectionSpec::CreateFromProto(
       LOG(FATAL)
         << "Unimplemented direction in connection spec " << name << ".";
   }
-  return HandleConnectionSpec(name, reads, writes);
+  CHECK(handle_connection_spec_proto.has_type())
+    << "Found connection spec " << name << " without required type.";
+  std::unique_ptr<types::Type> type =
+      types::Type::CreateFromProto(handle_connection_spec_proto.type());
+  return HandleConnectionSpec(std::move(name), reads, writes, std::move(type));
 }
 
 }  // namespace raksha::xform_to_datalog::arcs_manifest_tree

--- a/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.h
+++ b/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec.h
@@ -4,14 +4,14 @@
 #include <string>
 
 #include "src/common/logging/logging.h"
+#include "src/ir/access_path.h"
+#include "src/ir/types/type.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::xform_to_datalog::arcs_manifest_tree {
 
 // A class used to gather information about HandleConnectionSpecs from the
-// equivalent ArcsManifestProtos. Currently, the only thing we care about
-// from these is the name of the handle connection and whether it reads
-// and/or writes the handle to which it is connected.
+// equivalent ArcsManifestProtos.
 class HandleConnectionSpec {
  public:
   // Factory creating a HandleConnectionSpec from an arcs
@@ -19,11 +19,13 @@ class HandleConnectionSpec {
   static HandleConnectionSpec CreateFromProto(
       const arcs::HandleConnectionSpecProto &handle_connection_spec_proto);
 
-  const std::string &name() const {   return name_;  }
+  const std::string &name() const { return name_; }
 
-  bool reads() const {   return reads_;  }
+  bool reads() const { return reads_; }
 
-  bool writes() const {  return writes_;  }
+  bool writes() const { return writes_; }
+
+  const raksha::ir::types::Type &type() const { return *type_; }
 
   // Make an arcs HandleConnectionSpecProto from this object.
   arcs::HandleConnectionSpecProto MakeProto() const {
@@ -34,18 +36,45 @@ class HandleConnectionSpec {
         : (reads_) ? arcs::HandleConnectionSpecProto_Direction_READS
                    : arcs::HandleConnectionSpecProto_Direction_WRITES);
     result.set_name(name_);
+    *result.mutable_type() = type_->MakeProto();
     return result;
+  }
+
+  // Get all of the AccessPaths rooted at the associated ParticleSpec
+  // (indicated through the provided name) through leaf fields of type_.
+  std::vector<raksha::ir::AccessPath> GetAccessPaths(
+      std::string particle_spec_name) const {
+    namespace ir = raksha::ir;
+    std::vector<ir::AccessPath> result_paths;
+    ir::AccessPathSelectorsSet selectors_set =
+        type_->GetAccessPathSelectorsSet();
+    ir::AccessPathRoot root(
+        ir::HandleConnectionSpecAccessPathRoot(
+            std::move(particle_spec_name), name_));
+    for (ir::AccessPathSelectors selectors :
+         ir::AccessPathSelectorsSet::CreateAbslSet(selectors_set)) {
+      result_paths.push_back(ir::AccessPath(root, std::move(selectors)));
+    }
+    return result_paths;
   }
 
  private:
   HandleConnectionSpec(
-    const std::string name,
-    const bool reads,
-    const bool writes) : name_(name), reads_(reads), writes_(writes) {}
+    std::string name, bool reads, bool writes,
+    std::unique_ptr<raksha::ir::types::Type> type)
+    : name_(std::move(name)), reads_(reads), writes_(writes),
+      type_(std::move(type)) {}
 
+  // The name of this HandleConnectionSpec.
   std::string name_;
+  // Indicates whether the associated ParticleSpec reads this
+  // HandleConnectionSpec.
   bool reads_;
+  // Indicates whether the associated ParticleSpec writes this
+  // HandleConnectionSpec.
   bool writes_;
+  // The type of this HandleConnectionSpec.
+  std::unique_ptr<raksha::ir::types::Type> type_;
 };
 
 }  // namespace raksha::xform_to_datalog::arcs_manifest_tree

--- a/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec_test.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec_test.cc
@@ -38,18 +38,105 @@ TEST_P(RoundTripHandleConnectionSpecProtoTest,
           original_proto, result_proto));
 }
 
+// Note: each of these protos has a type field that is just a TEXT primitive.
+// Parsing the type correctly isn't the interesting part of parsing a
+// HandleConnectionSpec; that is tested elsewhere. The type field is required
+// and we are checking that it can be made back into an identical proto, so
+// that suffices for this test.
 static const ProtoStringAndExpectations string_and_expections_array[] = {
-    { .proto_str = "name: \"foo\" direction: READS", .expected_name = "foo",
-      .expected_reads = true, .expected_writes = false},
-    { .proto_str = "name: \"bar\" direction: WRITES", .expected_name = "bar",
-      .expected_reads = false, .expected_writes = true },
-    { .proto_str = "name: \"baz\" direction: READS_WRITES", .expected_name =
-    "baz", .expected_reads = true, .expected_writes = true}
+    { .proto_str = "name: \"foo\" direction: READS type: { primitive: TEXT }",
+      .expected_name = "foo", .expected_reads = true, .expected_writes = false},
+    { .proto_str = "name: \"bar\" direction: WRITES type: { primitive: TEXT }",
+      .expected_name = "bar", .expected_reads = false,
+      .expected_writes = true },
+    { .proto_str =
+        "name: \"baz\" direction: READS_WRITES type: { primitive: TEXT }",
+      .expected_name = "baz", .expected_reads = true, .expected_writes = true}
 };
 
 INSTANTIATE_TEST_SUITE_P(
     RoundTripHandleConnectionSpecProtoTest,
     RoundTripHandleConnectionSpecProtoTest,
     testing::ValuesIn(string_and_expections_array));
+
+struct ProtoStringAndExpectedAccessPathPieces {
+  std::string textproto;
+  std::string handle_connection_name;
+  std::vector<std::string> access_path_selectors_tostrings;
+};
+
+class GetAccessPathTest :
+ public testing::TestWithParam<
+  std::tuple<ProtoStringAndExpectedAccessPathPieces, std::string>> {};
+
+TEST_P(GetAccessPathTest, GetAccessPathTest) {
+  const ProtoStringAndExpectedAccessPathPieces &param = std::get<0>(GetParam());
+  const std::string &particle_spec_name = std::get<1>(GetParam());
+  arcs::HandleConnectionSpecProto hcs_proto;
+  google::protobuf::TextFormat::ParseFromString(param.textproto, &hcs_proto);
+  HandleConnectionSpec handle_connection_spec =
+      HandleConnectionSpec::CreateFromProto(hcs_proto);
+  std::vector<ir::AccessPath> access_paths =
+      handle_connection_spec.GetAccessPaths(particle_spec_name);
+  std::vector<std::string> found_access_path_selector_strings;
+  for (const ir::AccessPath &access_path : access_paths) {
+    ir::AccessPathRoot root = access_path.root();
+    EXPECT_EQ(
+        root, ir::AccessPathRoot(ir::HandleConnectionSpecAccessPathRoot(
+            particle_spec_name, param.handle_connection_name)));
+    found_access_path_selector_strings.push_back(
+        access_path.selectors().ToString());
+  }
+  EXPECT_THAT(found_access_path_selector_strings,
+              testing::UnorderedElementsAreArray(
+                  param.access_path_selectors_tostrings));
+}
+
+// Just some different strings that could be used as particle specs.
+std::string sample_particle_spec_names[] = {
+    "ParticleSpec",
+    "PS",
+    "P1",
+    "P2"
+};
+
+ProtoStringAndExpectedAccessPathPieces protos_and_access_path_info[] = {
+    { .textproto = "name: \"handle_spec\" direction: READS "
+                   "type: { primitive: TEXT }",
+      .handle_connection_name = "handle_spec",
+      .access_path_selectors_tostrings = { "" } },
+    { .textproto =
+         "name: \"hs\" direction: READS_WRITES "
+         "type: { entity: { "
+         "      schema: { "
+         "        fields [ { key: \"field1\", value: { primitive: TEXT } } ]"
+         "     } } }",
+         .handle_connection_name = "hs",
+         .access_path_selectors_tostrings = { ".field1" }},
+    { .textproto =
+      "name: \"spechandle\" direction: WRITES "
+      "type {"
+      "entity: { "
+      "  schema: { "
+      "    fields: [ "
+      "      { key: \"field1\", value: { primitive: TEXT }},"
+      "      { key: \"x\", value: { "
+      "        entity: { schema: { names: [\"embedded\"], fields: ["
+      "          { key: \"sub_field1\", value: { primitive: TEXT } },"
+      "          { key: \"sub_field2\", value: { primitive: TEXT } }"
+      "       ]}}}},"
+      "      { key: \"hello\", value: { primitive: TEXT } }"
+      "    ]"
+      " } } }",
+      .handle_connection_name = "spechandle",
+      .access_path_selectors_tostrings = {
+        ".field1", ".x.sub_field1", ".x.sub_field2", ".hello"
+    } }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    GetAccessPathTest, GetAccessPathTest,
+    testing::Combine(testing::ValuesIn(protos_and_access_path_info),
+                     testing::ValuesIn(sample_particle_spec_names)));
 
 }  // namespace raksha::xform_to_datalog::arcs_manifest_tree


### PR DESCRIPTION
This PR adds type information to HandleConnectionSpec, preserving the
information that was already in the manifest.proto. Initially, I thought
I wouldn't need this because my quick-and-dirty partial implementation
of the proto transformer looked like it did not need it. However, that
was more top-down than the cleaner approach has ended up being, and the
type information was necessary for building the ParticleSpec.

This PR also adds a method GetAccessPaths to HandleConnectionSpec, which
returns a vector containing all of the full AccessPaths that can be
accessed through the HandleConnectionSpec and end in a leaf field of the
type on HandleConnectionSpec. This is useful for building the edges
within a ParticleSpec.

This PR also adds operator== to the AccessPathRoots and some additional
field accessors to AccessPath. operator== on roots will eventually
become important for instantiating particle specs and was useful for
testing HandleConnectionSpec's new methods, so