### PR TITLE
Add a `checkHasTag` relation to the taint.dl.

### DIFF
--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -38,6 +38,9 @@
 // There is a claim that `accessPath` definitely has `tag` taint.
 .decl claimHasTag(accessPath: AccessPath, tag: Tag)
 
+// Check that `accessPath` definitely has `tag` taint.
+.decl checkHasTag(accessPath: AccessPath, tag: Tag)
+
 //-----------------------------------------------------------------------------
 // Rules
 //-----------------------------------------------------------------------------
@@ -77,5 +80,7 @@ mayHaveTag(base, tag) :-
   isAccessPath(member),
   mayHaveTag(member, tag),
   isMemberOf(base, member).
+
+.output checkHasTag
 
 #endif // SRC_ANALYSIS_SOUFFLE_TAINT_DL_


### PR DESCRIPTION
This is generated by `DatalogFacts`, but is not declared in taint.dl. No tests added as the existing tests will make sure `taint.dl` is compilable with this change.