### PR TITLE
Add an `overloaded` utility method for using inplace labmdas for visiting variants.

### DIFF
--- a/src/utils/BUILD
+++ b/src/utils/BUILD
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------------------------
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------------------------
+package(default_visibility = ["//src:__subpackages__"])
+
+cc_library(
+    name = "overloaded",
+    hdrs = ["overloaded.h"],
+    deps = [],
+)
+
+cc_test(
+    name = "overloaded_test",
+    srcs = ["overloaded_test.cc"],
+    deps = [
+        ":overloaded",
+        "//src/common/testing:gtest",
+    ],
+)

--- a/src/utils/overloaded.h
+++ b/src/utils/overloaded.h
@@ -1,0 +1,43 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#ifndef SRC_IR_UTILS_OVERLOADED_H_
+#define SRC_IR_UTILS_OVERLOADED_H_
+
+namespace raksha::utils {
+
+// See overloaded_test.cc for an example usage.   
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+
+// Allows using in-place lambas for the different types of a variant when
+// visiting a std::variant type. This won't be needed from C++20.
+//
+// Suppose we have the following variant type:
+//    using var_t = std::variant<int, long, double, std::string>;
+//
+// Here is an example of how `overloaded` can be used to use in-place lambas:
+//
+//  . var_t v = ...
+//    auto res = std::visit(overloaded {
+//      [](auto arg) { return generic_call(arg); },
+//      [](double arg) { return double_call(args); },
+//      [](const std::string& arg) { return string_call(arg); }
+//    }, v);
+//
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+}  // namespace raksha::utils
+
+#endif  // SRC_IR_UTILS_OVERLOADED_H_

--- a/src/utils/overloaded_test.cc
+++ b/src/utils/overloaded_test.cc
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#include "src/utils/overloaded.h"
+
+#include <string>
+#include <iostream>
+
+#include "src/common/testing/gtest.h"
+
+namespace raksha::utils {
+
+enum class Kind { kInt, kLong, kDouble, kString } kind;
+using VariantType = std::variant<int, long, double, std::string>;
+
+class OverloadedTest
+    : public testing::TestWithParam<std::pair<VariantType, Kind>> {};
+
+TEST_P(OverloadedTest, DispatchesToCorrectType) {
+  const auto& [variant, expected_kind] = GetParam();
+  Kind kind =
+      std::visit(overloaded{[](int l) { return Kind::kInt; },
+                            [](long l) { return Kind::kLong; },
+                            [](const std::string& s) { return Kind::kString; },
+                            [](double d) { return Kind::kDouble; }},
+                 variant);
+  EXPECT_EQ(kind, expected_kind);
+}
+
+INSTANTIATE_TEST_SUITE_P(OverloadedTest, OverloadedTest,
+                         testing::Values(std::make_pair(10, Kind::kInt),
+                                         std::make_pair(2.0, Kind::kDouble),
+                                         std::make_pair(5L, Kind::kLong),
+                                         std::make_pair("hello",
+                                                        Kind::kString)));
+
+}  // namespace raksha::utils


### PR DESCRIPTION
This utility is useful if we want to add variant visitors, where each variant needs a different behavior. See overloaded_test.cc for a usage.