### PR TITLE
Remove newline at end of fact Datalog strings.

### DIFF
--- a/src/ir/edge.h
+++ b/src/ir/edge.h
@@ -2,7 +2,7 @@
 #define SRC_IR_EDGE_H_
 
 #include "src/ir/access_path.h"
-#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 
 namespace raksha::ir {
 
@@ -16,8 +16,8 @@ class Edge {
 
   // Print the edge as a string containing a Datalog fact.
   std::string ToString() const {
-    return absl::StrCat(
-        "edge(\"", from_.ToString(), "\", \"", to_.ToString(), "\").\n");
+    constexpr absl::string_view kEdgeFormat = R"(edge("%s", "%s").)";
+    return absl::StrFormat(kEdgeFormat, from_.ToString(), to_.ToString());
   }
 
   bool operator==(const Edge &other) const {

--- a/src/ir/edge_test.cc
+++ b/src/ir/edge_test.cc
@@ -20,7 +20,7 @@ static const std::tuple<Edge, std::string> edge_tostring_pairs[] = {
                 "recipe2", "particle2", "handle2")),
             AccessPathSelectors(Selector(FieldSelector("field2"))))),
         "edge(\"recipe.particle.handle.field1\", "
-        "\"recipe2.particle2.handle2.field2\").\n"},
+        "\"recipe2.particle2.handle2.field2\")."},
     { Edge(
             AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
                 "r", "p", "h")),
@@ -28,7 +28,7 @@ static const std::tuple<Edge, std::string> edge_tostring_pairs[] = {
             AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
                 "r", "p", "h2")),
                        x_y_access_path_selectors)),
-      "edge(\"r.p.h.x.y\", \"r.p.h2.x.y\").\n" },
+      "edge(\"r.p.h.x.y\", \"r.p.h2.x.y\")." },
     { Edge(
           AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
               "pre", "fix", "1")),
@@ -36,7 +36,7 @@ static const std::tuple<Edge, std::string> edge_tostring_pairs[] = {
           AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
               "pre", "fix", "2")),
                      AccessPathSelectors())),
-      "edge(\"pre.fix.1\", \"pre.fix.2\").\n"} };
+      "edge(\"pre.fix.1\", \"pre.fix.2\")."} };
 
 class EdgeToStringTest :
     public testing::TestWithParam<std::tuple<Edge, std::string>> {};

--- a/src/ir/tag_check.h
+++ b/src/ir/tag_check.h
@@ -1,6 +1,7 @@
 #ifndef SRC_IR_TAG_CHECK_H_
 #define SRC_IR_TAG_CHECK_H_
 
+#include "absl/strings/str_format.h"
 #include "src/ir/tag_annotation_on_access_path.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
@@ -38,12 +39,12 @@ class TagCheck {
   // will eventually want, but is enough to get some simple Arcs tests
   // passing for the MVP.
   std::string ToString() const {
-    return absl::StrCat(
-        "checkHasTag(\"",
+    constexpr absl::string_view kCheckHasTagFormat =
+        R"(checkHasTag("%s", "%s").)";
+    return absl::StrFormat(
+        kCheckHasTagFormat,
         tag_annotation_on_access_path_.access_path().ToString(),
-        "\", \"",
-        tag_annotation_on_access_path_.tag(),
-        "\").\n");
+        tag_annotation_on_access_path_.tag());
   }
 
   bool operator==(const TagCheck &other) const {

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -61,17 +61,17 @@ static std::tuple<std::string, absl::ParsedFormat<'s'>>
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" } "
       "selectors: { field: \"field1\" } }, "
       "predicate: { label: { semantic_tag: \"tag\"} }",
-      absl::ParsedFormat<'s'>("checkHasTag(\"%s.field1\", \"tag\").\n") },
+      absl::ParsedFormat<'s'>("checkHasTag(\"%s.field1\", \"tag\").") },
     { "access_path: {"
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" } }, "
       "predicate: { label: { semantic_tag: \"tag2\"} }",
-      absl::ParsedFormat<'s'>("checkHasTag(\"%s\", \"tag2\").\n") },
+      absl::ParsedFormat<'s'>("checkHasTag(\"%s\", \"tag2\").") },
     { "access_path: { "
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" }, "
       "selectors: [{ field: \"x\" }, { field: \"y\" }] }, "
       "predicate: { label: { semantic_tag: \"user_selection\"} }",
       absl::ParsedFormat<'s'>(
-          "checkHasTag(\"%s.x.y\", \"user_selection\")" ".\n") }
+          "checkHasTag(\"%s.x.y\", \"user_selection\")" ".") }
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/ir/tag_claim.h
+++ b/src/ir/tag_claim.h
@@ -1,7 +1,7 @@
 #ifndef SRC_IR_TAG_CLAIM_H_
 #define SRC_IR_TAG_CLAIM_H_
 
