### PR TITLE
Rename ToString to ToDatalog for IR objects that become Datlog facts.

### DIFF
--- a/src/ir/edge.h
+++ b/src/ir/edge.h
@@ -15,7 +15,7 @@ class Edge {
     : from_(std::move(from)), to_(std::move(to)) {}
 
   // Print the edge as a string containing a Datalog fact.
-  std::string ToString() const {
+  std::string ToDatalog() const {
     constexpr absl::string_view kEdgeFormat = R"(edge("%s", "%s").)";
     return absl::StrFormat(kEdgeFormat, from_.ToString(), to_.ToString());
   }

--- a/src/ir/edge_test.cc
+++ b/src/ir/edge_test.cc
@@ -10,7 +10,7 @@ static const AccessPathSelectors x_y_access_path_selectors =
         Selector(FieldSelector("x")),
         AccessPathSelectors(Selector(FieldSelector("y"))));
 
-static const std::tuple<Edge, std::string> edge_tostring_pairs[] = {
+static const std::tuple<Edge, std::string> edge_todatalog_pairs[] = {
     { Edge(
         AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
             "recipe", "particle", "handle")),
@@ -38,18 +38,18 @@ static const std::tuple<Edge, std::string> edge_tostring_pairs[] = {
                      AccessPathSelectors())),
       "edge(\"pre.fix.1\", \"pre.fix.2\")."} };
 
-class EdgeToStringTest :
+class EdgeToDatalogTest :
     public testing::TestWithParam<std::tuple<Edge, std::string>> {};
 
