### PR TITLE
Add forward iterator for AccessPathSelectors.

### DIFF
--- a/src/ir/access_path_selectors.h
+++ b/src/ir/access_path_selectors.h
@@ -88,6 +88,16 @@ class AccessPathSelectors {
     }
   }
 
+  // TODO(#98): This exposes the fact that the internal collection is a vector.
+  // Iterator methods to iterate over underlying selectors in right order.
+  std::vector<Selector>::const_reverse_iterator begin() const {
+    return reverse_selectors_.rbegin();
+  }
+
+  std::vector<Selector>::const_reverse_iterator end() const {
+    return reverse_selectors_.rend();
+  }
+
   template<typename H>
   friend H AbslHashValue(H h, const AccessPathSelectors &instance) {
     return H::combine(std::move(h), instance.reverse_selectors_);

--- a/src/ir/access_path_selectors_test.cc
+++ b/src/ir/access_path_selectors_test.cc
@@ -82,6 +82,28 @@ INSTANTIATE_TEST_SUITE_P(
         testing::ValuesIn(access_path_strs),
         testing::ValuesIn(access_path_strs)));
 
+class AccessPathSelectorsIteratorTest
+    : public ::testing::TestWithParam<std::string> {};
+
+TEST_P(AccessPathSelectorsIteratorTest, SelectorsCanBeIteratedInOrder) {
+  const auto& path_string = GetParam();
+  const absl::StatusOr<AccessPathSelectors> access_path_selectors =
+      MakeSelectorAccessPathFromString(path_string);
+  ASSERT_TRUE(access_path_selectors.ok());
+
+  // Run StrJoin from the selectors instance and make sure it is right order.
+  EXPECT_EQ(absl::StrJoin(access_path_selectors->begin(),
+                          access_path_selectors->end(), "",
+                          [](std::string* result, const auto& x) {
+                            result->append(x.ToString());
+                          }),
+            path_string);
+}
+
+INSTANTIATE_TEST_SUITE_P(AccessPathSelectorsIteratorTest,
+                         AccessPathSelectorsIteratorTest,
+                         testing::ValuesIn(access_path_strs));
+
 class AccessPathTest : public ::testing::TestWithParam<std::string> {};
 
 // A string with components separated by dots and an AccessPathSelectors are


### PR DESCRIPTION
A quick and dirty solution to address #98. Ideally we want to have use something like std::ranges (which is only in C++20). However, this should serve as a good solution for now.