### PR TITLE
Move protobuf handling of AccessPath structures to ir/proto

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -6,10 +6,42 @@ cc_library(
         ["*.cc"],
         exclude = ["*_test.cc"],
     ),
-    hdrs = glob(["*.h"]),
+    hdrs = glob(
+        ["*.h"],
+        exclude = [
+            "access_path.h",
+            "access_path_root.h",
+            "access_path_selectors.h",
+            "access_path_selectors_set.h",
+            "field_selector.h",
+            "selector.h",
+        ],
+    ),
+    deps = [
+        ":access_path",
+        "//src/common/logging",
+        "//src/ir/proto:access_path",
+        "//third_party/arcs/proto:manifest_cc_proto",
+        "@absl//absl/container:flat_hash_map",
+        "@absl//absl/container:flat_hash_set",
+        "@absl//absl/hash",
+        "@absl//absl/strings",
+        "@absl//absl/types:variant",
+    ],
+)
+
+cc_library(
+    name = "access_path",
+    hdrs = [
+        "access_path.h",
+        "access_path_root.h",
+        "access_path_selectors.h",
+        "access_path_selectors_set.h",
+        "field_selector.h",
+        "selector.h",
+    ],
     deps = [
         "//src/common/logging",
-        "//third_party/arcs/proto:manifest_cc_proto",
         "@absl//absl/container:flat_hash_map",
         "@absl//absl/container:flat_hash_set",
         "@absl//absl/hash",

--- a/src/ir/access_path.h
+++ b/src/ir/access_path.h
@@ -13,25 +13,6 @@ namespace raksha::ir {
 // tree, and an AccessPathRoot, describing the path before that.
 class AccessPath {
  public:
-  // Create an AccessPath from the equivalent Arcs proto. We currently only
-  // handle the case in which an AccessPathProto is rooted at a
-  // (particle_spec, handle_connection), in which case it
-  static AccessPath CreateFromProto(
-      const arcs::AccessPathProto &access_path_proto) {
-    CHECK(!access_path_proto.has_store_id())
-      << "Currently, access paths involving stores are not implemented.";
-    CHECK(access_path_proto.has_handle())
-      << "Expected AccessPathProto to contain a handle member.";
-    HandleConnectionSpecAccessPathRoot hcs_access_path_root =
-        HandleConnectionSpecAccessPathRoot::CreateFromProto(
-            access_path_proto.handle());
-
-    AccessPathSelectors selectors =
-        AccessPathSelectors::CreateFromProto(access_path_proto);
-    return AccessPath(
-        AccessPathRoot(std::move(hcs_access_path_root)), std::move(selectors));
-  }
-
   explicit AccessPath(
     AccessPathRoot root, AccessPathSelectors access_path_selectors)
     : root_(std::move(root)),

--- a/src/ir/access_path_root.h
+++ b/src/ir/access_path_root.h
@@ -4,7 +4,6 @@
 #include "absl/types/variant.h"
 #include "absl/strings/str_join.h"
 #include "src/common/logging/logging.h"
-#include "third_party/arcs/proto/manifest.pb.h"
 
 // The classes in this file describe the root of an AccessPath. At the moment,
 // we have only two types of roots: a HandleConnectionSpecAccessPathRoot and
@@ -18,19 +17,6 @@ namespace raksha::ir {
 // locations.
 class HandleConnectionSpecAccessPathRoot {
  public:
-  static HandleConnectionSpecAccessPathRoot CreateFromProto(
-      const arcs::AccessPathProto_HandleRoot &handle_root_proto) {
-    std::string particle_spec_name = handle_root_proto.particle_spec();
-    CHECK(!particle_spec_name.empty())
-      << "Expected a HandleRoot message to have a non-empty particle_spec.";
-    std::string handle_connection_spec_name =
-        handle_root_proto.handle_connection();
-    CHECK(!handle_connection_spec_name.empty())
-      << "Expected a HandleRoot message to have a non-empty handle_connection.";
-    return HandleConnectionSpecAccessPathRoot(
-        particle_spec_name, handle_connection_spec_name);
-  }
-
   explicit HandleConnectionSpecAccessPathRoot(
       std::string particle_spec_name, std::string handle_connection_spec_name)
       : particle_spec_name_(std::move(particle_spec_name)),
@@ -42,14 +28,6 @@ class HandleConnectionSpecAccessPathRoot {
   std::string ToString() const {
     LOG(FATAL) << "Attempted to print out an AccessPath before connecting it "
                   "to a fully-instantiated root!";
-  }
-
-  // Make this class back into an arcs HandleRoot proto.
-  arcs::AccessPathProto_HandleRoot MakeProto() const {
-    arcs::AccessPathProto_HandleRoot result;
-    result.set_particle_spec(particle_spec_name_);
-    result.set_handle_connection(handle_connection_spec_name_);
-    return result;
   }
 
   // A HandleConnectionSpecAccessPathRoot has not been fully instantiated.

--- a/src/ir/access_path_root_test.cc
+++ b/src/ir/access_path_root_test.cc
@@ -1,8 +1,5 @@
 #include "src/ir/access_path_root.h"
 
-#include <google/protobuf/util/message_differencer.h>
-#include <google/protobuf/text_format.h>
-
 #include "absl/hash/hash_testing.h"
 #include "src/common/testing/gtest.h"
 
@@ -33,48 +30,6 @@ TEST(HandleAccessPathRootTest, HandleAccessPathRootTest) {
   EXPECT_TRUE(test_access_path_root.IsInstantiated());
   EXPECT_EQ(test_access_path_root.ToString(), "recipe.handle");
 }
-
-class ConnectionSpecRootProtoTest :
-    public testing::TestWithParam<
-      std::tuple<std::string, std::string, std::string>>{};
-
-TEST_P(ConnectionSpecRootProtoTest, ConnectionSpecRootProtoTest) {
-  std::string textproto;
-  std::string expected_particle_spec;
-  std::string expected_handle_connection;
-  std::tie(textproto, expected_particle_spec, expected_handle_connection) =
-      GetParam();
-
-  arcs::AccessPathProto_HandleRoot orig_handle_root_proto;
-  google::protobuf::TextFormat::ParseFromString(
-      textproto, &orig_handle_root_proto);
-
-  HandleConnectionSpecAccessPathRoot connection_spec_root =
-      HandleConnectionSpecAccessPathRoot::CreateFromProto(
-          orig_handle_root_proto);
-
-  EXPECT_EQ(connection_spec_root.particle_spec_name(), expected_particle_spec);
-  EXPECT_EQ(connection_spec_root.handle_connection_spec_name(),
-            expected_handle_connection);
-
-  arcs::AccessPathProto_HandleRoot result_handle_root_proto =
-      connection_spec_root.MakeProto();
-
-  EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals
-    (orig_handle_root_proto, result_handle_root_proto));
-}
-
-static std::tuple<std::string, std::string, std::string>
-  textproto_particle_spec_and_handle_connections[] = {
-    { "particle_spec: \"ps\" handle_connection: \"hc\"", "ps", "hc" },
-    { "particle_spec: \"p_spec\" handle_connection: \"handle\"",
-      "p_spec", "handle" },
-    {  "particle_spec: \"a\" handle_connection: \"b\"", "a", "b"}
-};
-
-INSTANTIATE_TEST_SUITE_P(
-    ConnectionSpecRootProtoTest, ConnectionSpecRootProtoTest,
-    testing::ValuesIn(textproto_particle_spec_and_handle_connections));
 
 enum AccessPathRootKind {
   kHandleConnectionSpec,

--- a/src/ir/access_path_selectors.h
+++ b/src/ir/access_path_selectors.h
@@ -27,22 +27,6 @@ namespace raksha::ir {
 // 3. The name AccessPathSelectors is a bit more self-documenting.
 class AccessPathSelectors {
  public:
-  // Create an AccessPathSelectors object from the selector list on an
-  // AccessPathProto. Note that this considers *only* the selector list and
-  // ignores the rest of the access_path_proto message.
-  static AccessPathSelectors CreateFromProto(
-      const arcs::AccessPathProto &access_path_proto) {
-    const auto &selector_list = access_path_proto.selectors();
-    AccessPathSelectors access_path_selectors;
-    for (auto iter = selector_list.rbegin(); iter != selector_list.rend();
-      ++iter) {
-      access_path_selectors = AccessPathSelectors(
-              Selector::CreateFromProto(*iter),
-              std::move(access_path_selectors));
-    }
-    return access_path_selectors;
-  }
-
   // Allow constructing an empty AccessPathSelectors object. This represents
   // an empty access path, such as one involving only a primitive type.
   explicit AccessPathSelectors() = default;
@@ -77,15 +61,6 @@ class AccessPathSelectors {
       [](std::string *out, const Selector &selector){
         out->append(selector.ToString()); });
 
-  }
-
-  // Fill the selectors of an arcs::AccessPathProto message using the
-  // information in the AccessPathSelectors object.
-  void FillSelectors(arcs::AccessPathProto &access_path_proto) const {
-    for (auto iter = reverse_selectors_.rbegin();
-      iter != reverse_selectors_.rend(); ++iter) {
-      *access_path_proto.add_selectors() = iter->MakeProto();
-    }
   }
 
   // TODO(#98): This exposes the fact that the internal collection is a vector.

--- a/src/ir/access_path_selectors_test.cc
+++ b/src/ir/access_path_selectors_test.cc
@@ -2,8 +2,6 @@
 
 #include <string>
 #include <vector>
-#include <google/protobuf/util/message_differencer.h>
-#include <google/protobuf/text_format.h>
 
 #include "absl/hash/hash_testing.h"
 #include "absl/status/statusor.h"
@@ -144,46 +142,5 @@ TEST(AccessPathHashTest, SelectorAccessPathHashTest) {
   EXPECT_TRUE(
       absl::VerifyTypeImplementsAbslHashCorrectly(access_paths_to_check));
 }
-
-static const std::tuple<std::string, std::string>
-  access_path_selectors_proto_tostring_pairs[] {
-    {"", ""},
-    { "selectors: { field: \"foo\" }", ".foo" },
-    { "selectors: [{ field: \"foo\" }, { field: \"bar\" }]", ".foo.bar" },
-    { "selectors: [{ field: \"foo\" }, { field: \"bar\" }, { field: \"baz\" }]",
-      ".foo.bar.baz" },
-};
-
-class AccessPathSelectorsFromProtoTest
- : public testing::TestWithParam<std::tuple<std::string, std::string>> {};
-
-TEST_P(AccessPathSelectorsFromProtoTest, AccessPathSelectorsFromProtoTest) {
-  std::string access_path_textproto = std::get<0>(GetParam());
-  std::string expected_to_string = std::get<1>(GetParam());
-
-  arcs::AccessPathProto orig_access_path_proto;
-  google::protobuf::TextFormat::ParseFromString(
-      access_path_textproto, &orig_access_path_proto);
-
-  // If this test were given an AccessPathProto with a root element, it would
-  // fail because this class handles the selector piece only. Guard ourselves
-  // from confusion due to bad inputs by checking that our input does not
-  // have a root.
-  EXPECT_FALSE(orig_access_path_proto.has_handle());
-  EXPECT_FALSE(orig_access_path_proto.has_store_id());
-
-  AccessPathSelectors access_path_selectors =
-      AccessPathSelectors::CreateFromProto(orig_access_path_proto);
-  EXPECT_EQ(access_path_selectors.ToString(), expected_to_string);
-
-  arcs::AccessPathProto result_access_path_proto;
-  access_path_selectors.FillSelectors(result_access_path_proto);
-  EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
-      result_access_path_proto, orig_access_path_proto));
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    AccessPathSelectorsFromProtoTest, AccessPathSelectorsFromProtoTest,
-    testing::ValuesIn(access_path_selectors_proto_tostring_pairs));
 
 } // namespace raksha::ir

--- a/src/ir/access_path_test.cc
+++ b/src/ir/access_path_test.cc
@@ -1,7 +1,5 @@
 #include "src/ir/access_path.h"
 
-#include <google/protobuf/text_format.h>
-
 #include "absl/hash/hash_testing.h"
 #include "src/common/testing/gtest.h"
 
@@ -61,45 +59,6 @@ TEST(InstantiateAccessPathTest, InstantiateAccessPathTest) {
                   "recipe2", "particle2", "handle2"))),
       "Attempt to instantiate an AccessPath that is already instantiated.");
 }
-
-static const std::tuple<std::string, std::string>
-  access_path_proto_tostring_pairs[] {
-    { "handle: { particle_spec: \"ps\", handle_connection: \"hc\" }", ""},
-    { "handle: { particle_spec: \"ps\", handle_connection: \"hc\" } "
-      "selectors: { field: \"foo\" }", ".foo" },
-    { "handle: { particle_spec: \"ps\", handle_connection: \"hc\" } "
-      "selectors: [{ field: \"foo\" }, { field: \"bar\" }]", ".foo.bar" },
-    { "handle: { particle_spec: \"ps\", handle_connection: \"hc\" } "
-      "selectors: [{ field: \"foo\" }, { field: \"bar\" }, { field: \"baz\" }]",
-      ".foo.bar.baz" },
-};
-
-class AccessPathFromProtoTest
- : public testing::TestWithParam<std::tuple<std::string, std::string>> {};
-
-TEST_P(AccessPathFromProtoTest, AccessPathFromProtoTest) {
-  std::string textproto;
-  std::string expected_tostring_suffix;
-  std::tie(textproto, expected_tostring_suffix) = GetParam();
-
-  arcs::AccessPathProto access_path_proto;
-  google::protobuf::TextFormat::ParseFromString(textproto, &access_path_proto);
-
-  AccessPath access_path = AccessPath::CreateFromProto(access_path_proto);
-
-  AccessPathRoot root(
-      HandleConnectionAccessPathRoot("recipe", "particle", "handle"));
-  ASSERT_EQ(
-      access_path.Instantiate(root).ToString(),
-      "recipe.particle.handle" + expected_tostring_suffix);
-  ASSERT_DEATH(
-      access_path.ToString(),
-      "Attempted to print out an AccessPath before connecting it to a "
-      "fully-instantiated root!");
-}
-
-INSTANTIATE_TEST_SUITE_P(AccessPathFromProtoTest, AccessPathFromProtoTest,
-                         testing::ValuesIn(access_path_proto_tostring_pairs));
 
 class AccessPathEqualsTest :
  public testing::TestWithParam<

--- a/src/ir/derives_from_claim.h
+++ b/src/ir/derives_from_claim.h
@@ -19,6 +19,7 @@
 
 #include "src/ir/access_path.h"
 #include "src/ir/edge.h"
+#include "src/ir/proto/access_path.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
@@ -37,9 +38,8 @@ class DerivesFromClaim {
       << "DerivesFrom proto does not have required field source.";
     CHECK(derives_from_proto.has_target())
       << "DerivesFrom proto does not have required field target.";
-    return DerivesFromClaim(
-        AccessPath::CreateFromProto(derives_from_proto.target()),
-        AccessPath::CreateFromProto(derives_from_proto.source()));
+    return DerivesFromClaim(proto::Decode(derives_from_proto.target()),
+                            proto::Decode(derives_from_proto.source()));
   }
 
   explicit DerivesFromClaim(AccessPath target, AccessPath source)

--- a/src/ir/derives_from_claim_test.cc
+++ b/src/ir/derives_from_claim_test.cc
@@ -21,6 +21,7 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "src/common/testing/gtest.h"
+#include "src/ir/proto/access_path.h"
 
 namespace raksha::ir {
 
@@ -69,7 +70,7 @@ class DerivesFromAsAccessPathPairTest :
     const std::string &textproto = std::get<ParamNum>(GetParam());
     google::protobuf::TextFormat::ParseFromString(
         textproto, &access_path_proto);
-    return AccessPath::CreateFromProto(access_path_proto);
+    return proto::Decode(access_path_proto);
   }
 
   DerivesFromClaim derives_from_claim_;

--- a/src/ir/field_selector.h
+++ b/src/ir/field_selector.h
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "absl/strings/str_cat.h"
-#include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
 
@@ -14,6 +13,8 @@ class FieldSelector {
  public:
   FieldSelector(std::string field_name) : field_name_(std::move(field_name)) {}
 
+  const std::string &field_name() const { return field_name_; }
+
   // Prints the string representing dereferencing the field in the AccessPath.
   // This will just be the "." punctuation plus the name of the field.
   std::string ToString() const { return absl::StrCat(".", field_name_); }
@@ -21,13 +22,6 @@ class FieldSelector {
   // Two fields selectors are equal exactly when their names are equal.
   bool operator==(const FieldSelector &other) const {
     return field_name_ == other.field_name_;
-  }
-
-  // Make a Manifest proto Selector from this FieldSelector.
-  arcs::AccessPathProto_Selector MakeProto() const {
-    arcs::AccessPathProto_Selector selector;
-    selector.set_field(field_name_);
-    return selector;
   }
 
   template<typename H>

--- a/src/ir/proto/BUILD
+++ b/src/ir/proto/BUILD
@@ -36,6 +36,46 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "access_path",
+    srcs = ["access_path.cc"],
+    hdrs = ["access_path.h"],
+    deps = [
+        "//src/ir:access_path",
+        "//third_party/arcs/proto:manifest_cc_proto",
+    ],
+)
+
+cc_test(
+    name = "access_path_test",
+    srcs = ["access_path_test.cc"],
+    deps = [
+        ":access_path",
+        "//src/common/testing:gtest",
+        "//src/ir",
+    ],
+)
+
+cc_test(
+    name = "access_path_root_test",
+    srcs = ["access_path_root_test.cc"],
+    deps = [
+        ":access_path",
+        "//src/common/testing:gtest",
+        "//src/ir",
+    ],
+)
+
+cc_test(
+    name = "access_path_selector_test",
+    srcs = ["access_path_selector_test.cc"],
+    deps = [
+        ":access_path",
+        "//src/common/testing:gtest",
+        "//src/ir",
+    ],
+)
+
 cc_test(
     name = "entity_type_test",
     srcs = ["entity_type_test.cc"],

--- a/src/ir/proto/access_path.cc
+++ b/src/ir/proto/access_path.cc
@@ -1,0 +1,114 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#include "src/ir/proto/access_path.h"
+
+#include "src/ir/access_path.h"
+#include "src/ir/access_path_root.h"
+#include "src/ir/access_path_selectors.h"
+#include "src/ir/field_selector.h"
+#include "src/ir/selector.h"
+#include "third_party/arcs/proto/manifest.pb.h"
+
+namespace raksha::ir::proto {
+
+//----------------
+// Selector
+
+Selector Decode(arcs::AccessPathProto_Selector selector) {
+  if (selector.has_field()) {
+    return Selector(FieldSelector(selector.field()));
+  }
+  LOG(FATAL) << "Found a Selector with an unimplemented specific type.";
+}
+
+
+// Make a Manifest proto Selector from this FieldSelector.
+arcs::AccessPathProto_Selector Encode(const FieldSelector &field_selector) {
+  arcs::AccessPathProto_Selector selector;
+  selector.set_field(field_selector.field_name());
+  return selector;
+}
+
+arcs::AccessPathProto_Selector Encode(const Selector &selector) {
+  return std::visit(
+      [](const auto &specific_selector) { return Encode(specific_selector); },
+      selector.variant());
+}
+
+//----------------------
+// AccessPathSelectors
+AccessPathSelectors DecodeSelectors(
+    const arcs::AccessPathProto &access_path_proto) {
+  const auto &selector_list = access_path_proto.selectors();
+  AccessPathSelectors access_path_selectors;
+  for (auto iter = selector_list.rbegin(); iter != selector_list.rend();
+       ++iter) {
+    access_path_selectors =
+        AccessPathSelectors(Decode(*iter), std::move(access_path_selectors));
+  }
+  return access_path_selectors;
+}
+
+void EncodeSelectors(const AccessPathSelectors &selectors,
+                     arcs::AccessPathProto &access_path_proto) {
+  for (const auto& selector: selectors) {
+    *access_path_proto.add_selectors() = Encode(selector);
+  }
+}
+
+//------------------
+// AccessPathRoot
+
+HandleConnectionSpecAccessPathRoot Decode(
+    const arcs::AccessPathProto_HandleRoot &handle_root_proto) {
+  std::string particle_spec_name = handle_root_proto.particle_spec();
+  CHECK(!particle_spec_name.empty())
+      << "Expected a HandleRoot message to have a non-empty particle_spec.";
+  std::string handle_connection_spec_name =
+      handle_root_proto.handle_connection();
+  CHECK(!handle_connection_spec_name.empty())
+      << "Expected a HandleRoot message to have a non-empty handle_connection.";
+  return HandleConnectionSpecAccessPathRoot(particle_spec_name,
+                                            handle_connection_spec_name);
+}
+
+arcs::AccessPathProto_HandleRoot Encode(
+    const HandleConnectionSpecAccessPathRoot &handle_root) {
+  arcs::AccessPathProto_HandleRoot result;
+  result.set_particle_spec(handle_root.particle_spec_name());
+  result.set_handle_connection(handle_root.handle_connection_spec_name());
+  return result;
+}
+
+
+//-----------------
+// AccessPath
+
+// We currently only handle the case in which an AccessPathProto is rooted at a
+// (particle_spec, handle_connection).
+AccessPath Decode(const arcs::AccessPathProto& access_path_proto) {
+  CHECK(!access_path_proto.has_store_id())
+      << "Currently, access paths involving stores are not implemented.";
+  CHECK(access_path_proto.has_handle())
+      << "Expected AccessPathProto to contain a handle member.";
+  HandleConnectionSpecAccessPathRoot hcs_access_path_root =
+      Decode(access_path_proto.handle());
+  AccessPathSelectors selectors = DecodeSelectors(access_path_proto);
+  return AccessPath(AccessPathRoot(std::move(hcs_access_path_root)),
+                    std::move(selectors));
+}
+
+}  // namespace raksha::ir::proto

--- a/src/ir/proto/access_path.h
+++ b/src/ir/proto/access_path.h
@@ -1,0 +1,54 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#ifndef SRC_IR_PROTO_ACCESS_PATH_H_
+#define SRC_IR_PROTO_ACCESS_PATH_H_
+
+#include "src/ir/access_path.h"
+#include "src/ir/access_path_root.h"
+#include "third_party/arcs/proto/manifest.pb.h"
+
+namespace raksha::ir::proto {
+
+// Decodes the given arcs::AccessPathProto_Selector to a Selector.
+Selector Decode(arcs::AccessPathProto_Selector selector);
+
+arcs::AccessPathProto_Selector Encode(const Selector& selector);
+
+// Returns an `AccessPathSelectors` instance from the given `AccessPathProto`.
+AccessPathSelectors DecodeSelectors(
+    const arcs::AccessPathProto& access_path_proto);
+
+// Encodes the given `selectors` into arcs::AccessPathProto.
+void EncodeSelectors(const AccessPathSelectors& selectors,
+                     arcs::AccessPathProto& access_path_proto);
+
+// Decodes the given `handle_root_proto` to `HandleConnectionAccessPathRoot`.
+HandleConnectionSpecAccessPathRoot Decode(
+    const arcs::AccessPathProto_HandleRoot& handle_root_proto);
+
+// Encodes the given `handle_root` as arcs::AccessPathProto_HandleRoot.
+arcs::AccessPathProto_HandleRoot Encode(
+    const HandleConnectionSpecAccessPathRoot& hande_root);
+
+// Decodes the given `access_path_proto` as a AccessPath.
+AccessPath Decode(const arcs::AccessPathProto& access_path_proto);
+
+// Encodes the given `access_path` as an arcs::AccessPathProto.
+arcs::AccessPathProto Encode(const AccessPath& access_path);
+
+}  // namespace raksha::ir::proto
+
+#endif  // SRC_IR_PROTO_ACCESS_PATH_H_

--- a/src/ir/proto/access_path_root_test.cc
+++ b/src/ir/proto/access_path_root_test.cc
@@ -1,0 +1,39 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#include "google/protobuf/text_format.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "src/common/testing/gtest.h"
+#include "src/ir/proto/access_path.h"
+
+namespace raksha::ir::proto {
+
+class AccessPathRootTest : public testing::TestWithParam<std::string> {};
+
+TEST_P(AccessPathRootTest, RoundTripToProtoPreservesAll) {
+  arcs::AccessPathProto_HandleRoot orig_root_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(GetParam(),
+                                                            &orig_root_proto))
+      << "Unable to parse text proto.";
+  ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+      orig_root_proto, Encode(Decode(orig_root_proto))));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessPathRootTest, AccessPathRootTest,
+    testing::Values(R"(particle_spec: "ps", handle_connection: "hc")",
+                    R"(particle_spec: "abc", handle_connection: "def")"));
+
+}  // namespace raksha::ir::proto