-#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "src/common/logging/logging.h"
 #include "src/ir/access_path.h"
 #include "src/ir/tag_annotation_on_access_path.h"
@@ -44,10 +44,12 @@ class TagClaim {
 
   // Produce a string containing a datalog fact for this TagClaim.
   std::string ToString() const {
-    return absl::StrCat(
-        "claimHasTag(\"",
+    constexpr absl::string_view kClaimHasTagFormat =
+        R"(claimHasTag("%s", "%s").)";
+    return absl::StrFormat(
+        kClaimHasTagFormat,
         tag_annotation_on_access_path_.access_path().ToString(),
-        "\", \"", tag_annotation_on_access_path_.tag(), "\").\n");
+        tag_annotation_on_access_path_.tag());
   }
 
   bool operator==(const TagClaim &other) const {

--- a/src/ir/tag_claim_test.cc
+++ b/src/ir/tag_claim_test.cc
@@ -63,17 +63,17 @@ static std::tuple<std::string, absl::ParsedFormat<'s'>>
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" } "
       "selectors: { field: \"field1\" } }, "
       "predicate: { label: { semantic_tag: \"tag\"} }",
-      absl::ParsedFormat<'s'>("claimHasTag(\"%s.field1\", \"tag\").\n") },
+      absl::ParsedFormat<'s'>("claimHasTag(\"%s.field1\", \"tag\").") },
     { "access_path: {"
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" } }, "
       "predicate: { label: { semantic_tag: \"tag2\"} }",
-      absl::ParsedFormat<'s'>("claimHasTag(\"%s\", \"tag2\").\n") },
+      absl::ParsedFormat<'s'>("claimHasTag(\"%s\", \"tag2\").") },
     { "access_path: { "
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" }, "
       "selectors: [{ field: \"x\" }, { field: \"y\" }] }, "
       "predicate: { label: { semantic_tag: \"user_selection\"} }",
       absl::ParsedFormat<'s'>(
-          "claimHasTag(\"%s.x.y\", \"user_selection\")" ".\n") }
+          "claimHasTag(\"%s.x.y\", \"user_selection\")" ".") }
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/xform_to_datalog/datalog_facts.h
+++ b/src/xform_to_datalog/datalog_facts.h
@@ -45,12 +45,11 @@ class DatalogFacts {
   std::string ToString() const {
     auto tostring_formatter = [](std::string *out, const auto &arg) {
       out->append(arg.ToString()); };
-
     return absl::StrFormat(
         kFactOutputFormat,
-        absl::StrJoin(claims_, "", tostring_formatter),
-        absl::StrJoin(checks_, "", tostring_formatter),
-        absl::StrJoin(edges_, "", tostring_formatter));
+        absl::StrJoin(claims_, "\n", tostring_formatter),
+        absl::StrJoin(checks_, "\n", tostring_formatter),
+        absl::StrJoin(edges_, "\n", tostring_formatter));
   }
 
   const std::vector<raksha::ir::TagClaim> &claims() const { return claims_; }
@@ -60,13 +59,16 @@ class DatalogFacts {
   const std::vector<raksha::ir::Edge> &edges() const { return edges_; }
 
  private:
-  static constexpr absl::string_view kFactOutputFormat = R"FORMAT(
+  static constexpr absl::string_view kFactOutputFormat = R"(
 // Claims:
 %s
+
 // Checks:
 %s
+
 // Edges:
-%s)FORMAT";
+%s
+)";
 
   std::vector<raksha::ir::TagClaim> claims_;
   std::vector<raksha::ir::TagCheck> checks_;

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -58,9 +58,12 @@ static std::tuple<DatalogFacts, std::string>
       R"(
 // Claims:
 
