### PR TITLE
    Dispute Example

### DIFF
--- a/rust/tools/authorization-logic/raksha_examples/VisionPipelineAuthLogic
+++ b/rust/tools/authorization-logic/raksha_examples/VisionPipelineAuthLogic
@@ -50,8 +50,16 @@
         isPrincipal(principalX).
 
     "LocalDevice" may("do_pure_computation", "raw_video_tag").
-    "LocalDevice" may("egress_to_shopping_service", "product_id_tag").
 
+    // "EndUser" opts-in to a policy about data egress.
+    // It delegates to this policy the right to decide what modules can egress
+    // any of "EndUser's" data.
+    "DataEgressPolicy1" canSay principalX may("egress_to_shopping_service", tagX) :-
+        isPrincipal(principalX), isTag(tagX).
+    // The EndUser also expresses a preference to this policy, which is 
+    // "allowEgress":
+    "EndUser" hasPrivacyPreference("allowEgress").
+        
     // Could also give different permissions to RemoteService for once it
     // has "product_id_tag".
 
@@ -63,6 +71,72 @@
     isPrincipal("ImageDetector").
     isPrincipal("ImageSelector").
     isPrincipal("ProductIdOutput").
+    isPrincipal("LocalDevice").
+}
+
+"ServiceProvider" says {
+    ownsTag("image_detection_model_tag").
+
+    // ServiceProvider also opts-in to "DataEgressPolicy1"
+    "DataEgressPolicy1" canSay principalX may("egress_to_shopping_service", tagX) :-
+        isPrincipal(principalX), isTag(tagX).
+    // ServiceProvider's preference is NOT to egress:
+    "ServiceProvider" hasPreference("disallowEgress").
+
+    // Delegates TPPR the ability to apply just the model tag anywhere
+    "ThirdPartyPrivacyReviewer" canSay hasTag(x, "image_detection_model_tag") :- 
+        isAccessPath(x).
+
+    // Delegate the right to claim that particles are "Local" to TPPR.
+    // (We can think of the principal "LocalDevice" as a group)
+    "ThirdPartyPrivacyReviewer" canSay principalX canActAs "LocalDevice" :-
+        isPrincipal(principalX).
+
+    // Give permission to do pure computation on any local device
+    "LocalDevice" may("do_pure_computation", "image_detection_model_tag").
+
+    // These are rules we should get rid of in the real thing.
+    // The universe relations probably don't need to be decentralized. We could
+    // have rules that populate a "centralized" universe and passes this 
+    // to all the principals. (Or there could be other ways to deal with this).
+    isPrincipal("VideoDataSource").
+    isPrincipal("ImageDetector").
+    isPrincipal("ImageSelector").
+    isPrincipal("ProductIdOutput").
+}
+
+
+"DataEgressPolicy1" says {
+    // Gathers preferences from both stakeholders:
+    "EndUser" canSay "EndUser" hasPreference(prefX) :-
+        isPreference(prefX).
+    "ServiceProvider" canSay "ServiceProvider" hasPreference(prefX) :-
+        isPreference(prefX).
+
+    // Egressing model data and video data is allowed EVEN if
+    // ServiceProvider says "no" as long as EndUser says "yes"
+    // (Both of these facts are used to make the same one decision about 
+    // egressing a handle that depends on both of these tags)
+    "ProductIdOutput" may("egress_to_shopping_service", "product_id_tag") :-
+        "EndUser" hasPreference("allowEgress").
+    "ProductIdOutput" may("egress_to_shopping_service", 
+        "image_detection_model_tag"). // Doesn't care about ServiceProvider pref
+}
+
+// Similar to policy 1, but we need agreement from BOTH parties:
+"DataEgressPolicy2" says {
+    // Gathers preferences from both stakeholders:
+    "EndUser" canSay "EndUser" hasPreference(prefX) :-
+        isPreference(prefX).
+    "ServiceProvider" canSay "ServiceProvider" hasPreference(prefX) :-
+        isPreference(prefX).
+
+    "ProductIdOutput" may("egress_to_shopping_service", "product_id_tag") :-
+        "EndUser" hasPreference("allowEgress").
+    "ProductIdOutput" may("egress_to_shopping_service",
+        "image_detection_model_tag") :-
+        // This policy DOES care about ServiceProvider's preference:
+        "ServiceProvider" hasPreference("allowEgress:).
 }
 
 "ThirdPartyPrivacyReviewer" says {
@@ -84,6 +158,7 @@
         isAccessPath(pathX).
 }
 
+
 // Maybe we want this part of the policy to sit closer to the particles
 // because sometimes relations will refer to path names ?
 // (We can ostensibly do this as long as we can write
@@ -93,16 +168,21 @@
 // but the "may"s still refer to the tags, and we figure out which tags to
 // get permissions about based on the taint analysis (for now both still 
 // operate on the tags).
-"ImageDetector" says "ImageDetector"
-    will("do_pure_computation", "raw_video_tag").
+//
+// Maybe it makes more sense if this speaker is TPPR
+"ImageDetector" says {
+    "ImageDetector" will("do_pure_computation", "id_sensor_data_packet").
+    "ImageDetector" will("do_pure_computation", "id_image_detection_model").
+}
 "ImageSelector" says {
-    "ImageSelector" will("do_pure_computation", "raw_video_tag").
+    "ImageSelector" will("do_pure_computation", "is_tracking_boxes").
     declassifies("is_select_image_id", "raw_video_tag").
     hasTag("is_select_image_id", "product_id_tag").
     objectSelected("EndUser", "is_selected_image_id").
 }
-"ProductIdOutput" says 
-    "ProductIdOutput" will("egress_to_shopping_service", "product_id_tag").
+"ProductIdOutput" says {
+    "ProductIdOutput" will("egress_to_shopping_service", "pa_product_id").
+}
 
 // Some queries to test this policy:
 video_is_local = query "EndUser" says   
@@ -136,10 +216,12 @@ local_can_do_computation = query "EndUser" says
 // taint of read handles: 
 //    taint(id_sensor_packet.camera_feed) = { "raw_video_tag" }
 //    taint(id_sensor_packet.video_resolution) = { }
-//    taint(id_image_detection_model) = { }
-// Usage:
-//    will("do_pure_computation", "raw_video_tag").
-//      Owner("raw_video_tag") = "EndUser"
+//    taint(id_image_detection_model) = { "image_detection_model_tag" }
+// usage:
+//    will("do_pure_computation", "id_sensor_data_packet").
+//    will("do_pure_computation", "id_image_detection_model")
+// owner:
+//    owner("raw_video_tag") = "EndUser"
 may_video_do_computation = query "EndUser" says 
     "ImageDetector" may("do_pure_computation", "raw_video_tag")?
 
@@ -148,10 +230,13 @@ may_video_do_computation = query "EndUser" says
 
 // Particle: ImageSelector
 // taint of read handles:
-//      taint(is_detection_boxes) = { "raw_video_tag" }
+//      taint(is_detection_boxes) = { "raw_video_tag",
+//          "image_detection_model_tag" }
 //      taint(is_user_selection_action) = { }
 // usage: 
 //      will("do_pure_computation", "raw_video_tag")
+//      will("do_pure_computation", "image_detection_model_tag")
+// owner
 may_selector_do_computation = query "EndUser" says
     "ImageSelector" may("do_pure_computation", "raw_video_tag")?
 


### PR DESCRIPTION
    This expands the vision pipeline example with two stakeholders
    that both own data that might be egressed. They have different
    preferences with how this "dispute" should be handled, but they
    both delegate to a policy that resolves this dispute. There are 
    different ways of writing how disputes should be handled.