--- a/src/ir/proto/access_path_selector_test.cc
+++ b/src/ir/proto/access_path_selector_test.cc
@@ -1,0 +1,83 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#include "google/protobuf/text_format.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "src/common/testing/gtest.h"
+#include "src/ir/proto/access_path.h"
+
+namespace raksha::ir::proto {
+
+class AccessPathSelectorTest : public testing::TestWithParam<std::string> {};
+
+TEST_P(AccessPathSelectorTest, RoundTripToProtoPreservesAll) {
+ arcs::AccessPathProto_Selector orig_selector_proto;
+ ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+     GetParam(), &orig_selector_proto))
+     << "Unable to parse text proto.";
+ ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+     orig_selector_proto, Encode(Decode(orig_selector_proto))));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessPathSelectorTest, AccessPathSelectorTest,
+    testing::Values(R"(field: "foo")", R"(field: "x")", R"(field: "bar")"));
+
+
+class AccessPathSelectorsFromProtoTest
+ : public testing::TestWithParam<std::tuple<std::string, std::string>> {};
+
+TEST_P(AccessPathSelectorsFromProtoTest, AccessPathSelectorsFromProtoTest) {
+  const auto& [access_path_textproto, expected_to_string] = GetParam();
+
+  arcs::AccessPathProto orig_access_path_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      access_path_textproto, &orig_access_path_proto))
+      << "Unable to parse text proto.";
+
+  // If this test were given an AccessPathProto with a root element, it would
+  // fail because this class handles the selector piece only. Guard ourselves
+  // from confusion due to bad inputs by checking that our input does not
+  // have a root.
+  EXPECT_FALSE(orig_access_path_proto.has_handle());
+  EXPECT_FALSE(orig_access_path_proto.has_store_id());
+
+  AccessPathSelectors access_path_selectors =
+      DecodeSelectors(orig_access_path_proto);
+  EXPECT_EQ(access_path_selectors.ToString(), expected_to_string);
+
+  arcs::AccessPathProto result_access_path_proto;
+  EncodeSelectors(access_path_selectors, result_access_path_proto);
+  EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+      result_access_path_proto, orig_access_path_proto));
+}
+
+static const std::tuple<std::string, std::string>
+    access_path_selectors_proto_tostring_pairs[]{
+        {"", ""},
+        {"selectors: { field: \"foo\" }", ".foo"},
+        {"selectors: [{ field: \"foo\" }, { field: \"bar\" }]", ".foo.bar"},
+        {"selectors: [{ field: \"foo\" }, { field: \"bar\" }, { field: \"baz\" "
+         "}]",
+         ".foo.bar.baz"},
+    };
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessPathSelectorsFromProtoTest, AccessPathSelectorsFromProtoTest,
+    testing::ValuesIn(access_path_selectors_proto_tostring_pairs));
+
+
+
+}  // namespace raksha::ir::proto

