### PR TITLE
Add new DerivesFromClaim, alter edge drawing in ParticleSpec to use it.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -76,6 +76,7 @@ cc_test(
     deps = [
         ":ir",
         "//src/common/testing:gtest",
+        "@absl//absl/hash:hash_testing",
     ],
 )
 
@@ -117,5 +118,16 @@ cc_test(
         ":ir",
         "//src/common/testing:gtest",
         "@absl//absl/hash:hash_testing",
+    ],
+)
+
+cc_test(
+    name = "derives_from_claim_test",
+    srcs = ["derives_from_claim_test.cc"],
+    deps = [
+        ":ir",
+        "//src/common/testing:gtest",
+        "@absl//absl/strings",
+        "@absl//absl/strings:str_format",
     ],
 )

--- a/src/ir/access_path.h
+++ b/src/ir/access_path.h
@@ -85,6 +85,12 @@ class AccessPath {
       (access_path_selectors_ == other.access_path_selectors_);
   }
 
+  template<typename H>
+  friend H AbslHashValue(H h, const AccessPath &access_path) {
+    return H::combine(
+        std::move(h), access_path.root_, access_path.access_path_selectors_);
+  }
+
  private:
   AccessPathRoot root_;
   AccessPathSelectors access_path_selectors_;

--- a/src/ir/access_path_test.cc
+++ b/src/ir/access_path_test.cc
@@ -2,6 +2,7 @@
 
 #include <google/protobuf/text_format.h>
 
+#include "absl/hash/hash_testing.h"
 #include "src/common/testing/gtest.h"
 
 namespace raksha::ir {
@@ -131,6 +132,7 @@ static AccessPathRoot sample_roots[] = {
         "spec1", "handle_spec1")),
     ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
         "recipe", "particle", "handle")),
+    ir::AccessPathRoot(ir::HandleAccessPathRoot("recipe", "handle"))
 };
 
 static AccessPathSelectors sample_selectors[] = {
@@ -150,5 +152,16 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Combine(
             testing::ValuesIn(sample_roots),
             testing::ValuesIn(sample_selectors))));
+
+TEST(AccessPathHashTest, AccessPathHashTest) {
+  std::vector<AccessPath> test_access_paths;
+  for (const AccessPathRoot &access_path_root : sample_roots) {
+    for (const AccessPathSelectors &access_path_selectors : sample_selectors) {
+      test_access_paths.push_back(
+          AccessPath(access_path_root, access_path_selectors));
+    }
+  }
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(test_access_paths));
+}
 
 }  // namespace raksha::ir