-TEST_P(EdgeToStringTest, EdgeToStringTest) {
+TEST_P(EdgeToDatalogTest, EdgeToDatalogTest) {
   const Edge &edge = std::get<0>(GetParam());
   const std::string &expected_to_string = std::get<1>(GetParam());
 
-  EXPECT_EQ(edge.ToString(), expected_to_string);
+  EXPECT_EQ(edge.ToDatalog(), expected_to_string);
 }
 
-INSTANTIATE_TEST_SUITE_P(EdgeToStringTest, EdgeToStringTest,
-                         testing::ValuesIn(edge_tostring_pairs));
+INSTANTIATE_TEST_SUITE_P(EdgeToDatalogTest, EdgeToDatalogTest,
+                         testing::ValuesIn(edge_todatalog_pairs));
 
 class EdgeEqTest : public testing::TestWithParam<
     std::tuple<

--- a/src/ir/tag_check.h
+++ b/src/ir/tag_check.h
@@ -38,7 +38,7 @@ class TagCheck {
   // simplified relative to the arbitrary boolean expression predicate we
   // will eventually want, but is enough to get some simple Arcs tests
   // passing for the MVP.
-  std::string ToString() const {
+  std::string ToDatalog() const {
     constexpr absl::string_view kCheckHasTagFormat =
         R"(checkHasTag("%s", "%s") :- mayHaveTag("%s", "%s").)";
     std::string access_path =

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -9,34 +9,34 @@
 
 namespace raksha::ir {
 
-class TagCheckToStringWithRootTest :
+class TagCheckToDatalogWithRootTest :
     public testing::TestWithParam<
       std::tuple<
         std::tuple<std::string, absl::ParsedFormat<'s', 's'>>, AccessPathRoot>>
       {};
 
-TEST_P(TagCheckToStringWithRootTest, TagCheckToStringWithRootTest) {
+TEST_P(TagCheckToDatalogWithRootTest, TagCheckToDatalogWithRootTest) {
   const std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
       &textproto_format_string_pair = std::get<0>(GetParam());
   const std::string &check_textproto =
       std::get<0>(textproto_format_string_pair);
-  const absl::ParsedFormat<'s', 's'> expected_tostring_format_string =
+  const absl::ParsedFormat<'s', 's'> expected_todatalog_format_string =
     std::get<1>(textproto_format_string_pair);
   const AccessPathRoot &root = std::get<1>(GetParam());
   std::string root_string = root.ToString();
-  const std::string &expected_tostring = absl::StrFormat(
-      expected_tostring_format_string, root_string, root_string);
+  const std::string &expected_todatalog = absl::StrFormat(
+      expected_todatalog_format_string, root_string, root_string);
   arcs::CheckProto check_proto;
   google::protobuf::TextFormat::ParseFromString(check_textproto, &check_proto);
   TagCheck unrooted_tag_check = TagCheck::CreateFromProto(check_proto);
   TagCheck tag_check = unrooted_tag_check.Instantiate(root);
-  // Expect the version with the concrete root to match the expected_tostring
-  // when ToString is called upon it.
-  ASSERT_EQ(tag_check.ToString(), expected_tostring);
-  // However, the version with the spec root should fail when ToString is
+  // Expect the version with the concrete root to match the expected_todatalog
+  // when ToDatalog is called upon it.
+  ASSERT_EQ(tag_check.ToDatalog(), expected_todatalog);
+  // However, the version with the spec root should fail when ToDatalog is
   // called.
   EXPECT_DEATH(
-      unrooted_tag_check.ToString(),
+      unrooted_tag_check.ToDatalog(),
       "Attempted to print out an AccessPath before connecting it to a "
       "fully-instantiated root!");
 }
@@ -52,7 +52,7 @@ static AccessPathRoot instantiated_roots[] = {
 };
 
 // Pairs of textprotos and format strings. The format strings will become the
-// expected ToString output when the root string is substituted for the %s.
+// expected ToDatalog output when the root string is substituted for the %s.
 // This allows us to test the result of combining each of the
 // TagChecks derived from the textprotos with each of the root strings.
 static std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
@@ -78,7 +78,7 @@ static std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    TagCheckToStringWithRootTest, TagCheckToStringWithRootTest,
+    TagCheckToDatalogWithRootTest, TagCheckToDatalogWithRootTest,
     testing::Combine(testing::ValuesIn(textproto_to_expected_format_string),
                      testing::ValuesIn(instantiated_roots)));
 

--- a/src/ir/tag_claim.h
+++ b/src/ir/tag_claim.h
@@ -50,7 +50,7 @@ class TagClaim {
   }
 
   // Produce a string containing a datalog fact for this TagClaim.
-  std::string ToString() const {
+  std::string ToDatalog() const {
     constexpr absl::string_view kClaimHasTagFormat =
         R"(claimHasTag("%s", "%s", "%s").)";
     return absl::StrFormat(

--- a/src/ir/tag_claim_test.cc
+++ b/src/ir/tag_claim_test.cc
@@ -9,7 +9,7 @@
 
 namespace raksha::ir {
 
-class TagClaimToStringWithRootTest :
+class TagClaimToDatalogWithRootTest :
     public testing::TestWithParam<
       std::tuple<
         std::string,
@@ -17,31 +17,31 @@ class TagClaimToStringWithRootTest :
         AccessPathRoot>>
       {};
 
-TEST_P(TagClaimToStringWithRootTest, TagClaimToStringWithRootTest) {
+TEST_P(TagClaimToDatalogWithRootTest, TagClaimToDatalogWithRootTest) {
   const std::string particle_spec_name = std::get<0>(GetParam());
   const std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
       &textproto_format_string_pair = std::get<1>(GetParam());
   const std::string &assume_textproto =
       std::get<0>(textproto_format_string_pair);
-  const absl::ParsedFormat<'s', 's'> expected_tostring_format_string =
+  const absl::ParsedFormat<'s', 's'> expected_todatalog_format_string =
     std::get<1>(textproto_format_string_pair);
   const AccessPathRoot &root = std::get<2>(GetParam());
 
-  const std::string &expected_tostring = absl::StrFormat(
-      expected_tostring_format_string, particle_spec_name, root.ToString());
+  const std::string &expected_todatalog = absl::StrFormat(
+      expected_todatalog_format_string, particle_spec_name, root.ToString());
   arcs::ClaimProto_Assume assume_proto;
   google::protobuf::TextFormat::ParseFromString(
       assume_textproto, &assume_proto);
   TagClaim unrooted_tag_claim =
       TagClaim::CreateFromProto(particle_spec_name, assume_proto);
   TagClaim tag_claim = unrooted_tag_claim.Instantiate(root);
-  // Expect the version with the concrete root to match the expected_tostring
-  // when ToString is called upon it.
-  ASSERT_EQ(tag_claim.ToString(), expected_tostring);
-  // However, the version with the spec root should fail when ToString is
+  // Expect the version with the concrete root to match the expected_todatalog
+  // when ToDatalog is called upon it.
+  ASSERT_EQ(tag_claim.ToDatalog(), expected_todatalog);
+  // However, the version with the spec root should fail when ToDatalog is
   // called.
   EXPECT_DEATH(
-      unrooted_tag_claim.ToString(),
+      unrooted_tag_claim.ToDatalog(),
       "Attempted to print out an AccessPath before connecting it to a "
       "fully-instantiated root!");
 }
@@ -64,7 +64,7 @@ static AccessPathRoot instantiated_roots[] = {
 };
 
 // Pairs of textprotos and format strings. The format strings will become the
-// expected ToString output when the root string is substituted for the %s.
+// expected ToDatalog output when the root string is substituted for the %s.
 // This allows us to test the result of combining each of the
 // TagClaims derived from the textprotos with each of the root strings.
 static std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
@@ -89,7 +89,7 @@ static std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    TagClaimToStringWithRootTest, TagClaimToStringWithRootTest,
+    TagClaimToDatalogWithRootTest, TagClaimToDatalogWithRootTest,
     testing::Combine(
         testing::ValuesIn(particle_spec_names),
         testing::ValuesIn(textproto_to_expected_format_string),

--- a/src/xform_to_datalog/datalog_facts.h
+++ b/src/xform_to_datalog/datalog_facts.h
@@ -36,8 +36,9 @@ class DatalogFacts {
       : manifest_datalog_facts_(std::move(manifest_datalog_facts)) {}
 
   // Returns the datalog program with necessary headers.
-  std::string ToString() const {
-    return absl::StrCat(kDatalogFilePrefix, manifest_datalog_facts_.ToString());
+  std::string ToDatalog() const {
+    return absl::StrCat(
+        kDatalogFilePrefix, manifest_datalog_facts_.ToDatalog());
   }
 
  private:

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -26,7 +26,7 @@ class DatalogFactsTest : public testing::TestWithParam<
 TEST_P(DatalogFactsTest, IncludesManifestFactsWithCorrectPrefixAndSuffix) {
   const auto& [manifest_datalog_facts, expected_string] = GetParam();
   DatalogFacts datalog_facts(manifest_datalog_facts);
-  EXPECT_EQ(datalog_facts.ToString(), expected_string);
+  EXPECT_EQ(datalog_facts.ToDatalog(), expected_string);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/xform_to_datalog/generate_datalog_program.cc
+++ b/src/xform_to_datalog/generate_datalog_program.cc
@@ -81,7 +81,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  datalog_file << datalog_facts.ToString();
+  datalog_file << datalog_facts.ToDatalog();
 
   return 0;
 }

--- a/src/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/xform_to_datalog/manifest_datalog_facts.h
@@ -42,14 +42,14 @@ class ManifestDatalogFacts {
   // Print out all contained facts as a single datalog string. Note: this
   // does not contain the header files that would be necessary to run this
   // against the datalog scripts; it contains only facts and comments.
-  std::string ToString() const {
-    auto tostring_formatter = [](std::string *out, const auto &arg) {
-      out->append(arg.ToString()); };
+  std::string ToDatalog() const {
+    auto todatalog_formatter = [](std::string *out, const auto &arg) {
+      out->append(arg.ToDatalog()); };
     return absl::StrFormat(
         kFactOutputFormat,
-        absl::StrJoin(claims_, "\n", tostring_formatter),
-        absl::StrJoin(checks_, "\n", tostring_formatter),
-        absl::StrJoin(edges_, "\n", tostring_formatter));
+        absl::StrJoin(claims_, "\n", todatalog_formatter),
+        absl::StrJoin(checks_, "\n", todatalog_formatter),
+        absl::StrJoin(edges_, "\n", todatalog_formatter));
   }
 
   const std::vector<raksha::ir::TagClaim> &claims() const { return claims_; }

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -24,14 +24,15 @@ namespace raksha::xform_to_datalog {
 
 namespace ir = raksha::ir;
 
-class ManifestDatalogFactsToStringTest :
-   public testing::TestWithParam<std::tuple<ManifestDatalogFacts, std::string>> {};
+class ManifestDatalogFactsToDatalogTest :
+   public testing::TestWithParam<std::tuple<ManifestDatalogFacts, std::string>>
+   {};
 
-TEST_P(ManifestDatalogFactsToStringTest, ManifestDatalogFactsToStringTest) {
+TEST_P(ManifestDatalogFactsToDatalogTest, ManifestDatalogFactsToDatalogTest) {
   const ManifestDatalogFacts &datalog_facts = std::get<0>(GetParam());
   const std::string &expected_result_string = std::get<1>(GetParam());
 
-  EXPECT_EQ(datalog_facts.ToString(), expected_result_string);
+  EXPECT_EQ(datalog_facts.ToDatalog(), expected_result_string);
 }
 
 static const ir::AccessPath kHandleH1AccessPath(
@@ -91,8 +92,9 @@ edge("recipe.particle.out", "recipe.h2").
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(ManifestDatalogFactsToStringTest, ManifestDatalogFactsToStringTest,
-                         testing::ValuesIn(datalog_facts_and_output_strings));
+INSTANTIATE_TEST_SUITE_P(
+    ManifestDatalogFactsToDatalogTest, ManifestDatalogFactsToDatalogTest,
+    testing::ValuesIn(datalog_facts_and_output_strings));
 
 // Create a manifest textproto to test constructing ManifestDatalogFacts from
 // a ManifestProto. The ParticleSpecs will be pretty simple, as we have
@@ -290,7 +292,7 @@ TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
   // failure than structured datalog facts.
   std::vector<std::string> claim_datalog_strings;
   for (const ir::TagClaim &claim : datalog_facts_.claims()) {
-    claim_datalog_strings.push_back(claim.ToString());
+    claim_datalog_strings.push_back(claim.ToDatalog());
   }
   EXPECT_THAT(claim_datalog_strings,
               testing::UnorderedElementsAreArray(kExpectedClaimStrings));
@@ -311,7 +313,7 @@ TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {
   // failure than structured datalog facts.
   std::vector<std::string> check_datalog_strings;
   for (const ir::TagCheck &check : datalog_facts_.checks()) {
-    check_datalog_strings.push_back(check.ToString());
+    check_datalog_strings.push_back(check.ToDatalog());
   }
   EXPECT_THAT(check_datalog_strings,
               testing::UnorderedElementsAreArray(kExpectedCheckStrings));
@@ -381,7 +383,7 @@ TEST_F(ParseBigManifestTest, ManifestProtoEdgesTest) {
   // failure than structured datalog facts.
   std::vector<std::string> edge_datalog_strings;
   for (const ir::Edge &edge : datalog_facts_.edges()) {
-    edge_datalog_strings.push_back(edge.ToString());
+    edge_datalog_strings.push_back(edge.ToDatalog());
   }
   EXPECT_THAT(edge_datalog_strings,
               testing::UnorderedElementsAreArray(kExpectedEdgeStrings));


### PR DESCRIPTION
This leaves structures below the level of a Datalog fact (such as
AccessPathSelectors) as ToString for now.