### PR TITLE
Allow all policy code to come from auth logic.

### DIFF
--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -64,7 +64,7 @@ claimHasTag(principal, path, tag) :- saysHasTag(principal, path, tag).
 // ownsTag from something with a speaker. This rule is likely to change. It
 // does not rule out the case that two different principals claim ownership of
 // a tag.
-ownsTag(speaker, tag) :- saysOwnsTag(speaker, owner, tag).
+ownsTag(owner, tag) :- saysOwnsTag(_, owner, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -56,7 +56,7 @@ downgrades(path, tag) :- ownsTag(owner, tag), saysDowngrades(owner, path, tag).
 // a tag, then it has the tag according to the taint analysis. This rule is
 // likely to be adjusted later. For confidentiality tags this should be OK to
 // start with.
-claimHasTag(path, tag) :- ownsTag(owner, tag), saysHasTag(_, path, tag).
+claimHasTag(principal, path, tag) :- saysHasTag(principal, path, tag).
 
 // This rule says that any principal can say that another principal owns a tag.
 // This rule is just a starting point to allow all aspects of the policy to
@@ -76,9 +76,6 @@ ownsTag(speaker, tag) :- saysOwnsTag(speaker, owner, tag).
 // cause all principals to be associated with all tags.
 // isTag(tag) :- ownsTag(_, tag).
 
-isTag(tag) :- saysDowngrades(_, _, tag).
-
-isPrincipal(speaker) :- saysDowngrades(speaker, _, _).
 isPrincipal(owner) :- ownsTag(owner, _).
 
 #endif // SRC_ANALYSIS_SOUFFLE_AUTHORIZATION_LOGIC_DL_

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -34,11 +34,13 @@
 
 .decl isPrincipal(p: Principal)
 
-isPrincipal(speaker) :- saysDowngrades(speaker, _, _).
-
 // This party is the owner of a taint Tag (they have the privilege to downgrade
 // it).
 .decl ownsTag(owner: Principal, tag: Tag)
+
+.decl saysCreateTag(speaker: Principal, tag: Tag)
+
+.decl saysHasTag(speaker: Principal, path: AccessPath, t: Tag)
 
 // Some accessPath is actually downgraded (by taking into consideration the
 // privileges of a party trying to downgrade it, and as a result of that party
@@ -52,12 +54,34 @@ isPrincipal(speaker) :- saysDowngrades(speaker, _, _).
 //-----------------------------------------------------------------------------
 downgrades(path, tag) :- ownsTag(owner, tag), saysDowngrades(owner, path, tag).
 
+claimNotHasTag(path, tag) :- downgrades(path, tag).
+
+// This rule conservatively says that if _any_ principal claims that a path has
+// a tag, then it has the tag according to the taint analysis. This rule is
+// likely to be adjusted later. For confidentiality tags this should be OK to
+// start with.
+claimHasTag(path, tag) :- saysHasTag(_, path, tag).
+
+// This rule says that any principal that creates a tag owns it. This rule is 
+// just a starting point to allow all aspects of the policy to come from 
+// authorization logic -- it is just a simple way to generate ownsTag from 
+// something with a speaker. This rule is likely to change. It does not rule
+// out the case that two different principals both create the same tag.
+ownsTag(speaker, tag) :- saysCreateTag(speaker, tag).
+
+//-----------------------------------------------------------------------------
+// Universe Populating Rules
+//-----------------------------------------------------------------------------
+
 // TODO(#126): Fix the universe populating rules, potentially by deleting
 //  them entirely.
-//
 // For now, we need to not populate isTag to handle cases where the tests
 // cause all principals to be associated with all tags.
 // isTag(tag) :- ownsTag(_, tag).
+
 isTag(tag) :- saysDowngrades(_, _, tag).
+
+isPrincipal(speaker) :- saysDowngrades(speaker, _, _).
+isPrincipal(owner) :- ownsTag(owner, _).
 
 #endif // SRC_ANALYSIS_SOUFFLE_AUTHORIZATION_LOGIC_DL_

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -28,8 +28,6 @@
 
 // Some party asserts the claim that the label of an access path should be
 // downgraded by removing the referenced tag from the set.
-// This relation needs to be in snake case because outputs from the 
-// authorization logic will be in snake case.
 .decl saysDowngrades(speaker: Principal, p: AccessPath, t: Tag)
 
 .decl isPrincipal(p: Principal)
@@ -38,7 +36,7 @@
 // it).
 .decl ownsTag(owner: Principal, tag: Tag)
 
-.decl saysCreateTag(speaker: Principal, tag: Tag)
+.decl saysOwnsTag(speaker: Principal, owner: Principal, tag: Tag)
 
 .decl saysHasTag(speaker: Principal, path: AccessPath, t: Tag)
 
@@ -54,20 +52,19 @@
 //-----------------------------------------------------------------------------
 downgrades(path, tag) :- ownsTag(owner, tag), saysDowngrades(owner, path, tag).
 
-claimNotHasTag(path, tag) :- downgrades(path, tag).
-
 // This rule conservatively says that if _any_ principal claims that a path has
 // a tag, then it has the tag according to the taint analysis. This rule is
 // likely to be adjusted later. For confidentiality tags this should be OK to
 // start with.
-claimHasTag(path, tag) :- saysHasTag(_, path, tag).
+claimHasTag(path, tag) :- ownsTag(owner, tag), saysHasTag(_, path, tag).
 
-// This rule says that any principal that creates a tag owns it. This rule is 
-// just a starting point to allow all aspects of the policy to come from 
-// authorization logic -- it is just a simple way to generate ownsTag from 
-// something with a speaker. This rule is likely to change. It does not rule
-// out the case that two different principals both create the same tag.
-ownsTag(speaker, tag) :- saysCreateTag(speaker, tag).
+// This rule says that any principal can say that another principal owns a tag.
+// This rule is just a starting point to allow all aspects of the policy to
+// come from authorization logic -- it is just a simple way to generate
+// ownsTag from something with a speaker. This rule is likely to change. It
+// does not rule out the case that two different principals claim ownership of
+// a tag.
+ownsTag(speaker, tag) :- saysOwnsTag(speaker, owner, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/examples/vision_pipeline/VisionPipelineAuthLogicOutput.dl
+++ b/src/analysis/souffle/examples/vision_pipeline/VisionPipelineAuthLogicOutput.dl
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-----------------------------------------------------------------------------
-#include "authorization_logic.dl"
+#include "../../authorization_logic.dl"
 
 // This file is roughly what should be produced by authorization logic as an 
 // output. I think in reality there are gaps (one is that the output from the 

--- a/src/analysis/souffle/examples/vision_pipeline/VisionPipelineOut.dl
+++ b/src/analysis/souffle/examples/vision_pipeline/VisionPipelineOut.dl
@@ -20,8 +20,8 @@
 // //third_party/arcs/examples/VisionPipeline.arcs into
 // datalog (presumably by converting it into protos in between)
 
-#include "taint.dl"
-#include "authorization_logic.dl"
+#include "../../taint.dl"
+#include "../../authorization_logic.dl"
 #include "VisionPipelineTagOwners.dl"
 #include "VisionPipelineAuthLogicOutput.dl"
 

--- a/src/analysis/souffle/examples/vision_pipeline/VisionPipelineTagOwners.dl
+++ b/src/analysis/souffle/examples/vision_pipeline/VisionPipelineTagOwners.dl
@@ -13,19 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-----------------------------------------------------------------------------
-#include "authorization_logic.dl"
+#include "../../authorization_logic.dl"
 
 // This code assign owners to tags for the VisionPipeline.arcs example.
-// This is not generated code. This is policy code that is written directly
-// in datalog (for now).
-//
-// This is the only bit of "policy" code that
-// isn't expressed in authorization logic, and it isn't in authorization logic
-// just because these facts are "universally true" rather than having a 
-// "speaker". We might also try making these "SomePrincipal says ownsTag(...)"
-// instead later, but this seems like a simpler way to start.
-ownsTag("EndUser", "raw_video_tag").
-ownsTag("EndUser", "detected_images_tag").
-ownsTag("EndUser", "user_selection_tag").
-ownsTag("EndUser", "product_id_tag").
-ownsTag("ServiceProvider", "image_detection_model_tag").
+// It comes from authorization logic where it looks like "P says createTag(t)"
+saysCreateTag("EndUser", "raw_video_tag").
+saysCreateTag("EndUser", "detected_images_tag").
+saysCreateTag("EndUser", "user_selection_tag").
+saysCreateTag("EndUser", "product_id_tag").
+saysCreateTag("ServiceProvider", "image_detection_model_tag").

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -44,10 +44,6 @@
 // is made by `principal`.
 .decl claimHasTag(principal: Principal, accessPath: AccessPath, tag: Tag)
 
-// There is a claim that `accessPath` definitely does not have `tag` taint
-// (even if the taint analysis would otherwise have this taint).
-.decl claimNotHasTag(accessPath: AccessPath, tag: Tag)
-
 //-----------------------------------------------------------------------------
 // Rules
 //-----------------------------------------------------------------------------
@@ -57,7 +53,7 @@ mayHaveTag(tgt, tag) :- hasTag(tgt, tag).
 
 mayHaveTag(tgt, tag) :-
     edge(src, tgt), mayHaveTag(src, tag),
-    !claimNotHasTag(tgt, tag).
+    !downgrades(tgt, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -52,8 +52,7 @@ hasTag(tgt, tag) :- claimHasTag(principal, tgt, tag), ownsTag(principal, tag).
 mayHaveTag(tgt, tag) :- hasTag(tgt, tag).
 
 mayHaveTag(tgt, tag) :-
-    edge(src, tgt), mayHaveTag(src, tag),
-    !downgrades(tgt, tag).
+    edge(src, tgt), mayHaveTag(src, tag), !downgrades(tgt, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -44,6 +44,10 @@
 // is made by `principal`.
 .decl claimHasTag(principal: Principal, accessPath: AccessPath, tag: Tag)
 
+// There is a claim that `accessPath` definitely does not have `tag` taint
+// (even if the taint analysis would otherwise have this taint).
+.decl claimNotHasTag(accessPath: AccessPath, tag: Tag)
+
 //-----------------------------------------------------------------------------
 // Rules
 //-----------------------------------------------------------------------------
@@ -52,7 +56,8 @@ hasTag(tgt, tag) :- claimHasTag(principal, tgt, tag), ownsTag(principal, tag).
 mayHaveTag(tgt, tag) :- hasTag(tgt, tag).
 
 mayHaveTag(tgt, tag) :-
-  edge(src, tgt), mayHaveTag(src, tag), !downgrades(tgt, tag).
+    edge(src, tgt), mayHaveTag(src, tag),
+    !claimNotHasTag(tgt, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules


### PR DESCRIPTION
Every relation now has a speaker so that all aspects of policy code
aside from the graph (which comes from manifests) can come from
authorization logic. Aspects of how this works are likely to be iterated
on.