--- a/src/ir/proto/access_path_test.cc
+++ b/src/ir/proto/access_path_test.cc
@@ -1,0 +1,69 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#include "src/ir/proto/access_path.h"
+
+#include "google/protobuf/text_format.h"
+#include "src/common/testing/gtest.h"
+
+namespace raksha::ir::proto {
+
+class AccessPathFromProtoTest
+    : public testing::TestWithParam<std::tuple<std::string, std::string>> {};
+
+TEST_P(AccessPathFromProtoTest, AccessPathFromProtoTest) {
+  const auto& [textproto, expected_tostring_suffix] = GetParam();
+
+  arcs::AccessPathProto access_path_proto;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(textproto,
+                                                            &access_path_proto))
+      << "Unable to parse text proto.";
+
+  AccessPath access_path = Decode(access_path_proto);
+
+  AccessPathRoot root(
+      HandleConnectionAccessPathRoot("recipe", "particle", "handle"));
+  ASSERT_EQ(
+      access_path.Instantiate(root).ToString(),
+      "recipe.particle.handle" + expected_tostring_suffix);
+  ASSERT_DEATH(
+      access_path.ToString(),
+      "Attempted to print out an AccessPath before connecting it to a "
+      "fully-instantiated root!");
+}
+
+static const std::tuple<std::string, std::string>
+    access_path_proto_tostring_pairs[]{
+        {R"(handle: { particle_spec: "ps", handle_connection: "hc" })", ""},
+        {R"(
+handle: { particle_spec: "ps", handle_connection: "hc"}
+selectors: { field: "foo" }
+)",
+         ".foo"},
+        {R"(
+handle: { particle_spec: "ps", handle_connection: "hc" }
+selectors: [{ field: "foo" }, { field: "bar" }]
+)",
+         ".foo.bar"},
+        {R"(
+handle: { particle_spec: "ps", handle_connection: "hc" }
+selectors: [{ field: "foo" }, { field: "bar" }, { field: "baz" }]
+)",
+         ".foo.bar.baz"}};
+
+INSTANTIATE_TEST_SUITE_P(AccessPathFromProtoTest, AccessPathFromProtoTest,
+                         testing::ValuesIn(access_path_proto_tostring_pairs));
+
+}  // namespace raksha::ir::proto

