### PR TITLE
Create TagClaims for full range of Arcs tag claims.

### DIFF
--- a/src/ir/tag_annotation_on_access_path.h
+++ b/src/ir/tag_annotation_on_access_path.h
@@ -1,3 +1,19 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
 #ifndef SRC_IR_TAG_ANNOTATION_ON_ACCESS_PATH_SELECTORS_H_
 #define SRC_IR_TAG_ANNOTATION_ON_ACCESS_PATH_SELECTORS_H_
 
@@ -20,6 +36,14 @@ namespace raksha::ir {
 // ensure that the tag is present or not. In addition, the two have very
 // similar internal representation in the Arcs manifest protos, allowing us
 // to use the same code to create the two different structures.
+//
+// TODO(#138): The above comment is actually no longer fully true. While it
+//  remains the case that the protos that represent tag claims and checks
+//  have similar internal structure, that structure is parsed very
+//  differently, as claims allow only "and" and "not" predicates, while
+//  checks can check arbitrary boolean expressions on the presence of tags.
+//  Claim is already no longer relying upon this class; it should be
+//  eliminated when we fix #137.
 class TagAnnotationOnAccessPath {
  public:
   template<class T>

--- a/src/ir/tag_claim.cc
+++ b/src/ir/tag_claim.cc
@@ -1,0 +1,74 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#include "src/ir/tag_claim.h"
+
+namespace raksha::ir {
+
+std::vector<TagClaim> TagClaim::GetTagClaimsFromPredicate(
+    std::string claiming_particle_name,
+    AccessPath access_path,
+    const arcs::InformationFlowLabelProto_Predicate &predicate,
+    const bool in_negation) {
+  switch (predicate.predicate_case()) {
+    // Base case: if it is a label, construct a TagClaim with the given info.
+    case arcs::InformationFlowLabelProto_Predicate::kLabel: {
+      const arcs::InformationFlowLabelProto &label = predicate.label();
+      CHECK(label.has_semantic_tag())
+        << "semantic_tag field required on InformationFlowLabelProto.";
+      bool claim_tag_is_present = !in_negation;
+      return std::vector<TagClaim>{
+          TagClaim(
+              std::move(claiming_particle_name), std::move(access_path),
+              claim_tag_is_present, label.semantic_tag())};
+    }
+    case arcs::InformationFlowLabelProto_Predicate::kNot: {
+      CHECK(!in_negation) << "Double negation not allowed in Assume claim.";
+      arcs::InformationFlowLabelProto_Predicate_Not not_predicate =
+          predicate.not_();
+      CHECK(not_predicate.has_predicate())
+        << "Inner predicate is required in Not predicate in Assume.";
+      return GetTagClaimsFromPredicate(
+          std::move(claiming_particle_name), std::move(access_path),
+          not_predicate.predicate(), true/*in_negation*/);
+    }
+    case arcs::InformationFlowLabelProto_Predicate::kAnd: {
+      CHECK(!in_negation) << "Negated Ands not allowed in Assume claim.";
+      arcs::InformationFlowLabelProto_Predicate_And and_predicate =
+          predicate.and_();
+      CHECK(and_predicate.has_conjunct0())
+        << "And predicate missing required conjunct0 field.";
+      CHECK(and_predicate.has_conjunct1())
+        << "And predicate missing required conjunct1 field.";
+      std::vector<TagClaim> and_result_claims = GetTagClaimsFromPredicate(
+              claiming_particle_name, access_path, and_predicate.conjunct0(),
+              false/*in_negation*/);
+      std::vector<TagClaim> conjunct1_claims = GetTagClaimsFromPredicate(
+              claiming_particle_name, access_path, and_predicate.conjunct1(),
+              false/*in_negation*/);
+      and_result_claims.insert(
+          and_result_claims.end(),
+          std::make_move_iterator(conjunct1_claims.begin()),
+          std::make_move_iterator(conjunct1_claims.end()));
+      return and_result_claims;
+    }
+    default: {
+      LOG(FATAL) << "Found unexpected predicate kind in Assume claim proto.";
+    }
+  }
+}
+
+}  // namespace raksha::ir

--- a/src/ir/tag_claim.h
+++ b/src/ir/tag_claim.h
@@ -1,3 +1,19 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
 #ifndef SRC_IR_TAG_CLAIM_H_
 #define SRC_IR_TAG_CLAIM_H_
 
@@ -9,26 +25,40 @@
 
 namespace raksha::ir {
 
+// Represents a claim that adds or removes a single tag from a particular
+// access path.
 class TagClaim {
  public:
-  // Create a tag claim from an arcs Assume proto. Despite the fact
-  // that the access path indicated by a claim indicates a root, it's not
-  // rooted deeply enough for us; the root goes only to the particle spec name,
-  // whereas we'd like to go all the way to the recipe name. Therefore, the
-  // resulting TagClaim has a SpecAccessPathRoot.
-  static TagClaim CreateFromProto(
-      std::string claiming_particle_name,
-      const arcs::ClaimProto_Assume &assume_proto) {
-    return TagClaim(
-        std::move(claiming_particle_name),
-        TagAnnotationOnAccessPath::CreateFromProto(assume_proto, "Assume"));
+  // Create a list of TagClaims from an Assume proto. Each of these will be
+  // uninstantiated and thus rooted at the ParticleSpec.
+  static std::vector<TagClaim> CreateFromProto(
+    std::string claiming_particle_name,
+    const arcs::ClaimProto_Assume &assume_proto) {
+    CHECK(assume_proto.has_access_path())
+      << "Expected Assume message to have access_path field.";
+    const arcs::AccessPathProto &access_path_proto = assume_proto.access_path();
+    AccessPath access_path = proto::Decode(access_path_proto);
+    CHECK(assume_proto.has_predicate())
+      << "Expected Assume message to have predicate field.";
+    const arcs::InformationFlowLabelProto_Predicate &predicate =
+        assume_proto.predicate();
+
+    // Now that we have gathered the top-level information from the Assume
+    // proto, descend into the predicate to construct the list of claims.
+    return GetTagClaimsFromPredicate(
+        std::move(claiming_particle_name), std::move(access_path), predicate,
+        /*in_negation=*/false);
   }
 
   explicit TagClaim(
       std::string claiming_particle_name,
-      TagAnnotationOnAccessPath tag_annotation_on_access_path)
+      AccessPath access_path,
+      bool claim_tag_is_present,
+      std::string tag)
     : claiming_particle_name_(std::move(claiming_particle_name)),
-      tag_annotation_on_access_path_(std::move(tag_annotation_on_access_path))
+      access_path_(std::move(access_path)),
+      claim_tag_is_present_(claim_tag_is_present),
+      tag_(std::move(tag))
     {}
 
   // Return a TagClaim that is the same as *this, but with the root new_root.
@@ -36,7 +66,9 @@ class TagClaim {
   TagClaim Instantiate(AccessPathRoot new_root) const {
     return TagClaim(
         claiming_particle_name_,
-        tag_annotation_on_access_path_.Instantiate(std::move(new_root)));
+        access_path_.Instantiate(new_root),
+        claim_tag_is_present_,
+        tag_);
   }
 
   // Allow this TagClaim to participate in a bulk instantiation of multiple
@@ -46,35 +78,49 @@ class TagClaim {
           &instantiation_map) const {
     return TagClaim(
         claiming_particle_name_,
-        tag_annotation_on_access_path_.BulkInstantiate(instantiation_map));
+        access_path_.BulkInstantiate(instantiation_map),
+        claim_tag_is_present_,
+        tag_);
   }
 
   // Produce a string containing a datalog fact for this TagClaim.
   std::string ToDatalog() const {
-    constexpr absl::string_view kClaimHasTagFormat =
-        R"(claimHasTag("%s", "%s", "%s").)";
+    constexpr absl::string_view kClaimTagFormat =
+        R"(%s("%s", "%s", "%s").)";
+    absl::string_view relation_name =
+        (claim_tag_is_present_) ? "claimHasTag" : "saysDowngrades";
     return absl::StrFormat(
-        kClaimHasTagFormat,
-        claiming_particle_name_,
-        tag_annotation_on_access_path_.access_path().ToString(),
-        tag_annotation_on_access_path_.tag());
+        kClaimTagFormat, relation_name, claiming_particle_name_,
+        access_path_.ToString(), tag_);
   }
 
   bool operator==(const TagClaim &other) const {
     return
       (claiming_particle_name_ == other.claiming_particle_name_) &&
-      (tag_annotation_on_access_path_ == other.tag_annotation_on_access_path_);
+          (access_path_ == other.access_path_) &&
+          (claim_tag_is_present_ == other.claim_tag_is_present_) &&
+          (tag_ == other.tag_);
   }
 
  private:
+  // Helper function for CreateFromProto that descends recursively into
+  // predicate to gather all TagClaims contained within it.
+  static std::vector<TagClaim> GetTagClaimsFromPredicate(
+    std::string claiming_particle_name,
+    AccessPath access_path,
+    const arcs::InformationFlowLabelProto_Predicate &predicate,
+    const bool in_negation);
+
   // The name of the particle performing this claim. Important for connecting
   // the claim to a principal for authorization logic purposes.
   std::string claiming_particle_name_;
-  // Internally, we represent the data as a TagAnnotationOnAccessPath object.
-  // This allows us to share code with TagCheck. While TagCheck and TagClaim
-  // are semantically very different, they are very similar in their internal
-  // representation, both here and in Arcs manifest protos.
-  TagAnnotationOnAccessPath tag_annotation_on_access_path_;
+  // The access path upon which the claim is being made.
+  AccessPath access_path_;
+  // If true, we are claiming that the tag is present. If false, we are
+  // claiming that the tag is absent.
+  bool claim_tag_is_present_;
+  // The tag being claimed.
+  std::string tag_;
 };
 
 }  // namespace raksha::ir