--- a/src/ir/derives_from_claim.h
+++ b/src/ir/derives_from_claim.h
@@ -1,0 +1,68 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#ifndef SRC_IR_DERIVES_FROM_CLAIM_H_
+#define SRC_IR_DERIVES_FROM_CLAIM_H_
+
+#include "src/ir/access_path.h"
+#include "src/ir/edge.h"
+#include "third_party/arcs/proto/manifest.pb.h"
+
+namespace raksha::ir {
+
+// A claim that a particular target_ AccessPath in a particular derives from the
+// given source_. Multiple DerivesFrom can indicate the same target_, which
+// shall indicate that that target derives only from the source_s given by
+// the DerivesFromClaims. DerivesFrom claims exclude a particular target
+// access path from the default edge-drawing behavior within a Particle, in
+// which all inputs are connected to all outputs.
+class DerivesFromClaim {
+ public:
+  static DerivesFromClaim CreateFromProto(
+      const arcs::ClaimProto_DerivesFrom &derives_from_proto) {
+    CHECK(derives_from_proto.has_source())
+      << "DerivesFrom proto does not have required field source.";
+    CHECK(derives_from_proto.has_target())
+      << "DerivesFrom proto does not have required field target.";
+    return DerivesFromClaim(
+        AccessPath::CreateFromProto(derives_from_proto.target()),
+        AccessPath::CreateFromProto(derives_from_proto.source()));
+  }
+
+  explicit DerivesFromClaim(AccessPath target, AccessPath source)
+    : target_(target), source_(source) {}
+
+  const AccessPath &target() const { return target_; }
+
+  const AccessPath &source() const { return source_; }
+
+  // Internally, a DerivesFromClaim is basically just an explicitly-indicated
+  // edge from one AccessPath to another. The GetAsEdge method returns the
+  // Edge indicated by the DerivesFrom claim.
+  Edge GetAsEdge() const {
+    return Edge(source_, target_);
+  }
+
+ private:
+  // The target_ AccessPath is the AccessPath that explicitly derives from
+  // source_.
+  AccessPath target_;
+  AccessPath source_;
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_DERIVES_FROM_CLAIM_H_

--- a/src/ir/derives_from_claim_test.cc
+++ b/src/ir/derives_from_claim_test.cc
@@ -1,0 +1,99 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#include "src/ir/derives_from_claim.h"
+
+#include <google/protobuf/text_format.h>
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "src/common/testing/gtest.h"
+
+namespace raksha::ir {
+
+// A DerivesFrom class is very simple structurally: it is just two
+// AccessPaths smashed together. We take advantage of that to produce
+// DerivesFrom textproto from pairs of AccessPath textprotos. We then use the
+// pair to generate our observed output and the original AccessPath  textprotos
+// to generate our expected output(s).
+constexpr absl::string_view kDerivesFromTextprotoFormat =
+    R"(target: {%s} source: {%s})";
+
+static const std::string kSampleAccessPathTextprotos[] = {
+    R"(
+handle: { particle_spec: "ps", handle_connection: "hc" }
+selectors: { field: "field1" })",
+    R"(
+handle: { particle_spec: "particle_spec", handle_connection: "handle_conn" }
+selectors: [{ field: "x" }, { field: "y" }])",
+    R"(handle: { particle_spec: "s", handle_connection: "h" })",
+};
+
+class DerivesFromAsAccessPathPairTest :
+    public ::testing::TestWithParam<std::tuple<std::string, std::string>> {
+ public:
+  DerivesFromAsAccessPathPairTest()
+    : derives_from_claim_(CreateDerivesFromFromParams()),
+      expected_target_(CreateAccessPathFromParam<0>()),
+      expected_source_(CreateAccessPathFromParam<1>()) {}
+
+ protected:
+  DerivesFromClaim CreateDerivesFromFromParams() const {
+      arcs::ClaimProto_DerivesFrom derives_from_proto;
+      const std::string &textproto =
+          absl::StrFormat(
+                kDerivesFromTextprotoFormat,
+                std::get<0>(GetParam()),
+                std::get<1>(GetParam()));
+      google::protobuf::TextFormat::ParseFromString(
+          textproto, &derives_from_proto);
+      return DerivesFromClaim::CreateFromProto(derives_from_proto);
+  }
+
+  template<int ParamNum>
+  AccessPath CreateAccessPathFromParam() const {
+    arcs::AccessPathProto access_path_proto;
+    const std::string &textproto = std::get<ParamNum>(GetParam());
+    google::protobuf::TextFormat::ParseFromString(
+        textproto, &access_path_proto);
+    return AccessPath::CreateFromProto(access_path_proto);
+  }
+
+  DerivesFromClaim derives_from_claim_;
+  AccessPath expected_target_;
+  AccessPath expected_source_;
+};
+
+TEST_P(DerivesFromAsAccessPathPairTest, TargetTest) {
+  EXPECT_EQ(derives_from_claim_.target(), expected_target_);
+}
+
+TEST_P(DerivesFromAsAccessPathPairTest, SourceTest) {
+  EXPECT_EQ(derives_from_claim_.source(), expected_source_);
+}
+
+TEST_P(DerivesFromAsAccessPathPairTest, EdgeTest) {
+  EXPECT_EQ(
+      derives_from_claim_.GetAsEdge(),
+      Edge(expected_source_, expected_target_));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DerivesFromAsAccessPathPairTest, DerivesFromAsAccessPathPairTest,
+    testing::Combine(testing::ValuesIn(kSampleAccessPathTextprotos),
+                     testing::ValuesIn(kSampleAccessPathTextprotos)));
+
+}  // namespace raksha::ir