+
 // Checks:
 
+
 // Edges:
+
 )" },
     { DatalogFacts(
         { ir::TagClaim(ir::TagAnnotationOnAccessPath(
@@ -71,7 +74,7 @@ static std::tuple<DatalogFacts, std::string>
           ir::Edge(kHandleConnectionInAccessPath,
                    kHandleConnectionOutAccessPath),
            ir::Edge(kHandleConnectionOutAccessPath, kHandleH2AccessPath)}),
-      R"EXPECTED(
+      R"(
 // Claims:
 claimHasTag("recipe.particle.out", "tag").
 
@@ -82,7 +85,7 @@ checkHasTag("recipe.particle.in", "tag2").
 edge("recipe.h1", "recipe.particle.in").
 edge("recipe.particle.in", "recipe.particle.out").
 edge("recipe.particle.out", "recipe.h2").
-)EXPECTED"
+)"
     }
 };
 
@@ -271,18 +274,12 @@ class ParseBigManifestTest : public testing::Test {
 };
 
 static const std::string kExpectedClaimStrings[] = {
-    R"(claimHasTag("NamedR.PS1#0.out_handle.field1", "tag1").
-)",
-    R"(claimHasTag("NamedR.PS1#1.out_handle.field1", "tag1").
-)",
-    R"(claimHasTag("NamedR.PS2#2.out_handle.field1", "tag3").
-)",
-    R"(claimHasTag("GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "tag1").
-)",
-    R"(claimHasTag("GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "tag3").
-)",
-    R"(claimHasTag("GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "tag3").
-)",
+    R"(claimHasTag("NamedR.PS1#0.out_handle.field1", "tag1").)",
+    R"(claimHasTag("NamedR.PS1#1.out_handle.field1", "tag1").)",
+    R"(claimHasTag("NamedR.PS2#2.out_handle.field1", "tag3").)",
+    R"(claimHasTag("GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "tag1").)",
+    R"(claimHasTag("GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "tag3").)",
+    R"(claimHasTag("GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "tag3").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
@@ -298,18 +295,12 @@ TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
 }
 
 static std::string kExpectedCheckStrings[] = {
-    R"(checkHasTag("NamedR.PS1#0.in_handle.field1", "tag2").
-)",
-    R"(checkHasTag("NamedR.PS1#1.in_handle.field1", "tag2").
-)",
-    R"(checkHasTag("NamedR.PS2#2.in_handle.field1", "tag4").
-)",
-    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "tag2").
-)",
-    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "tag4").
-)",
-    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "tag4").
-)",
+    R"(checkHasTag("NamedR.PS1#0.in_handle.field1", "tag2").)",
+    R"(checkHasTag("NamedR.PS1#1.in_handle.field1", "tag2").)",
+    R"(checkHasTag("NamedR.PS2#2.in_handle.field1", "tag4").)",
+    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "tag2").)",
+    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "tag4").)",
+    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "tag4").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {
@@ -327,79 +318,59 @@ TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {
 static const std::string kExpectedEdgeStrings[] = {
     // Named recipe edges:
     // Edges connecting h1 to NamedR.PS1#0 for fields {field1, field2}.
-    R"(edge("NamedR.h1.field1", "NamedR.PS1#0.in_handle.field1").
-)",
-    R"(edge("NamedR.h1.field2", "NamedR.PS1#0.in_handle.field2").
-)",
+    R"(edge("NamedR.h1.field1", "NamedR.PS1#0.in_handle.field1").)",
+    R"(edge("NamedR.h1.field2", "NamedR.PS1#0.in_handle.field2").)",
 
     // Edges connecting h2 to NamedR.PS1#0 for field1
-     R"(edge("NamedR.PS1#0.out_handle.field1", "NamedR.h2.field1").
-)",
+     R"(edge("NamedR.PS1#0.out_handle.field1", "NamedR.h2.field1").)",
 
     // Intra-particle connection
