### PR TITLE
Generate a conditional `checkHasTag` rule for a checks in a spec.

### DIFF
--- a/src/ir/tag_check.h
+++ b/src/ir/tag_check.h
@@ -40,11 +40,13 @@ class TagCheck {
   // passing for the MVP.
   std::string ToString() const {
     constexpr absl::string_view kCheckHasTagFormat =
-        R"(checkHasTag("%s", "%s").)";
-    return absl::StrFormat(
-        kCheckHasTagFormat,
-        tag_annotation_on_access_path_.access_path().ToString(),
-        tag_annotation_on_access_path_.tag());
+        R"(checkHasTag("%s", "%s") :- mayHaveTag("%s", "%s").)";
+    std::string access_path =
+        tag_annotation_on_access_path_.access_path().ToString();
+    std::string tag = tag_annotation_on_access_path_.tag();
+
+    return absl::StrFormat(kCheckHasTagFormat, access_path, tag, access_path,
+                           tag);
   }
 
   bool operator==(const TagCheck &other) const {

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -12,20 +12,20 @@ namespace raksha::ir {
 class TagCheckToStringWithRootTest :
     public testing::TestWithParam<
       std::tuple<
-        std::tuple<std::string, absl::ParsedFormat<'s'>>, AccessPathRoot>>
+        std::tuple<std::string, absl::ParsedFormat<'s', 's'>>, AccessPathRoot>>
       {};
 
 TEST_P(TagCheckToStringWithRootTest, TagCheckToStringWithRootTest) {
-  const std::tuple<std::string, absl::ParsedFormat<'s'>>
+  const std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
       &textproto_format_string_pair = std::get<0>(GetParam());
   const std::string &check_textproto =
       std::get<0>(textproto_format_string_pair);
-  const absl::ParsedFormat<'s'> expected_tostring_format_string =
+  const absl::ParsedFormat<'s', 's'> expected_tostring_format_string =
     std::get<1>(textproto_format_string_pair);
   const AccessPathRoot &root = std::get<1>(GetParam());
-
+  std::string root_string = root.ToString();
   const std::string &expected_tostring = absl::StrFormat(
-      expected_tostring_format_string, root.ToString());
+      expected_tostring_format_string, root_string, root_string);
   arcs::CheckProto check_proto;
   google::protobuf::TextFormat::ParseFromString(check_textproto, &check_proto);
   TagCheck unrooted_tag_check = TagCheck::CreateFromProto(check_proto);
@@ -55,23 +55,26 @@ static AccessPathRoot instantiated_roots[] = {
 // expected ToString output when the root string is substituted for the %s.
 // This allows us to test the result of combining each of the
 // TagChecks derived from the textprotos with each of the root strings.
-static std::tuple<std::string, absl::ParsedFormat<'s'>>
+static std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
     textproto_to_expected_format_string[] = {
     { "access_path: { "
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" } "
       "selectors: { field: \"field1\" } }, "
       "predicate: { label: { semantic_tag: \"tag\"} }",
-      absl::ParsedFormat<'s'>("checkHasTag(\"%s.field1\", \"tag\").") },
+      absl::ParsedFormat<'s', 's'>("checkHasTag(\"%s.field1\", \"tag\") :- "
+                               "mayHaveTag(\"%s.field1\", \"tag\").") },
     { "access_path: {"
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" } }, "
       "predicate: { label: { semantic_tag: \"tag2\"} }",
-      absl::ParsedFormat<'s'>("checkHasTag(\"%s\", \"tag2\").") },
+      absl::ParsedFormat<'s', 's'>("checkHasTag(\"%s\", \"tag2\") :- "
+                              "mayHaveTag(\"%s\", \"tag2\").") },
     { "access_path: { "
       "handle: { particle_spec: \"ps\", " "handle_connection: \"hc\" }, "
       "selectors: [{ field: \"x\" }, { field: \"y\" }] }, "
       "predicate: { label: { semantic_tag: \"user_selection\"} }",
-      absl::ParsedFormat<'s'>(
-          "checkHasTag(\"%s.x.y\", \"user_selection\")" ".") }
+      absl::ParsedFormat<'s', 's'>(
+          "checkHasTag(\"%s.x.y\", \"user_selection\")" " :- "
+          "mayHaveTag(\"%s.x.y\", \"user_selection\")" ".") }
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -79,7 +79,7 @@ static std::tuple<DatalogFacts, std::string>
 claimHasTag("recipe.particle.out", "tag").
 
 // Checks:
-checkHasTag("recipe.particle.in", "tag2").
+checkHasTag("recipe.particle.in", "tag2") :- mayHaveTag("recipe.particle.in", "tag2").
 
 // Edges:
 edge("recipe.h1", "recipe.particle.in").
@@ -295,12 +295,12 @@ TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
 }
 
 static std::string kExpectedCheckStrings[] = {
-    R"(checkHasTag("NamedR.PS1#0.in_handle.field1", "tag2").)",
-    R"(checkHasTag("NamedR.PS1#1.in_handle.field1", "tag2").)",
-    R"(checkHasTag("NamedR.PS2#2.in_handle.field1", "tag4").)",
-    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "tag2").)",
-    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "tag4").)",
-    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "tag4").)",
+    R"(checkHasTag("NamedR.PS1#0.in_handle.field1", "tag2") :- mayHaveTag("NamedR.PS1#0.in_handle.field1", "tag2").)",
+    R"(checkHasTag("NamedR.PS1#1.in_handle.field1", "tag2") :- mayHaveTag("NamedR.PS1#1.in_handle.field1", "tag2").)",
+    R"(checkHasTag("NamedR.PS2#2.in_handle.field1", "tag4") :- mayHaveTag("NamedR.PS2#2.in_handle.field1", "tag4").)",
+    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "tag2") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "tag2").)",
+    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "tag4") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "tag4").)",
+    R"(checkHasTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "tag4") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "tag4").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {


### PR DESCRIPTION
Currently, a check in a spec just asserts `checkHasTag`. Instead, it should generate `checkHasTag(...) : mayHaveTag(...)`. Otherwise, the checks get trivially satisfied.