--- a/src/xform_to_datalog/arcs_manifest_tree/particle_spec.h
+++ b/src/xform_to_datalog/arcs_manifest_tree/particle_spec.h
@@ -5,6 +5,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "src/common/logging/logging.h"
+#include "src/ir/derives_from_claim.h"
 #include "src/ir/edge.h"
 #include "src/ir/tag_check.h"
 #include "src/ir/tag_claim.h"
@@ -16,7 +17,7 @@ namespace raksha::xform_to_datalog::arcs_manifest_tree {
 // This struct is used to return the members of a ParticleSpec after being
 // instantiated.
 struct InstantiatedParticleSpecFacts {
-  std::vector<raksha::ir::TagClaim> claims;
+  std::vector<raksha::ir::TagClaim> tag_claims;
   std::vector<raksha::ir::TagCheck> checks;
   std::vector<raksha::ir::Edge> edges;
 };
@@ -37,7 +38,9 @@ class ParticleSpec {
 
   const std::vector<raksha::ir::TagCheck> &checks() const { return checks_; }
 
-  const std::vector<raksha::ir::TagClaim> &claims() const { return claims_; }
+  const std::vector<raksha::ir::TagClaim> &tag_claims() const {
+    return tag_claims_;
+  }
 
   const std::vector<raksha::ir::Edge> &edges() const { return edges_; }
 
@@ -57,8 +60,8 @@ class ParticleSpec {
     for (const raksha::ir::TagCheck &check : checks_) {
       result.checks.push_back(check.BulkInstantiate(instantiation_map));
     }
-    for (const raksha::ir::TagClaim &claim : claims_) {
-      result.claims.push_back(claim.BulkInstantiate(instantiation_map));
+    for (const raksha::ir::TagClaim &claim : tag_claims_) {
+      result.tag_claims.push_back(claim.BulkInstantiate(instantiation_map));
     }
     for (const raksha::ir::Edge &edge : edges_) {
       result.edges.push_back(edge.BulkInstantiate(instantiation_map));
@@ -70,10 +73,12 @@ class ParticleSpec {
   ParticleSpec(
       std::string name,
       std::vector<raksha::ir::TagCheck> checks,
-      std::vector<raksha::ir::TagClaim> claims,
+      std::vector<raksha::ir::TagClaim> tag_claims,
+      std::vector<raksha::ir::DerivesFromClaim> derives_from_claims,
       std::vector<HandleConnectionSpec> handle_connection_specs)
       : name_(std::move(name)), checks_(std::move(checks)),
-        claims_(std::move(claims)) {
+        tag_claims_(std::move(tag_claims)),
+        derives_from_claims_(std::move(derives_from_claims)) {
     for (HandleConnectionSpec &handle_connection_spec :
       handle_connection_specs) {
       std::string hcs_name = handle_connection_spec.name();
@@ -95,7 +100,10 @@ class ParticleSpec {
   std::vector<raksha::ir::TagCheck> checks_;
   // The claims this ParticleSpec performs upon its AccessPaths. All such
   // claims are made upon uninstantiated AccessPaths.
-  std::vector<raksha::ir::TagClaim> claims_;
+  std::vector<raksha::ir::TagClaim> tag_claims_;
+  // Claims that a particular AccessPath in this ParticleSpec derives from
+  // some other AccessPath.
+  std::vector<raksha::ir::DerivesFromClaim> derives_from_claims_;
   // The dataflow edges within this ParticleSpec connecting its
   // HandleConnectionSpecs. These edges are all between uninstantiated
   // AccessPaths.

--- a/src/xform_to_datalog/arcs_manifest_tree/particle_spec_test.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/particle_spec_test.cc
@@ -29,7 +29,7 @@ TEST_P(ParticleSpecFromProtoTest, ParticleSpecFromProtoTest) {
 
   EXPECT_EQ(particle_spec.name(), param.expected_name);
   EXPECT_THAT(
-      particle_spec.claims(),
+      particle_spec.tag_claims(),
       testing::UnorderedElementsAreArray(param.expected_claims));
   EXPECT_THAT(
       particle_spec.checks(),
@@ -112,6 +112,253 @@ name: "PS1" connections: [
               kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
           ir::AccessPath(
               kPs1OutHandleRoot, MakeSingleFieldSelectors("field3"))),
+    } },
+        { .textproto = R"(
+name: "PS1"
+connections: [
+  {
+    name: "out_handle" direction: WRITES
+    type: {
+      entity: {
+        schema: {
+          fields: [
+            { key: "field1", value: { primitive: TEXT } },
+            { key: "field2", value: { primitive: TEXT } },
+            { key: "field3", value: { primitive: TEXT } } ] } } } },
+  {
+    name: "in_handle" direction: READS
+    type: {
+      entity: {
+        schema: {
+          fields: [
+            { key: "field2", value: { primitive: TEXT } },
+            { key: "world", value: { primitive: TEXT } } ] } } } } ],
+claims: [
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field2" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "field2" } } } } ])",
+    .expected_name = "PS1", .expected_claims = { }, .expected_checks = { },
+    .expected_edges = {
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field1"))),
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field2"))),
+        ir::Edge(
+          ir::AccessPath(
+              kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+          ir::AccessPath(
+              kPs1OutHandleRoot, MakeSingleFieldSelectors("field3"))),
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field1"))),
+        ir::Edge(
+          ir::AccessPath(
+              kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
+          ir::AccessPath(
+              kPs1OutHandleRoot, MakeSingleFieldSelectors("field3"))),
+    } },
+    { .textproto = R"(
+name: "PS1"
+connections: [
+  {
+    name: "out_handle" direction: WRITES
+    type: {
+      entity: {
+        schema: {
+          fields: [
+            { key: "field1", value: { primitive: TEXT } },
+            { key: "field2", value: { primitive: TEXT } },
+            { key: "field3", value: { primitive: TEXT } } ] } } } },
+  {
+    name: "in_handle" direction: READS
+    type: {
+      entity: {
+        schema: {
+          fields: [
+            { key: "field2", value: { primitive: TEXT } },
+            { key: "world", value: { primitive: TEXT } } ] } } } } ],
+claims: [
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field2" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "field2" } } } },
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field1" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "world" } } } }
+ ])",
+    .expected_name = "PS1", .expected_claims = { }, .expected_checks = { },
+    .expected_edges = {
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field2"))),
+        ir::Edge(
+          ir::AccessPath(
+              kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+          ir::AccessPath(
+              kPs1OutHandleRoot, MakeSingleFieldSelectors("field3"))),
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field1"))),
+        ir::Edge(
+          ir::AccessPath(
+              kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
+          ir::AccessPath(
+              kPs1OutHandleRoot, MakeSingleFieldSelectors("field3"))),
+    } },
+    { .textproto = R"(
+name: "PS1"
+connections: [
+  {
+    name: "out_handle" direction: WRITES
+    type: {
+      entity: {
+        schema: {
+          fields: [
+            { key: "field1", value: { primitive: TEXT } },
+            { key: "field2", value: { primitive: TEXT } },
+            { key: "field3", value: { primitive: TEXT } } ] } } } },
+  {
+    name: "in_handle" direction: READS
+    type: {
+      entity: {
+        schema: {
+          fields: [
+            { key: "field2", value: { primitive: TEXT } },
+            { key: "world", value: { primitive: TEXT } } ] } } } } ],
+claims: [
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field2" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "field2" } } } },
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field2" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "world" } } } },
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field1" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "world" } } } }
+ ])",
+    .expected_name = "PS1", .expected_claims = { }, .expected_checks = { },
+    .expected_edges = {
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field2"))),
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field2"))),
+        ir::Edge(
+          ir::AccessPath(
+              kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+          ir::AccessPath(
+              kPs1OutHandleRoot, MakeSingleFieldSelectors("field3"))),
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field1"))),
+        ir::Edge(
+          ir::AccessPath(
+              kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
+          ir::AccessPath(
+              kPs1OutHandleRoot, MakeSingleFieldSelectors("field3"))),
+    } },
+    { .textproto = R"(
+name: "PS1"
+connections: [
+  {
+    name: "out_handle" direction: WRITES
+    type: {
+      entity: {
+        schema: {
+          fields: [
+            { key: "field1", value: { primitive: TEXT } },
+            { key: "field2", value: { primitive: TEXT } },
+            { key: "field3", value: { primitive: TEXT } } ] } } } },
+  {
+    name: "in_handle" direction: READS
+    type: {
+      entity: {
+        schema: {
+          fields: [
+            { key: "field2", value: { primitive: TEXT } },
+            { key: "world", value: { primitive: TEXT } } ] } } } } ],
+claims: [
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field2" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "field2" } } } },
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field1" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "world" } } } },
+  { derives_from: {
+      target: {
+        handle: { particle_spec: "PS1" handle_connection: "out_handle" }
+        selectors: { field: "field3" } }
+      source: {
+        handle: { particle_spec: "PS1" handle_connection: "in_handle" }
+        selectors: { field: "field2" } } } }
+ ])",
+    .expected_name = "PS1", .expected_claims = { }, .expected_checks = { },
+    .expected_edges = {
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field2"))),
+        ir::Edge(
+          ir::AccessPath(
+              kPs1InHandleRoot, MakeSingleFieldSelectors("field2")),
+          ir::AccessPath(
+              kPs1OutHandleRoot, MakeSingleFieldSelectors("field3"))),
+        ir::Edge(
+            ir::AccessPath(
+                kPs1InHandleRoot, MakeSingleFieldSelectors("world")),
+            ir::AccessPath(
+                kPs1OutHandleRoot, MakeSingleFieldSelectors("field1"))),
     } },
     { .textproto = R"(
 name: "PS1" connections: [
@@ -313,7 +560,7 @@ TEST(BulkInstantiateTest, BulkInstantiateTest) {
       particle_spec.BulkInstantiate(instantiation_map);
 
   ASSERT_THAT(
-      instantiated_facts.claims,
+      instantiated_facts.tag_claims,
       testing::UnorderedElementsAreArray({
         ir::TagClaim(ir::TagAnnotationOnAccessPath(ir::AccessPath(
           p1_out_impl, MakeSingleFieldSelectors("field1")), "tag1")),

--- a/src/xform_to_datalog/datalog_facts.cc
+++ b/src/xform_to_datalog/datalog_facts.cc
@@ -169,8 +169,8 @@ DatalogFacts DatalogFacts::CreateFromManifestProto(
           particle_spec.BulkInstantiate(instantiation_map);
       result_claims.insert(
           result_claims.end(),
-          std::move_iterator(particle_spec_facts.claims.begin()),
-          std::move_iterator(particle_spec_facts.claims.end()));
+          std::move_iterator(particle_spec_facts.tag_claims.begin()),
+          std::move_iterator(particle_spec_facts.tag_claims.end()));
       result_checks.insert(
         result_checks.end(),
         std::move_iterator(particle_spec_facts.checks.begin()),


### PR DESCRIPTION
The DerivesFromClaim claims that, within some ParticleSpec, an output
AccessPath derives from an input AccessPath. A DerivesFromClaim both
acts as an explicitly-specified dataflow edge and a request to exclude
the target AccessPath from participating in the default process that
draws all input handle connections to all output handle connections.

This commit also adds a hash function to AccessPath (which was not
needed before) and tests it.

In addition, because we now have two different kinds of claim, this
renames claim fields to tag_claim in all cases except those in
DatalogFacts. We refrained from doing this there to avoid disrupting
@bgogul's work on an overarching binary to produce datalog facts.