-    R"(edge("NamedR.PS1#0.in_handle.field1", "NamedR.PS1#0.out_handle.field1").
-)",
+    R"(edge("NamedR.PS1#0.in_handle.field1", "NamedR.PS1#0.out_handle.field1").)",
 
     // Edges connecting h2 to NamedR.PS1#1 for field1.
-    R"(edge("NamedR.h2.field1", "NamedR.PS1#1.in_handle.field1").
-)",
+    R"(edge("NamedR.h2.field1", "NamedR.PS1#1.in_handle.field1").)",
 
     // Edges connecting h3 to NamedR.PS1#1 for field1
-    R"(edge("NamedR.PS1#1.out_handle.field1", "NamedR.h3.field1").
-)",
+    R"(edge("NamedR.PS1#1.out_handle.field1", "NamedR.h3.field1").)",
 
     // Intra-particle connection
-    R"(edge("NamedR.PS1#1.in_handle.field1", "NamedR.PS1#1.out_handle.field1").
-)",
+    R"(edge("NamedR.PS1#1.in_handle.field1", "NamedR.PS1#1.out_handle.field1").)",
 
     // Edges connecting h3 to NamedR.PS2#2 for field1
-    R"(edge("NamedR.h3.field1", "NamedR.PS2#2.in_handle.field1").
-)",
+    R"(edge("NamedR.h3.field1", "NamedR.PS2#2.in_handle.field1").)",
 
     // Edges connecting h4 to NamedR.Ps2#2 for field1
-    R"(edge("NamedR.PS2#2.out_handle.field1", "NamedR.h4.field1").
-)",
+    R"(edge("NamedR.PS2#2.out_handle.field1", "NamedR.h4.field1").)",
 
     // Intra-particle connection
-
-    R"(edge("NamedR.PS2#2.in_handle.field1", "NamedR.PS2#2.out_handle.field1").
-)",
+    R"(edge("NamedR.PS2#2.in_handle.field1", "NamedR.PS2#2.out_handle.field1").)",
 
     // Unnamed recipe edges:
-    R"(edge("GENERATED_RECIPE_NAME0.h1.field1", "GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1").
-)",
+    R"(edge("GENERATED_RECIPE_NAME0.h1.field1", "GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1").)",
 
     // Edges connecting h2 to NamedR.PS1#0 for field1
-    R"(edge("GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "GENERATED_RECIPE_NAME0.h2.field1").
-)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "GENERATED_RECIPE_NAME0.h2.field1").)",
 
     // Intra-particle connection
-    R"(edge("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1").
-)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1").)",
 
     // Edges connecting h2 to NamedR.PS2#1 for field1.
-    R"(edge("GENERATED_RECIPE_NAME0.h2.field1", "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1").
-)",
+    R"(edge("GENERATED_RECIPE_NAME0.h2.field1", "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1").)",
 
     // Edges connecting h3 to NamedR.PS2#1 for field1
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "GENERATED_RECIPE_NAME0.h3.field1").
-)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "GENERATED_RECIPE_NAME0.h3.field1").)",
 
     // Intra-particle connection
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1").
-)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1").)",
 
     // Edges connecting h3 to NamedR.PS2#2 for field1
-    R"(edge("GENERATED_RECIPE_NAME0.h3.field1", "GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1").
-)",
+    R"(edge("GENERATED_RECIPE_NAME0.h3.field1", "GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1").)",
 
     // Edges connecting h4 to NamedR.PS2#2 for field1
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "GENERATED_RECIPE_NAME0.h4.field1").
-)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "GENERATED_RECIPE_NAME0.h4.field1").)",
 
     // Intra-particle connection
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1").
-)"
+    R"(edge("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1").)"
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoEdgesTest) {


### PR DESCRIPTION
The initial ToString functions for classes representing Datalog facts
added trailing newlines for those facts. This was a mistake, as this
made the expected outputs in tests testing these functions much uglier.
This PR fixes this issue by moving the newlines to the delimiter in the
StrJoin function combining the datalog facts instead. This PR
fixes #110.