--- a/src/ir/selector_test.cc
+++ b/src/ir/selector_test.cc
@@ -1,8 +1,5 @@
 #include "src/ir/selector.h"
 
-#include <google/protobuf/util/message_differencer.h>
-#include <google/protobuf/text_format.h>
-
 #include "absl/hash/hash_testing.h"
 #include "src/common/testing/gtest.h"
 
@@ -93,33 +90,5 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(
         testing::ValuesIn(example_selectors),
         testing::ValuesIn(example_selectors)));
-
-class RoundTripSelectorProtoTest :
- public testing::TestWithParam<std::tuple<std::string, std::string>> {};
-
-TEST_P(RoundTripSelectorProtoTest, RoundTripSelectorProtoTest) {
-  arcs::AccessPathProto_Selector orig_selector_proto;
-  const std::string &selector_as_textproto = std::get<0>(GetParam());
-  const std::string &expected_selector_to_string = std::get<1>(GetParam());
-  google::protobuf::TextFormat::ParseFromString(
-      selector_as_textproto, &orig_selector_proto);
-  Selector selector = Selector::CreateFromProto(orig_selector_proto);
-  EXPECT_EQ(selector.ToString(), expected_selector_to_string);
-  arcs::AccessPathProto_Selector result_selector_proto = selector.MakeProto();
-  ASSERT_TRUE(
-      google::protobuf::util::MessageDifferencer::Equals(
-          orig_selector_proto, result_selector_proto));
-}
-
-static const std::tuple<std::string, std::string>
-  selector_proto_and_tostring_pairs[] = {
-    { "field: \"foo\"", ".foo" },
-    { "field: \"x\"", ".x" },
-    { "field: \"bar\"", ".bar"}
-};
-
-INSTANTIATE_TEST_SUITE_P(
-    RoundTripSelectorProtoTest, RoundTripSelectorProtoTest,
-    testing::ValuesIn(selector_proto_and_tostring_pairs));
 
 }  // namespace raksha::ir

--- a/src/ir/tag_annotation_on_access_path.h
+++ b/src/ir/tag_annotation_on_access_path.h
@@ -4,8 +4,9 @@
 #include <string>
 
 #include "src/common/logging/logging.h"
-#include "src/ir/access_path_selectors.h"
 #include "src/ir/access_path.h"
+#include "src/ir/access_path_selectors.h"
+#include "src/ir/proto/access_path.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
@@ -27,7 +28,7 @@ class TagAnnotationOnAccessPath {
     CHECK(proto.has_access_path())
       << "Expected " << proto_name << " message to have access_path field.";
     const arcs::AccessPathProto &access_path_proto = proto.access_path();
-    AccessPath access_path = AccessPath::CreateFromProto(access_path_proto);
+    AccessPath access_path = proto::Decode(access_path_proto);
     CHECK(proto.has_predicate())
       << "Expected " << proto_name << " message to have predicate field.";
     const arcs::InformationFlowLabelProto_Predicate &predicate =


### PR DESCRIPTION
Makes further progress towards #118.

Do not merge this until https://github.com/google-research/raksha/pull/133 is merged.