--- a/src/xform_to_datalog/arcs_manifest_tree/particle_spec.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/particle_spec.cc
@@ -1,3 +1,19 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
 #include "src/xform_to_datalog/arcs_manifest_tree/particle_spec.h"
 
 namespace raksha::xform_to_datalog::arcs_manifest_tree {
@@ -29,8 +45,12 @@ ParticleSpec ParticleSpec::CreateFromProto(
         continue;
       }
       case arcs::ClaimProto::kAssume: {
-        tag_claims.push_back(
-            ir::TagClaim::CreateFromProto(name, claim.assume()));
+        std::vector<ir::TagClaim> current_assume_claims =
+            ir::TagClaim::CreateFromProto(name, claim.assume());
+        tag_claims.insert(
+            tag_claims.end(),
+            std::make_move_iterator(current_assume_claims.begin()),
+            std::make_move_iterator(current_assume_claims.end()));
         continue;
       }
       default: {

--- a/src/xform_to_datalog/arcs_manifest_tree/particle_spec_test.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/particle_spec_test.cc
@@ -1,3 +1,19 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
 #include "src/xform_to_datalog/arcs_manifest_tree/particle_spec.h"
 
 #include <google/protobuf/text_format.h>
@@ -462,18 +478,16 @@ claims: [ { assume: {
       .expected_claims = {
           ir::TagClaim(
               "PS2",
-              ir::TagAnnotationOnAccessPath(
-                  ir::AccessPath(
-                      kPs2HcHandleRoot, MakeSingleFieldSelectors("field1")),
-                      "tag1")
-              ),
+              ir::AccessPath(
+                  kPs2HcHandleRoot, MakeSingleFieldSelectors("field1")),
+              true,
+              "tag1"),
           ir::TagClaim(
               "PS2",
-              ir::TagAnnotationOnAccessPath(
-                  ir::AccessPath(
-                      kPs2Hc2HandleRoot, MakeSingleFieldSelectors("field2")),
-                      "tag2")
-              )
+              ir::AccessPath(
+                  kPs2Hc2HandleRoot, MakeSingleFieldSelectors("field2")),
+              true,
+              "tag2")
       },
       .expected_checks = { },
       .expected_edges = { }
@@ -566,14 +580,14 @@ TEST(BulkInstantiateTest, BulkInstantiateTest) {
       testing::UnorderedElementsAreArray({
         ir::TagClaim(
             "PS1",
-            ir::TagAnnotationOnAccessPath(ir::AccessPath(
-                p1_out_impl, MakeSingleFieldSelectors("field1")), "tag1")),
+            ir::AccessPath(p1_out_impl, MakeSingleFieldSelectors("field1")),
+            true,
+            "tag1"),
         ir::TagClaim(
             "PS1",
-            ir::TagAnnotationOnAccessPath(
-                ir::AccessPath(
-                    p1_in_out_impl,
-                    MakeSingleFieldSelectors("field2")), "tag2"))}));
+            ir::AccessPath(p1_in_out_impl, MakeSingleFieldSelectors("field2")),
+            true,
+            "tag2")}));
 
   ASSERT_THAT(
       instantiated_facts.checks,

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -51,13 +51,13 @@ INSTANTIATE_TEST_SUITE_P(
             ManifestDatalogFacts(
                 {ir::TagClaim(
                     "particle",
-                    ir::TagAnnotationOnAccessPath(
-                        ir::AccessPath(
-                            ir::AccessPathRoot(
-                                ir::HandleConnectionAccessPathRoot(
-                                    "recipe", "particle", "out")),
-                        ir::AccessPathSelectors()),
-                    "tag"))},
+                      ir::AccessPath(
+                          ir::AccessPathRoot(
+                              ir::HandleConnectionAccessPathRoot(
+                                  "recipe", "particle", "out")),
+                      ir::AccessPathSelectors()),
+                      true,
+                      "tag")},
                 {}, {}),
             R"(// GENERATED FILE, DO NOT EDIT!
 

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -68,9 +68,7 @@ static std::tuple<ManifestDatalogFacts, std::string>
 )" },
     { ManifestDatalogFacts(
         { ir::TagClaim(
-            "particle",
-            ir::TagAnnotationOnAccessPath(
-                kHandleConnectionOutAccessPath, "tag")) },
+            "particle", kHandleConnectionOutAccessPath, true, "tag") },
         { ir::TagCheck(ir::TagAnnotationOnAccessPath(
             kHandleConnectionInAccessPath, "tag2")) },
         { ir::Edge(kHandleH1AccessPath, kHandleConnectionInAccessPath),


### PR DESCRIPTION
Previously, our parsing of Manifest Assume protos could only handle
those claims that were simple introductions of a single tag. With this
commit, we now handle the full range of 'and' and 'not' predicates that
can occur in an Arcs tag claim.

Note that this uses the saysDowngrades relation for expressing negative
tag claims. I wonder whether this conflicts with @aferr's plan for this;
I can add a separate relation if that would be better.