### PR TITLE
Build  rust/tools/authorization-logic using bazel.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,3 +39,6 @@ jobs:
       # Verifies that Arcs manifest tests that we do not yet handle parse correctly.
       - name: Verify that disabled Arcs manifest tests build.
         run: bazel build //src/analysis/souffle/tests/arcs_manifest_tests_todo/...
+
+      - name: Verify that we can build authorization logic code with bazel
+        run: bazel build //rust/tools/authorization-logic:authorization_logic

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -180,3 +180,9 @@ load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 # TODO(#143): We need this specific repository for authorization logic.
 rust_repositories(version = "nightly", iso_date = "2021-07-01", edition="2018")
+
+#--------------------
+# Cargo Raze Crates
+#--------------------
+load("//third_party/cargo:crates.bzl", "raze_fetch_remote_crates")
+raze_fetch_remote_crates()

--- a/rust/tools/authorization-logic/BUILD
+++ b/rust/tools/authorization-logic/BUILD
@@ -1,0 +1,57 @@
+#-------------------------------------------------------------------------------
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------------------------
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_rust//rust:rust.bzl", "rust_binary")
+
+licenses(["notice"])
+
+rust_binary(
+    name = "authorization_logic",
+    srcs = [
+        "src/ast.rs",
+        "src/compilation_top_level.rs",
+        "src/main.rs",
+        "src/parsing/antlr_gen/authlogiclexer.rs",
+        "src/parsing/antlr_gen/authlogiclistener.rs",
+        "src/parsing/antlr_gen/authlogicparser.rs",
+        "src/parsing/antlr_gen/mod.rs",
+        "src/parsing/astconstructionvisitor.rs",
+        "src/parsing/mod.rs",
+        "src/signing/export_assertions.rs",
+        "src/signing/import_assertions.rs",
+        "src/signing/mod.rs",
+        "src/signing/tink_interface.rs",
+        "src/souffle/datalog_ir.rs",
+        "src/souffle/lowering_ast_datalog.rs",
+        "src/souffle/mod.rs",
+        "src/souffle/souffle_emitter.rs",
+        "src/souffle/souffle_interface.rs",
+        "src/test/mod.rs",
+        "src/test/test_claim_importing.rs",
+        "src/test/test_export_signatures.rs",
+        "src/test/test_queries.rs",
+        "src/test/test_signing.rs",
+    ],
+    deps = [
+        "//rust/tools/authorization-logic/cargo:antlr_rust",
+        "//rust/tools/authorization-logic/cargo:bincode",
+        "//rust/tools/authorization-logic/cargo:serde",
+        "//rust/tools/authorization-logic/cargo:tink_core",
+        "//rust/tools/authorization-logic/cargo:tink_signature",
+    ],
+)

--- a/rust/tools/authorization-logic/BUILD
+++ b/rust/tools/authorization-logic/BUILD
@@ -36,7 +36,7 @@ genrule(
     srcs = ["src/parsing/AuthLogic.g4"],
     tools = [
         ":antlr4rust_jar",
-	":antlr_gen_mod_rs",
+        ":antlr_gen_mod_rs",
         "@bazel_tools//tools/jdk:current_java_runtime",
         "@bazel_tools//tools/jdk:java",
     ],
@@ -46,11 +46,11 @@ genrule(
        "antlr_gen/authlogicparser.rs",
        "antlr_gen/lib.rs",
     ],
-    cmd = "pwd; $(execpath @bazel_tools//tools/jdk:java) " +
+    cmd = "$(execpath @bazel_tools//tools/jdk:java) " +
           "-jar $(location :antlr4rust_jar) " +
-	  "-Dlanguage=Rust -Xexact-output-dir -o $(RULEDIR)/antlr_gen $< ;" +
-	  "echo \"#![feature(try_blocks)]\" >  $(RULEDIR)/antlr_gen/lib.rs ;" +
-	  "cat $(location :antlr_gen_mod_rs) >> $(RULEDIR)/antlr_gen/lib.rs"
+          "-Dlanguage=Rust -Xexact-output-dir -o $(RULEDIR)/antlr_gen $< ;" +
+          "echo \"#![feature(try_blocks)]\" >  $(RULEDIR)/antlr_gen/lib.rs ;" +
+          "cat $(location :antlr_gen_mod_rs) >> $(RULEDIR)/antlr_gen/lib.rs"
 )
 
 rust_library(
@@ -88,7 +88,7 @@ rust_binary(
         "--cfg=feature=\"bazel_build\""
     ],
     deps = [
-	":antlr_gen",
+        ":antlr_gen",
         "//rust/tools/authorization-logic/cargo:antlr_rust",
         "//rust/tools/authorization-logic/cargo:bincode",
         "//rust/tools/authorization-logic/cargo:serde",

--- a/rust/tools/authorization-logic/BUILD
+++ b/rust/tools/authorization-logic/BUILD
@@ -16,9 +16,50 @@
 #-------------------------------------------------------------------------------
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:rust.bzl", "rust_binary", "rust_library")
 
 licenses(["notice"])
+
+filegroup(
+    name = "antlr4rust_jar",
+    srcs = ["third_party/antlr4-rust/antlr4rust.jar"]
+)
+
+filegroup(
+    name = "antlr_gen_mod_rs",
+    srcs = ["src/parsing/antlr_gen/mod.rs"]
+)
+
+# Generate the parsing-related files using antlr4rust
+genrule(
+    name = "antlr_gen_srcs",
+    srcs = ["src/parsing/AuthLogic.g4"],
+    tools = [
+        ":antlr4rust_jar",
+	":antlr_gen_mod_rs",
+        "@bazel_tools//tools/jdk:current_java_runtime",
+        "@bazel_tools//tools/jdk:java",
+    ],
+    outs = [
+       "antlr_gen/authlogiclexer.rs",
+       "antlr_gen/authlogiclistener.rs",
+       "antlr_gen/authlogicparser.rs",
+       "antlr_gen/lib.rs",
+    ],
+    cmd = "pwd; $(execpath @bazel_tools//tools/jdk:java) " +
+          "-jar $(location :antlr4rust_jar) " +
+	  "-Dlanguage=Rust -Xexact-output-dir -o $(RULEDIR)/antlr_gen $< ;" +
+	  "echo \"#![feature(try_blocks)]\" >  $(RULEDIR)/antlr_gen/lib.rs ;" +
+	  "cat $(location :antlr_gen_mod_rs) >> $(RULEDIR)/antlr_gen/lib.rs"
+)
+
+rust_library(
+    name = "antlr_gen",
+    srcs = [":antlr_gen_srcs"],
+    deps = [
+        "//rust/tools/authorization-logic/cargo:antlr_rust",
+    ]
+)
 
 rust_binary(
     name = "authorization_logic",
@@ -26,10 +67,6 @@ rust_binary(
         "src/ast.rs",
         "src/compilation_top_level.rs",
         "src/main.rs",
-        "src/parsing/antlr_gen/authlogiclexer.rs",
-        "src/parsing/antlr_gen/authlogiclistener.rs",
-        "src/parsing/antlr_gen/authlogicparser.rs",
-        "src/parsing/antlr_gen/mod.rs",
         "src/parsing/astconstructionvisitor.rs",
         "src/parsing/mod.rs",
         "src/signing/export_assertions.rs",
@@ -47,7 +84,11 @@ rust_binary(
         "src/test/test_queries.rs",
         "src/test/test_signing.rs",
     ],
+    rustc_flags = [
+        "--cfg=feature=\"bazel_build\""
+    ],
     deps = [
+	":antlr_gen",
         "//rust/tools/authorization-logic/cargo:antlr_rust",
         "//rust/tools/authorization-logic/cargo:bincode",
         "//rust/tools/authorization-logic/cargo:serde",

--- a/rust/tools/authorization-logic/Cargo.toml
+++ b/rust/tools/authorization-logic/Cargo.toml
@@ -13,3 +13,60 @@ tink-signature = "^0.2"
 bincode = "^1.1.4"
 serde = "^1.0"
 
+[package.metadata.raze]
+# The path at which to write output files.
+#
+# `cargo raze` will generate Bazel-compatible BUILD files into this path.
+# This can either be a relative path (e.g. "foo/bar"), relative to this
+# Cargo.toml file; or relative to the Bazel workspace root (e.g. "//foo/bar").
+workspace_path = "//third_party/cargo"
+
+output_buildfile_suffix = "BUILD.bazel"
+default_gen_buildrs = false
+
+# This causes aliases for dependencies to be rendered in the BUILD
+# file located next to this `Cargo.toml` file.
+# package_aliases_dir = "."
+
+# The set of targets to generate BUILD rules for.
+targets = [
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+]
+
+# The two acceptable options are "Remote" and "Vendored" which
+# is used to indicate whether the user is using a non-vendored or
+# vendored set of dependencies.
+genmode = "Remote"
+
+[package.metadata.raze.crates.serde.'1.0.26']
+gen_buildrs = true
+
+[package.metadata.raze.crates.tink-proto.'0.2.0']
+gen_buildrs = true
+build_data_dependencies = ["@com_google_protobuf//:protoc"]
+
+[package.metadata.raze.crates.tink-proto.'0.2.0'.buildrs_additional_environment_variables]
+PROTOC = "$(execpath @com_google_protobuf//:protoc)"
+
+[package.metadata.raze.crates.typenum.'*']
+gen_buildrs = true
+additional_flags = [
+    "--cfg=feature=\\\"force_unix_path_separator\\\""
+]
+
+[package.metadata.raze.crates.indexmap.'1.6.0']
+gen_buildrs = true
+additional_flags = [
+    "--cfg=has_std",
+]
+
+[package.metadata.raze.crates.proc-macro2.'1.0.26']
+additional_flags = [
+    "--cfg=use_proc_macro",
+]
+
+[package.metadata.raze.crates.prost-build.'*']
+gen_buildrs = true
+build_data_dependencies = ["@com_google_protobuf//:protoc"]

--- a/rust/tools/authorization-logic/build.rs
+++ b/rust/tools/authorization-logic/build.rs
@@ -22,13 +22,13 @@ use std::{env, error::Error, process::Command};
 fn run_antlr_on(grammar_file: &str, antlr_path: &str) -> Result<(), Box<dyn Error>> {
     let parsing_subdir = env::current_dir().unwrap().join("src/parsing");
     let full_file = grammar_file.to_owned() + ".g4";
-
+    let java_bin = env::var("JAVA").unwrap_or("java".to_string());
     // When debugging either this build script or the antlr, code it may be
     // useful to build with
     // 'cargo build -vv &> output file'
     // because cargo omits errors generated from executed commands otherwise
 
-    Command::new("java")
+    Command::new(java_bin)
         .current_dir(parsing_subdir)
         .arg("-jar")
         .arg(antlr_path)

--- a/rust/tools/authorization-logic/cargo/BUILD.bazel
+++ b/rust/tools/authorization-logic/cargo/BUILD.bazel
@@ -1,0 +1,66 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+licenses([
+    "notice",  # See individual crates for specific licenses
+])
+
+# Aliased targets
+alias(
+    name = "antlr_rust",
+    actual = "@raze__antlr_rust__0_2_0//:antlr_rust",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "bincode",
+    actual = "@raze__bincode__1_3_3//:bincode",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde",
+    actual = "@raze__serde__1_0_126//:serde",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "tink_core",
+    actual = "@raze__tink_core__0_2_0//:tink_core",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "tink_signature",
+    actual = "@raze__tink_signature__0_2_0//:tink_signature",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+# Export file for Stardoc support
+exports_files(
+    [
+        "crates.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/rust/tools/authorization-logic/src/parsing/astconstructionvisitor.rs
+++ b/rust/tools/authorization-logic/src/parsing/astconstructionvisitor.rs
@@ -16,8 +16,16 @@
 
 use crate::{
     ast::*,
+};
+
+#[cfg(feature = "bazel_build")]
+use antlr_gen::{authlogiclexer::*, authlogicparser::*};
+
+#[cfg(not(feature = "bazel_build"))]
+use crate::{
     parsing::antlr_gen::{authlogiclexer::*, authlogicparser::*},
 };
+
 use antlr_rust::{common_token_stream::CommonTokenStream, tree::ParseTree, InputStream};
 
 /// This function produces an abstract syntax tree (AST) rooted with a program node when given the

--- a/rust/tools/authorization-logic/src/parsing/mod.rs
+++ b/rust/tools/authorization-logic/src/parsing/mod.rs
@@ -14,5 +14,7 @@
  * limitations under the License.
  */
 
+#[cfg(not(feature = "bazel_build"))]
 mod antlr_gen;
+
 pub mod astconstructionvisitor;

--- a/third_party/cargo/BUILD.bazel
+++ b/third_party/cargo/BUILD.bazel
@@ -1,0 +1,14 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# Export file for Stardoc support
+exports_files(
+    [
+        "crates.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -1,0 +1,1062 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")  # buildifier: disable=load
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")  # buildifier: disable=load
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: disable=load
+
+def raze_fetch_remote_crates():
+    """This function defines a collection of repos and should be called in a WORKSPACE file"""
+    maybe(
+        http_archive,
+        name = "raze__antlr_rust__0_2_0",
+        url = "https://crates.io/api/v1/crates/antlr-rust/0.2.0/download",
+        type = "tar.gz",
+        sha256 = "31cef0bab9c69cb4edd4764cd227b0db357a5634ad5a9200f9fb0a8d32e50947",
+        strip_prefix = "antlr-rust-0.2.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.antlr-rust-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__anyhow__1_0_40",
+        url = "https://crates.io/api/v1/crates/anyhow/1.0.40/download",
+        type = "tar.gz",
+        sha256 = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b",
+        strip_prefix = "anyhow-1.0.40",
+        build_file = Label("//third_party/cargo/remote:BUILD.anyhow-1.0.40.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__autocfg__1_0_1",
+        url = "https://crates.io/api/v1/crates/autocfg/1.0.1/download",
+        type = "tar.gz",
+        sha256 = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a",
+        strip_prefix = "autocfg-1.0.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.autocfg-1.0.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__base64__0_13_0",
+        url = "https://crates.io/api/v1/crates/base64/0.13.0/download",
+        type = "tar.gz",
+        sha256 = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd",
+        strip_prefix = "base64-0.13.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.base64-0.13.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__better_any__0_1_1",
+        url = "https://crates.io/api/v1/crates/better_any/0.1.1/download",
+        type = "tar.gz",
+        sha256 = "b359aebd937c17c725e19efcb661200883f04c49c53e7132224dac26da39d4a0",
+        strip_prefix = "better_any-0.1.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.better_any-0.1.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__better_typeid_derive__0_1_1",
+        url = "https://crates.io/api/v1/crates/better_typeid_derive/0.1.1/download",
+        type = "tar.gz",
+        sha256 = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3",
+        strip_prefix = "better_typeid_derive-0.1.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.better_typeid_derive-0.1.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__bincode__1_3_3",
+        url = "https://crates.io/api/v1/crates/bincode/1.3.3/download",
+        type = "tar.gz",
+        sha256 = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad",
+        strip_prefix = "bincode-1.3.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.bincode-1.3.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__bit_set__0_5_2",
+        url = "https://crates.io/api/v1/crates/bit-set/0.5.2/download",
+        type = "tar.gz",
+        sha256 = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de",
+        strip_prefix = "bit-set-0.5.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.bit-set-0.5.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__bit_vec__0_6_3",
+        url = "https://crates.io/api/v1/crates/bit-vec/0.6.3/download",
+        type = "tar.gz",
+        sha256 = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb",
+        strip_prefix = "bit-vec-0.6.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.bit-vec-0.6.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__bitflags__1_2_1",
+        url = "https://crates.io/api/v1/crates/bitflags/1.2.1/download",
+        type = "tar.gz",
+        sha256 = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693",
+        strip_prefix = "bitflags-1.2.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.bitflags-1.2.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__bitvec__0_20_4",
+        url = "https://crates.io/api/v1/crates/bitvec/0.20.4/download",
+        type = "tar.gz",
+        sha256 = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848",
+        strip_prefix = "bitvec-0.20.4",
+        build_file = Label("//third_party/cargo/remote:BUILD.bitvec-0.20.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__block_buffer__0_9_0",
+        url = "https://crates.io/api/v1/crates/block-buffer/0.9.0/download",
+        type = "tar.gz",
+        sha256 = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4",
+        strip_prefix = "block-buffer-0.9.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.block-buffer-0.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__byteorder__1_4_3",
+        url = "https://crates.io/api/v1/crates/byteorder/1.4.3/download",
+        type = "tar.gz",
+        sha256 = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
+        strip_prefix = "byteorder-1.4.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.byteorder-1.4.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__bytes__1_0_1",
+        url = "https://crates.io/api/v1/crates/bytes/1.0.1/download",
+        type = "tar.gz",
+        sha256 = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040",
+        strip_prefix = "bytes-1.0.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.bytes-1.0.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__cfg_if__1_0_0",
+        url = "https://crates.io/api/v1/crates/cfg-if/1.0.0/download",
+        type = "tar.gz",
+        sha256 = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        strip_prefix = "cfg-if-1.0.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.cfg-if-1.0.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__const_oid__0_5_2",
+        url = "https://crates.io/api/v1/crates/const-oid/0.5.2/download",
+        type = "tar.gz",
+        sha256 = "279bc8fc53f788a75c7804af68237d1fce02cde1e275a886a4b320604dc2aeda",
+        strip_prefix = "const-oid-0.5.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.const-oid-0.5.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__cpufeatures__0_1_4",
+        url = "https://crates.io/api/v1/crates/cpufeatures/0.1.4/download",
+        type = "tar.gz",
+        sha256 = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8",
+        strip_prefix = "cpufeatures-0.1.4",
+        build_file = Label("//third_party/cargo/remote:BUILD.cpufeatures-0.1.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__crypto_mac__0_11_0",
+        url = "https://crates.io/api/v1/crates/crypto-mac/0.11.0/download",
+        type = "tar.gz",
+        sha256 = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e",
+        strip_prefix = "crypto-mac-0.11.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.crypto-mac-0.11.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__curve25519_dalek__3_1_0",
+        url = "https://crates.io/api/v1/crates/curve25519-dalek/3.1.0/download",
+        type = "tar.gz",
+        sha256 = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3",
+        strip_prefix = "curve25519-dalek-3.1.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.curve25519-dalek-3.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__der__0_3_5",
+        url = "https://crates.io/api/v1/crates/der/0.3.5/download",
+        type = "tar.gz",
+        sha256 = "2eeb9d92785d1facb50567852ce75d0858630630e7eabea59cf7eb7474051087",
+        strip_prefix = "der-0.3.5",
+        build_file = Label("//third_party/cargo/remote:BUILD.der-0.3.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__digest__0_9_0",
+        url = "https://crates.io/api/v1/crates/digest/0.9.0/download",
+        type = "tar.gz",
+        sha256 = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066",
+        strip_prefix = "digest-0.9.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.digest-0.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ecdsa__0_11_1",
+        url = "https://crates.io/api/v1/crates/ecdsa/0.11.1/download",
+        type = "tar.gz",
+        sha256 = "34d33b390ab82f2e1481e331dbd0530895640179d2128ef9a79cc690b78d1eba",
+        strip_prefix = "ecdsa-0.11.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.ecdsa-0.11.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ed25519__1_1_1",
+        url = "https://crates.io/api/v1/crates/ed25519/1.1.1/download",
+        type = "tar.gz",
+        sha256 = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6",
+        strip_prefix = "ed25519-1.1.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.ed25519-1.1.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ed25519_dalek__1_0_1",
+        url = "https://crates.io/api/v1/crates/ed25519-dalek/1.0.1/download",
+        type = "tar.gz",
+        sha256 = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d",
+        strip_prefix = "ed25519-dalek-1.0.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.ed25519-dalek-1.0.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__either__1_6_1",
+        url = "https://crates.io/api/v1/crates/either/1.6.1/download",
+        type = "tar.gz",
+        sha256 = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457",
+        strip_prefix = "either-1.6.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.either-1.6.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__elliptic_curve__0_9_12",
+        url = "https://crates.io/api/v1/crates/elliptic-curve/0.9.12/download",
+        type = "tar.gz",
+        sha256 = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005",
+        strip_prefix = "elliptic-curve-0.9.12",
+        build_file = Label("//third_party/cargo/remote:BUILD.elliptic-curve-0.9.12.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ff__0_9_0",
+        url = "https://crates.io/api/v1/crates/ff/0.9.0/download",
+        type = "tar.gz",
+        sha256 = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe",
+        strip_prefix = "ff-0.9.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.ff-0.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__fixedbitset__0_2_0",
+        url = "https://crates.io/api/v1/crates/fixedbitset/0.2.0/download",
+        type = "tar.gz",
+        sha256 = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d",
+        strip_prefix = "fixedbitset-0.2.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.fixedbitset-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__funty__1_1_0",
+        url = "https://crates.io/api/v1/crates/funty/1.1.0/download",
+        type = "tar.gz",
+        sha256 = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7",
+        strip_prefix = "funty-1.1.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.funty-1.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__generic_array__0_14_4",
+        url = "https://crates.io/api/v1/crates/generic-array/0.14.4/download",
+        type = "tar.gz",
+        sha256 = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817",
+        strip_prefix = "generic-array-0.14.4",
+        build_file = Label("//third_party/cargo/remote:BUILD.generic-array-0.14.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__getrandom__0_1_16",
+        url = "https://crates.io/api/v1/crates/getrandom/0.1.16/download",
+        type = "tar.gz",
+        sha256 = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce",
+        strip_prefix = "getrandom-0.1.16",
+        build_file = Label("//third_party/cargo/remote:BUILD.getrandom-0.1.16.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__getrandom__0_2_3",
+        url = "https://crates.io/api/v1/crates/getrandom/0.2.3/download",
+        type = "tar.gz",
+        sha256 = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753",
+        strip_prefix = "getrandom-0.2.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.getrandom-0.2.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__group__0_9_0",
+        url = "https://crates.io/api/v1/crates/group/0.9.0/download",
+        type = "tar.gz",
+        sha256 = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8",
+        strip_prefix = "group-0.9.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.group-0.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__hashbrown__0_9_1",
+        url = "https://crates.io/api/v1/crates/hashbrown/0.9.1/download",
+        type = "tar.gz",
+        sha256 = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04",
+        strip_prefix = "hashbrown-0.9.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.hashbrown-0.9.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__heck__0_3_2",
+        url = "https://crates.io/api/v1/crates/heck/0.3.2/download",
+        type = "tar.gz",
+        sha256 = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac",
+        strip_prefix = "heck-0.3.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.heck-0.3.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__hkdf__0_11_0",
+        url = "https://crates.io/api/v1/crates/hkdf/0.11.0/download",
+        type = "tar.gz",
+        sha256 = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b",
+        strip_prefix = "hkdf-0.11.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.hkdf-0.11.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__hmac__0_11_0",
+        url = "https://crates.io/api/v1/crates/hmac/0.11.0/download",
+        type = "tar.gz",
+        sha256 = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b",
+        strip_prefix = "hmac-0.11.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.hmac-0.11.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__indexmap__1_6_2",
+        url = "https://crates.io/api/v1/crates/indexmap/1.6.2/download",
+        type = "tar.gz",
+        sha256 = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3",
+        strip_prefix = "indexmap-1.6.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.indexmap-1.6.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__instant__0_1_9",
+        url = "https://crates.io/api/v1/crates/instant/0.1.9/download",
+        type = "tar.gz",
+        sha256 = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec",
+        strip_prefix = "instant-0.1.9",
+        build_file = Label("//third_party/cargo/remote:BUILD.instant-0.1.9.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__itertools__0_9_0",
+        url = "https://crates.io/api/v1/crates/itertools/0.9.0/download",
+        type = "tar.gz",
+        sha256 = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b",
+        strip_prefix = "itertools-0.9.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.itertools-0.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__itoa__0_4_7",
+        url = "https://crates.io/api/v1/crates/itoa/0.4.7/download",
+        type = "tar.gz",
+        sha256 = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736",
+        strip_prefix = "itoa-0.4.7",
+        build_file = Label("//third_party/cargo/remote:BUILD.itoa-0.4.7.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__lazy_static__1_4_0",
+        url = "https://crates.io/api/v1/crates/lazy_static/1.4.0/download",
+        type = "tar.gz",
+        sha256 = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+        strip_prefix = "lazy_static-1.4.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.lazy_static-1.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__libc__0_2_93",
+        url = "https://crates.io/api/v1/crates/libc/0.2.93/download",
+        type = "tar.gz",
+        sha256 = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41",
+        strip_prefix = "libc-0.2.93",
+        build_file = Label("//third_party/cargo/remote:BUILD.libc-0.2.93.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__lock_api__0_4_3",
+        url = "https://crates.io/api/v1/crates/lock_api/0.4.3/download",
+        type = "tar.gz",
+        sha256 = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176",
+        strip_prefix = "lock_api-0.4.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.lock_api-0.4.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__log__0_4_14",
+        url = "https://crates.io/api/v1/crates/log/0.4.14/download",
+        type = "tar.gz",
+        sha256 = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710",
+        strip_prefix = "log-0.4.14",
+        build_file = Label("//third_party/cargo/remote:BUILD.log-0.4.14.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__multimap__0_8_3",
+        url = "https://crates.io/api/v1/crates/multimap/0.8.3/download",
+        type = "tar.gz",
+        sha256 = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a",
+        strip_prefix = "multimap-0.8.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.multimap-0.8.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__murmur3__0_4_1",
+        url = "https://crates.io/api/v1/crates/murmur3/0.4.1/download",
+        type = "tar.gz",
+        sha256 = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c",
+        strip_prefix = "murmur3-0.4.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.murmur3-0.4.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__once_cell__1_7_2",
+        url = "https://crates.io/api/v1/crates/once_cell/1.7.2/download",
+        type = "tar.gz",
+        sha256 = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3",
+        strip_prefix = "once_cell-1.7.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.once_cell-1.7.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__opaque_debug__0_3_0",
+        url = "https://crates.io/api/v1/crates/opaque-debug/0.3.0/download",
+        type = "tar.gz",
+        sha256 = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5",
+        strip_prefix = "opaque-debug-0.3.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.opaque-debug-0.3.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__p256__0_8_1",
+        url = "https://crates.io/api/v1/crates/p256/0.8.1/download",
+        type = "tar.gz",
+        sha256 = "2f05f5287453297c4c16af5e2b04df8fd2a3008d70f252729650bc6d7ace5844",
+        strip_prefix = "p256-0.8.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.p256-0.8.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__parking_lot__0_11_1",
+        url = "https://crates.io/api/v1/crates/parking_lot/0.11.1/download",
+        type = "tar.gz",
+        sha256 = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb",
+        strip_prefix = "parking_lot-0.11.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.parking_lot-0.11.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__parking_lot_core__0_8_3",
+        url = "https://crates.io/api/v1/crates/parking_lot_core/0.8.3/download",
+        type = "tar.gz",
+        sha256 = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018",
+        strip_prefix = "parking_lot_core-0.8.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.parking_lot_core-0.8.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__petgraph__0_5_1",
+        url = "https://crates.io/api/v1/crates/petgraph/0.5.1/download",
+        type = "tar.gz",
+        sha256 = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7",
+        strip_prefix = "petgraph-0.5.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.petgraph-0.5.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__pkcs8__0_6_1",
+        url = "https://crates.io/api/v1/crates/pkcs8/0.6.1/download",
+        type = "tar.gz",
+        sha256 = "c9c2f795bc591cb3384cb64082a578b89207ac92bb89c9d98c1ea2ace7cd8110",
+        strip_prefix = "pkcs8-0.6.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.pkcs8-0.6.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ppv_lite86__0_2_10",
+        url = "https://crates.io/api/v1/crates/ppv-lite86/0.2.10/download",
+        type = "tar.gz",
+        sha256 = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857",
+        strip_prefix = "ppv-lite86-0.2.10",
+        build_file = Label("//third_party/cargo/remote:BUILD.ppv-lite86-0.2.10.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__proc_macro2__1_0_26",
+        url = "https://crates.io/api/v1/crates/proc-macro2/1.0.26/download",
+        type = "tar.gz",
+        sha256 = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec",
+        strip_prefix = "proc-macro2-1.0.26",
+        build_file = Label("//third_party/cargo/remote:BUILD.proc-macro2-1.0.26.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__prost__0_7_0",
+        url = "https://crates.io/api/v1/crates/prost/0.7.0/download",
+        type = "tar.gz",
+        sha256 = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2",
+        strip_prefix = "prost-0.7.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.prost-0.7.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__prost_build__0_7_0",
+        url = "https://crates.io/api/v1/crates/prost-build/0.7.0/download",
+        type = "tar.gz",
+        sha256 = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3",
+        strip_prefix = "prost-build-0.7.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.prost-build-0.7.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__prost_derive__0_7_0",
+        url = "https://crates.io/api/v1/crates/prost-derive/0.7.0/download",
+        type = "tar.gz",
+        sha256 = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4",
+        strip_prefix = "prost-derive-0.7.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.prost-derive-0.7.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__prost_types__0_7_0",
+        url = "https://crates.io/api/v1/crates/prost-types/0.7.0/download",
+        type = "tar.gz",
+        sha256 = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb",
+        strip_prefix = "prost-types-0.7.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.prost-types-0.7.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__quote__1_0_9",
+        url = "https://crates.io/api/v1/crates/quote/1.0.9/download",
+        type = "tar.gz",
+        sha256 = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7",
+        strip_prefix = "quote-1.0.9",
+        build_file = Label("//third_party/cargo/remote:BUILD.quote-1.0.9.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__radium__0_6_2",
+        url = "https://crates.io/api/v1/crates/radium/0.6.2/download",
+        type = "tar.gz",
+        sha256 = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb",
+        strip_prefix = "radium-0.6.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.radium-0.6.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand__0_7_3",
+        url = "https://crates.io/api/v1/crates/rand/0.7.3/download",
+        type = "tar.gz",
+        sha256 = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03",
+        strip_prefix = "rand-0.7.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand-0.7.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand__0_8_3",
+        url = "https://crates.io/api/v1/crates/rand/0.8.3/download",
+        type = "tar.gz",
+        sha256 = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e",
+        strip_prefix = "rand-0.8.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand-0.8.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_chacha__0_2_2",
+        url = "https://crates.io/api/v1/crates/rand_chacha/0.2.2/download",
+        type = "tar.gz",
+        sha256 = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402",
+        strip_prefix = "rand_chacha-0.2.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand_chacha-0.2.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_chacha__0_3_0",
+        url = "https://crates.io/api/v1/crates/rand_chacha/0.3.0/download",
+        type = "tar.gz",
+        sha256 = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d",
+        strip_prefix = "rand_chacha-0.3.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand_chacha-0.3.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_core__0_5_1",
+        url = "https://crates.io/api/v1/crates/rand_core/0.5.1/download",
+        type = "tar.gz",
+        sha256 = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19",
+        strip_prefix = "rand_core-0.5.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand_core-0.5.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_core__0_6_2",
+        url = "https://crates.io/api/v1/crates/rand_core/0.6.2/download",
+        type = "tar.gz",
+        sha256 = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7",
+        strip_prefix = "rand_core-0.6.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand_core-0.6.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_hc__0_2_0",
+        url = "https://crates.io/api/v1/crates/rand_hc/0.2.0/download",
+        type = "tar.gz",
+        sha256 = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c",
+        strip_prefix = "rand_hc-0.2.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand_hc-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_hc__0_3_0",
+        url = "https://crates.io/api/v1/crates/rand_hc/0.3.0/download",
+        type = "tar.gz",
+        sha256 = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73",
+        strip_prefix = "rand_hc-0.3.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand_hc-0.3.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__redox_syscall__0_2_6",
+        url = "https://crates.io/api/v1/crates/redox_syscall/0.2.6/download",
+        type = "tar.gz",
+        sha256 = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041",
+        strip_prefix = "redox_syscall-0.2.6",
+        build_file = Label("//third_party/cargo/remote:BUILD.redox_syscall-0.2.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__remove_dir_all__0_5_3",
+        url = "https://crates.io/api/v1/crates/remove_dir_all/0.5.3/download",
+        type = "tar.gz",
+        sha256 = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7",
+        strip_prefix = "remove_dir_all-0.5.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.remove_dir_all-0.5.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ryu__1_0_5",
+        url = "https://crates.io/api/v1/crates/ryu/1.0.5/download",
+        type = "tar.gz",
+        sha256 = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e",
+        strip_prefix = "ryu-1.0.5",
+        build_file = Label("//third_party/cargo/remote:BUILD.ryu-1.0.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__scopeguard__1_1_0",
+        url = "https://crates.io/api/v1/crates/scopeguard/1.1.0/download",
+        type = "tar.gz",
+        sha256 = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+        strip_prefix = "scopeguard-1.1.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.scopeguard-1.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__serde__1_0_126",
+        url = "https://crates.io/api/v1/crates/serde/1.0.126/download",
+        type = "tar.gz",
+        sha256 = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03",
+        strip_prefix = "serde-1.0.126",
+        build_file = Label("//third_party/cargo/remote:BUILD.serde-1.0.126.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__serde_derive__1_0_126",
+        url = "https://crates.io/api/v1/crates/serde_derive/1.0.126/download",
+        type = "tar.gz",
+        sha256 = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43",
+        strip_prefix = "serde_derive-1.0.126",
+        build_file = Label("//third_party/cargo/remote:BUILD.serde_derive-1.0.126.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__serde_json__1_0_64",
+        url = "https://crates.io/api/v1/crates/serde_json/1.0.64/download",
+        type = "tar.gz",
+        sha256 = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79",
+        strip_prefix = "serde_json-1.0.64",
+        build_file = Label("//third_party/cargo/remote:BUILD.serde_json-1.0.64.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__sha_1__0_9_6",
+        url = "https://crates.io/api/v1/crates/sha-1/0.9.6/download",
+        type = "tar.gz",
+        sha256 = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16",
+        strip_prefix = "sha-1-0.9.6",
+        build_file = Label("//third_party/cargo/remote:BUILD.sha-1-0.9.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__sha2__0_9_5",
+        url = "https://crates.io/api/v1/crates/sha2/0.9.5/download",
+        type = "tar.gz",
+        sha256 = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12",
+        strip_prefix = "sha2-0.9.5",
+        build_file = Label("//third_party/cargo/remote:BUILD.sha2-0.9.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__signature__1_3_0",
+        url = "https://crates.io/api/v1/crates/signature/1.3.0/download",
+        type = "tar.gz",
+        sha256 = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68",
+        strip_prefix = "signature-1.3.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.signature-1.3.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__smallvec__1_6_1",
+        url = "https://crates.io/api/v1/crates/smallvec/1.6.1/download",
+        type = "tar.gz",
+        sha256 = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e",
+        strip_prefix = "smallvec-1.6.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.smallvec-1.6.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__spki__0_3_0",
+        url = "https://crates.io/api/v1/crates/spki/0.3.0/download",
+        type = "tar.gz",
+        sha256 = "9dae7e047abc519c96350e9484a96c6bf1492348af912fd3446dd2dc323f6268",
+        strip_prefix = "spki-0.3.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.spki-0.3.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__subtle__2_4_0",
+        url = "https://crates.io/api/v1/crates/subtle/2.4.0/download",
+        type = "tar.gz",
+        sha256 = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2",
+        strip_prefix = "subtle-2.4.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.subtle-2.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__syn__1_0_69",
+        url = "https://crates.io/api/v1/crates/syn/1.0.69/download",
+        type = "tar.gz",
+        sha256 = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb",
+        strip_prefix = "syn-1.0.69",
+        build_file = Label("//third_party/cargo/remote:BUILD.syn-1.0.69.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__synstructure__0_12_4",
+        url = "https://crates.io/api/v1/crates/synstructure/0.12.4/download",
+        type = "tar.gz",
+        sha256 = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701",
+        strip_prefix = "synstructure-0.12.4",
+        build_file = Label("//third_party/cargo/remote:BUILD.synstructure-0.12.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__tap__1_0_1",
+        url = "https://crates.io/api/v1/crates/tap/1.0.1/download",
+        type = "tar.gz",
+        sha256 = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369",
+        strip_prefix = "tap-1.0.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.tap-1.0.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__tempfile__3_2_0",
+        url = "https://crates.io/api/v1/crates/tempfile/3.2.0/download",
+        type = "tar.gz",
+        sha256 = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22",
+        strip_prefix = "tempfile-3.2.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.tempfile-3.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__tink_core__0_2_0",
+        url = "https://crates.io/api/v1/crates/tink-core/0.2.0/download",
+        type = "tar.gz",
+        sha256 = "b7fefcbc7d04471b83ca8b3c445c376d45a8ab8fc35c3aa215df51f90aa95737",
+        strip_prefix = "tink-core-0.2.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.tink-core-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__tink_proto__0_2_0",
+        url = "https://crates.io/api/v1/crates/tink-proto/0.2.0/download",
+        type = "tar.gz",
+        sha256 = "6f097af9d2db1a08ea01008f88bc803d8bda25c13bfdc076df7449da907e259f",
+        strip_prefix = "tink-proto-0.2.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.tink-proto-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__tink_signature__0_2_0",
+        url = "https://crates.io/api/v1/crates/tink-signature/0.2.0/download",
+        type = "tar.gz",
+        sha256 = "c5b54df96bd2a0524d2ffb9f2b6aa9574a4c9a4834e7d8585907f5b04fcd0743",
+        strip_prefix = "tink-signature-0.2.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.tink-signature-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__typed_arena__2_0_1",
+        url = "https://crates.io/api/v1/crates/typed-arena/2.0.1/download",
+        type = "tar.gz",
+        sha256 = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae",
+        strip_prefix = "typed-arena-2.0.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.typed-arena-2.0.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__typenum__1_13_0",
+        url = "https://crates.io/api/v1/crates/typenum/1.13.0/download",
+        type = "tar.gz",
+        sha256 = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06",
+        strip_prefix = "typenum-1.13.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.typenum-1.13.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__unicode_segmentation__1_7_1",
+        url = "https://crates.io/api/v1/crates/unicode-segmentation/1.7.1/download",
+        type = "tar.gz",
+        sha256 = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796",
+        strip_prefix = "unicode-segmentation-1.7.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.unicode-segmentation-1.7.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__unicode_xid__0_2_1",
+        url = "https://crates.io/api/v1/crates/unicode-xid/0.2.1/download",
+        type = "tar.gz",
+        sha256 = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564",
+        strip_prefix = "unicode-xid-0.2.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.unicode-xid-0.2.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__uuid__0_8_2",
+        url = "https://crates.io/api/v1/crates/uuid/0.8.2/download",
+        type = "tar.gz",
+        sha256 = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7",
+        strip_prefix = "uuid-0.8.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.uuid-0.8.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__version_check__0_9_3",
+        url = "https://crates.io/api/v1/crates/version_check/0.9.3/download",
+        type = "tar.gz",
+        sha256 = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe",
+        strip_prefix = "version_check-0.9.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.version_check-0.9.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__wasi__0_10_2_wasi_snapshot_preview1",
+        url = "https://crates.io/api/v1/crates/wasi/0.10.2+wasi-snapshot-preview1/download",
+        type = "tar.gz",
+        sha256 = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6",
+        strip_prefix = "wasi-0.10.2+wasi-snapshot-preview1",
+        build_file = Label("//third_party/cargo/remote:BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__wasi__0_9_0_wasi_snapshot_preview1",
+        url = "https://crates.io/api/v1/crates/wasi/0.9.0+wasi-snapshot-preview1/download",
+        type = "tar.gz",
+        sha256 = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519",
+        strip_prefix = "wasi-0.9.0+wasi-snapshot-preview1",
+        build_file = Label("//third_party/cargo/remote:BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__which__4_1_0",
+        url = "https://crates.io/api/v1/crates/which/4.1.0/download",
+        type = "tar.gz",
+        sha256 = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe",
+        strip_prefix = "which-4.1.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.which-4.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__winapi__0_3_9",
+        url = "https://crates.io/api/v1/crates/winapi/0.3.9/download",
+        type = "tar.gz",
+        sha256 = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        strip_prefix = "winapi-0.3.9",
+        build_file = Label("//third_party/cargo/remote:BUILD.winapi-0.3.9.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__winapi_i686_pc_windows_gnu__0_4_0",
+        url = "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
+        type = "tar.gz",
+        sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__winapi_x86_64_pc_windows_gnu__0_4_0",
+        url = "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
+        type = "tar.gz",
+        sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__wyz__0_2_0",
+        url = "https://crates.io/api/v1/crates/wyz/0.2.0/download",
+        type = "tar.gz",
+        sha256 = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214",
+        strip_prefix = "wyz-0.2.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.wyz-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__zeroize__1_3_0",
+        url = "https://crates.io/api/v1/crates/zeroize/1.3.0/download",
+        type = "tar.gz",
+        sha256 = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd",
+        strip_prefix = "zeroize-1.3.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.zeroize-1.3.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__zeroize_derive__1_1_0",
+        url = "https://crates.io/api/v1/crates/zeroize_derive/1.1.0/download",
+        type = "tar.gz",
+        sha256 = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1",
+        strip_prefix = "zeroize_derive-1.1.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.zeroize_derive-1.1.0.bazel"),
+    )

--- a/third_party/cargo/remote/BUILD.antlr-rust-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.antlr-rust-0.2.0.bazel
@@ -1,0 +1,66 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # BSD-3-Clause from expression "BSD-3-Clause"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "antlr_rust",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__better_any__0_1_1//:better_any",
+        "@raze__bit_set__0_5_2//:bit_set",
+        "@raze__byteorder__1_4_3//:byteorder",
+        "@raze__lazy_static__1_4_0//:lazy_static",
+        "@raze__murmur3__0_4_1//:murmur3",
+        "@raze__once_cell__1_7_2//:once_cell",
+        "@raze__parking_lot__0_11_1//:parking_lot",
+        "@raze__typed_arena__2_0_1//:typed_arena",
+        "@raze__uuid__0_8_2//:uuid",
+    ],
+)
+
+# Unsupported target "my_test" with type "test" omitted
+
+# Unsupported target "perf" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.anyhow-1.0.40.bazel
+++ b/third_party/cargo/remote/BUILD.anyhow-1.0.40.bazel
@@ -1,0 +1,83 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "anyhow",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.40",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "test_autotrait" with type "test" omitted
+
+# Unsupported target "test_backtrace" with type "test" omitted
+
+# Unsupported target "test_boxed" with type "test" omitted
+
+# Unsupported target "test_chain" with type "test" omitted
+
+# Unsupported target "test_context" with type "test" omitted
+
+# Unsupported target "test_convert" with type "test" omitted
+
+# Unsupported target "test_downcast" with type "test" omitted
+
+# Unsupported target "test_ffi" with type "test" omitted
+
+# Unsupported target "test_fmt" with type "test" omitted
+
+# Unsupported target "test_macros" with type "test" omitted
+
+# Unsupported target "test_repr" with type "test" omitted
+
+# Unsupported target "test_source" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "integers" with type "example" omitted
+
+# Unsupported target "paths" with type "example" omitted
+
+# Unsupported target "traits" with type "example" omitted
+
+# Unsupported target "versions" with type "example" omitted
+
+rust_library(
+    name = "autocfg",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "rustflags" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.base64-0.13.0.bazel
+++ b/third_party/cargo/remote/BUILD.base64-0.13.0.bazel
@@ -1,0 +1,69 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "benchmarks" with type "bench" omitted
+
+# Unsupported target "base64" with type "example" omitted
+
+# Unsupported target "make_tables" with type "example" omitted
+
+rust_library(
+    name = "base64",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.13.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "decode" with type "test" omitted
+
+# Unsupported target "encode" with type "test" omitted
+
+# Unsupported target "helpers" with type "test" omitted
+
+# Unsupported target "tests" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.better_any-0.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.better_any-0.1.1.bazel
@@ -1,0 +1,62 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "better_any",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__better_typeid_derive__0_1_1//:better_typeid_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "compile_fail" with type "test" omitted
+
+# Unsupported target "expand" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.better_typeid_derive-0.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.better_typeid_derive-0.1.1.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "better_typeid_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "proc-macro",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_26//:proc_macro2",
+        "@raze__quote__1_0_9//:quote",
+        "@raze__syn__1_0_69//:syn",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.bincode-1.3.3.bazel
+++ b/third_party/cargo/remote/BUILD.bincode-1.3.3.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "bincode",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.3.3",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__serde__1_0_126//:serde",
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.bit-set-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.bit-set-0.5.2.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "bit_set",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.5.2",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__bit_vec__0_6_3//:bit_vec",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.bit-vec-0.6.3.bazel
+++ b/third_party/cargo/remote/BUILD.bit-vec-0.6.3.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "bit_vec",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.6.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.bitflags-1.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.bitflags-1.2.1.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "bitflags",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.2.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.bitvec-0.20.4.bazel
+++ b/third_party/cargo/remote/BUILD.bitvec-0.20.4.bazel
@@ -1,0 +1,67 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "eq" with type "bench" omitted
+
+# Unsupported target "macros" with type "bench" omitted
+
+# Unsupported target "memcpy" with type "bench" omitted
+
+# Unsupported target "mut_access" with type "bench" omitted
+
+# Unsupported target "slice" with type "bench" omitted
+
+rust_library(
+    name = "bitvec",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.20.4",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__funty__1_1_0//:funty",
+        "@raze__radium__0_6_2//:radium",
+        "@raze__tap__1_0_1//:tap",
+        "@raze__wyz__0_2_0//:wyz",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.block-buffer-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.block-buffer-0.9.0.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "block_buffer",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__generic_array__0_14_4//:generic_array",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.byteorder-1.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.byteorder-1.4.3.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "byteorder",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "i128",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.4.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.bytes-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.bytes-1.0.1.bazel
@@ -1,0 +1,81 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "buf" with type "bench" omitted
+
+# Unsupported target "bytes" with type "bench" omitted
+
+# Unsupported target "bytes_mut" with type "bench" omitted
+
+rust_library(
+    name = "bytes",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "test_buf" with type "test" omitted
+
+# Unsupported target "test_buf_mut" with type "test" omitted
+
+# Unsupported target "test_bytes" with type "test" omitted
+
+# Unsupported target "test_bytes_odd_alloc" with type "test" omitted
+
+# Unsupported target "test_bytes_vec_alloc" with type "test" omitted
+
+# Unsupported target "test_chain" with type "test" omitted
+
+# Unsupported target "test_debug" with type "test" omitted
+
+# Unsupported target "test_iter" with type "test" omitted
+
+# Unsupported target "test_reader" with type "test" omitted
+
+# Unsupported target "test_serde" with type "test" omitted
+
+# Unsupported target "test_take" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "cfg_if",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "xcrate" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.const-oid-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.const-oid-0.5.2.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "const_oid",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.5.2",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "lib" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.cpufeatures-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.cpufeatures-0.1.4.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "cpufeatures",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.4",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "aarch64" with type "test" omitted
+
+# Unsupported target "x86" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.crypto-mac-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.crypto-mac-0.11.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "crypto_mac",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.11.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__generic_array__0_14_4//:generic_array",
+        "@raze__subtle__2_4_0//:subtle",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.curve25519-dalek-3.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.curve25519-dalek-3.1.0.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # BSD-3-Clause from expression "BSD-3-Clause"
+])
+
+# Generated Targets
+
+# Unsupported target "dalek_benchmarks" with type "bench" omitted
+
+rust_library(
+    name = "curve25519_dalek",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "std",
+        "u64_backend",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "3.1.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__byteorder__1_4_3//:byteorder",
+        "@raze__digest__0_9_0//:digest",
+        "@raze__rand_core__0_5_1//:rand_core",
+        "@raze__subtle__2_4_0//:subtle",
+        "@raze__zeroize__1_3_0//:zeroize",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.der-0.3.5.bazel
+++ b/third_party/cargo/remote/BUILD.der-0.3.5.bazel
@@ -1,0 +1,61 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "der",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "big-uint",
+        "const-oid",
+        "oid",
+        "typenum",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.5",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__const_oid__0_5_2//:const_oid",
+        "@raze__typenum__1_13_0//:typenum",
+    ],
+)
+
+# Unsupported target "derive" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.digest-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.digest-0.9.0.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "digest",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__generic_array__0_14_4//:generic_array",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.ecdsa-0.11.1.bazel
+++ b/third_party/cargo/remote/BUILD.ecdsa-0.11.1.bazel
@@ -1,0 +1,70 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "ecdsa",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "arithmetic",
+        "default",
+        "der",
+        "digest",
+        "hazmat",
+        "hmac",
+        "sign",
+        "std",
+        "verify",
+        "zeroize",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.11.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__der__0_3_5//:der",
+        "@raze__elliptic_curve__0_9_12//:elliptic_curve",
+        "@raze__hmac__0_11_0//:hmac",
+        "@raze__signature__1_3_0//:signature",
+    ],
+)
+
+# Unsupported target "lib" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.ed25519-1.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.ed25519-1.1.1.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "ed25519",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.1.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__signature__1_3_0//:signature",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.ed25519-dalek-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.ed25519-dalek-1.0.1.bazel
@@ -1,0 +1,71 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # BSD-3-Clause from expression "BSD-3-Clause"
+])
+
+# Generated Targets
+
+# Unsupported target "ed25519_benchmarks" with type "bench" omitted
+
+rust_library(
+    name = "ed25519_dalek",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+        "@raze__serde__1_0_126//:serde": "serde_crate",
+    },
+    crate_features = [
+        "default",
+        "rand",
+        "serde_crate",
+        "std",
+        "u64_backend",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__curve25519_dalek__3_1_0//:curve25519_dalek",
+        "@raze__ed25519__1_1_1//:ed25519",
+        "@raze__rand__0_7_3//:rand",
+        "@raze__serde__1_0_126//:serde",
+        "@raze__sha2__0_9_5//:sha2",
+        "@raze__zeroize__1_3_0//:zeroize",
+    ],
+)
+
+# Unsupported target "ed25519" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.either-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.either-1.6.1.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "either",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "use_std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.6.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.elliptic-curve-0.9.12.bazel
+++ b/third_party/cargo/remote/BUILD.elliptic-curve-0.9.12.bazel
@@ -1,0 +1,74 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "elliptic_curve",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "arithmetic",
+        "bitvec",
+        "ff",
+        "group",
+        "hazmat",
+        "pkcs8",
+        "std",
+        "zeroize",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.12",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__bitvec__0_20_4//:bitvec",
+        "@raze__ff__0_9_0//:ff",
+        "@raze__generic_array__0_14_4//:generic_array",
+        "@raze__group__0_9_0//:group",
+        "@raze__pkcs8__0_6_1//:pkcs8",
+        "@raze__rand_core__0_6_2//:rand_core",
+        "@raze__subtle__2_4_0//:subtle",
+        "@raze__zeroize__1_3_0//:zeroize",
+    ],
+)
+
+# Unsupported target "pkcs8" with type "test" omitted
+
+# Unsupported target "secret_key" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.ff-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.ff-0.9.0.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "ff",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__bitvec__0_20_4//:bitvec",
+        "@raze__rand_core__0_6_2//:rand_core",
+        "@raze__subtle__2_4_0//:subtle",
+    ],
+)
+
+# Unsupported target "derive" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.fixedbitset-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.fixedbitset-0.2.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "benches" with type "bench" omitted
+
+rust_library(
+    name = "fixedbitset",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.funty-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.funty-1.1.0.bazel
@@ -1,0 +1,53 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "funty",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.1.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.generic-array-0.14.4.bazel
+++ b/third_party/cargo/remote/BUILD.generic-array-0.14.4.bazel
@@ -1,0 +1,68 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "generic_array",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.14.4",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__typenum__1_13_0//:typenum",
+    ],
+)
+
+# Unsupported target "arr" with type "test" omitted
+
+# Unsupported target "generics" with type "test" omitted
+
+# Unsupported target "hex" with type "test" omitted
+
+# Unsupported target "import_name" with type "test" omitted
+
+# Unsupported target "iter" with type "test" omitted
+
+# Unsupported target "mod" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.getrandom-0.1.16.bazel
+++ b/third_party/cargo/remote/BUILD.getrandom-0.1.16.bazel
@@ -1,0 +1,72 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "mod" with type "bench" omitted
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "getrandom",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.16",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__cfg_if__1_0_0//:cfg_if",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_93//:libc",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "common" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.getrandom-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.getrandom-0.2.3.bazel
@@ -1,0 +1,74 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "mod" with type "bench" omitted
+
+rust_library(
+    name = "getrandom",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.3",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__cfg_if__1_0_0//:cfg_if",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_93//:libc",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "custom" with type "test" omitted
+
+# Unsupported target "normal" with type "test" omitted
+
+# Unsupported target "rdrand" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.group-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.group-0.9.0.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "group",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__ff__0_9_0//:ff",
+        "@raze__rand_core__0_6_2//:rand_core",
+        "@raze__subtle__2_4_0//:subtle",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.hashbrown-0.9.1.bazel
+++ b/third_party/cargo/remote/BUILD.hashbrown-0.9.1.bazel
@@ -1,0 +1,64 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "hashbrown",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "raw",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "hasher" with type "test" omitted
+
+# Unsupported target "rayon" with type "test" omitted
+
+# Unsupported target "serde" with type "test" omitted
+
+# Unsupported target "set" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.heck-0.3.2.bazel
+++ b/third_party/cargo/remote/BUILD.heck-0.3.2.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "heck",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.2",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__unicode_segmentation__1_7_1//:unicode_segmentation",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.hkdf-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.hkdf-0.11.0.bazel
@@ -1,0 +1,65 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "hkdf" with type "bench" omitted
+
+# Unsupported target "extract" with type "example" omitted
+
+# Unsupported target "from_prk" with type "example" omitted
+
+# Unsupported target "main" with type "example" omitted
+
+rust_library(
+    name = "hkdf",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/hkdf.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.11.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__digest__0_9_0//:digest",
+        "@raze__hmac__0_11_0//:hmac",
+    ],
+)
+
+# Unsupported target "tests" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.hmac-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.hmac-0.11.0.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "hmac",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.11.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__crypto_mac__0_11_0//:crypto_mac",
+        "@raze__digest__0_9_0//:digest",
+    ],
+)
+
+# Unsupported target "lib" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.indexmap-1.6.2.bazel
+++ b/third_party/cargo/remote/BUILD.indexmap-1.6.2.bazel
@@ -1,0 +1,98 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "indexmap_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.6.2",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__autocfg__1_0_1//:autocfg",
+    ],
+)
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "faststring" with type "bench" omitted
+
+rust_library(
+    name = "indexmap",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+        "--cfg=has_std",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.6.2",
+    # buildifier: leave-alone
+    deps = [
+        ":indexmap_build_script",
+        "@raze__hashbrown__0_9_1//:hashbrown",
+    ],
+)
+
+# Unsupported target "equivalent_trait" with type "test" omitted
+
+# Unsupported target "macros_full_path" with type "test" omitted
+
+# Unsupported target "quick" with type "test" omitted
+
+# Unsupported target "tests" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.instant-0.1.9.bazel
+++ b/third_party/cargo/remote/BUILD.instant-0.1.9.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # BSD-3-Clause from expression "BSD-3-Clause"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "instant",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.9",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__cfg_if__1_0_0//:cfg_if",
+    ],
+)
+
+# Unsupported target "wasm" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.itertools-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.itertools-0.9.0.bazel
@@ -1,0 +1,90 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench1" with type "bench" omitted
+
+# Unsupported target "combinations_with_replacement" with type "bench" omitted
+
+# Unsupported target "fold_specialization" with type "bench" omitted
+
+# Unsupported target "tree_fold1" with type "bench" omitted
+
+# Unsupported target "tuple_combinations" with type "bench" omitted
+
+# Unsupported target "tuples" with type "bench" omitted
+
+# Unsupported target "iris" with type "example" omitted
+
+rust_library(
+    name = "itertools",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "use_std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__either__1_6_1//:either",
+    ],
+)
+
+# Unsupported target "adaptors_no_collect" with type "test" omitted
+
+# Unsupported target "fold_specialization" with type "test" omitted
+
+# Unsupported target "merge_join" with type "test" omitted
+
+# Unsupported target "peeking_take_while" with type "test" omitted
+
+# Unsupported target "quick" with type "test" omitted
+
+# Unsupported target "specializations" with type "test" omitted
+
+# Unsupported target "test_core" with type "test" omitted
+
+# Unsupported target "test_std" with type "test" omitted
+
+# Unsupported target "tuples" with type "test" omitted
+
+# Unsupported target "zip" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.itoa-0.4.7.bazel
+++ b/third_party/cargo/remote/BUILD.itoa-0.4.7.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "itoa",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.7",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "lazy_static",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.4.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "no_std" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.libc-0.2.93.bazel
+++ b/third_party/cargo/remote/BUILD.libc-0.2.93.bazel
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "libc",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.93",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "const_fn" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.lock_api-0.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.lock_api-0.4.3.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "lock_api",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.3",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__scopeguard__1_1_0//:scopeguard",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.log-0.4.14.bazel
+++ b/third_party/cargo/remote/BUILD.log-0.4.14.bazel
@@ -1,0 +1,62 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "value" with type "bench" omitted
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "log",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.14",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__cfg_if__1_0_0//:cfg_if",
+    ],
+)
+
+# Unsupported target "filters" with type "test" omitted
+
+# Unsupported target "macros" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.multimap-0.8.3.bazel
+++ b/third_party/cargo/remote/BUILD.multimap-0.8.3.bazel
@@ -1,0 +1,53 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "multimap",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.8.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.murmur3-0.4.1.bazel
+++ b/third_party/cargo/remote/BUILD.murmur3-0.4.1.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "murmur3",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__byteorder__1_4_3//:byteorder",
+    ],
+)
+
+# Unsupported target "hasher_tests" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.once_cell-1.7.2.bazel
+++ b/third_party/cargo/remote/BUILD.once_cell-1.7.2.bazel
@@ -1,0 +1,73 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "example" omitted
+
+# Unsupported target "bench_acquire" with type "example" omitted
+
+# Unsupported target "bench_vs_lazy_static" with type "example" omitted
+
+# Unsupported target "lazy_static" with type "example" omitted
+
+# Unsupported target "reentrant_init_deadlocks" with type "example" omitted
+
+# Unsupported target "regex" with type "example" omitted
+
+# Unsupported target "test_synchronization" with type "example" omitted
+
+rust_library(
+    name = "once_cell",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "default",
+        "race",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.7.2",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "it" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.opaque-debug-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.opaque-debug-0.3.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "opaque_debug",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "mod" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.p256-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.p256-0.8.1.bazel
@@ -1,0 +1,71 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "p256",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+        "@raze__ecdsa__0_11_1//:ecdsa": "ecdsa_core",
+    },
+    crate_features = [
+        "arithmetic",
+        "default",
+        "digest",
+        "ecdsa",
+        "ecdsa-core",
+        "pkcs8",
+        "sha2",
+        "sha256",
+        "std",
+        "zeroize",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.8.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__ecdsa__0_11_1//:ecdsa",
+        "@raze__elliptic_curve__0_9_12//:elliptic_curve",
+        "@raze__sha2__0_9_5//:sha2",
+    ],
+)
+
+# Unsupported target "pkcs8" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.parking_lot-0.11.1.bazel
+++ b/third_party/cargo/remote/BUILD.parking_lot-0.11.1.bazel
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "parking_lot",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.11.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__instant__0_1_9//:instant",
+        "@raze__lock_api__0_4_3//:lock_api",
+        "@raze__parking_lot_core__0_8_3//:parking_lot_core",
+    ],
+)
+
+# Unsupported target "issue_203" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.parking_lot_core-0.8.3.bazel
+++ b/third_party/cargo/remote/BUILD.parking_lot_core-0.8.3.bazel
@@ -1,0 +1,75 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "parking_lot_core",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.8.3",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__instant__0_1_9//:instant",
+        "@raze__smallvec__1_6_1//:smallvec",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_93//:libc",
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(windows)
+        (
+            "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@raze__winapi__0_3_9//:winapi",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/cargo/remote/BUILD.petgraph-0.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.petgraph-0.5.1.bazel
@@ -1,0 +1,79 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "dijkstra" with type "bench" omitted
+
+# Unsupported target "iso" with type "bench" omitted
+
+# Unsupported target "matrix_graph" with type "bench" omitted
+
+# Unsupported target "ograph" with type "bench" omitted
+
+# Unsupported target "stable_graph" with type "bench" omitted
+
+# Unsupported target "unionfind" with type "bench" omitted
+
+rust_library(
+    name = "petgraph",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.5.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__fixedbitset__0_2_0//:fixedbitset",
+        "@raze__indexmap__1_6_2//:indexmap",
+    ],
+)
+
+# Unsupported target "graph" with type "test" omitted
+
+# Unsupported target "graphmap" with type "test" omitted
+
+# Unsupported target "iso" with type "test" omitted
+
+# Unsupported target "quickcheck" with type "test" omitted
+
+# Unsupported target "stable_graph" with type "test" omitted
+
+# Unsupported target "unionfind" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.pkcs8-0.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.pkcs8-0.6.1.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "pkcs8",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.6.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__der__0_3_5//:der",
+        "@raze__spki__0_3_0//:spki",
+    ],
+)
+
+# Unsupported target "encrypted_private_key" with type "test" omitted
+
+# Unsupported target "one_asymmetric_key" with type "test" omitted
+
+# Unsupported target "private_key" with type "test" omitted
+
+# Unsupported target "public_key" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.ppv-lite86-0.2.10.bazel
+++ b/third_party/cargo/remote/BUILD.ppv-lite86-0.2.10.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "ppv_lite86",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "simd",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.10",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.proc-macro2-1.0.26.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro2-1.0.26.bazel
@@ -1,0 +1,69 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "proc_macro2",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+        "--cfg=use_proc_macro",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.26",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__unicode_xid__0_2_1//:unicode_xid",
+    ],
+)
+
+# Unsupported target "comments" with type "test" omitted
+
+# Unsupported target "features" with type "test" omitted
+
+# Unsupported target "marker" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted
+
+# Unsupported target "test_fmt" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.prost-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.prost-0.7.0.bazel
@@ -1,0 +1,62 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "varint" with type "bench" omitted
+
+rust_library(
+    name = "prost",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "prost-derive",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__prost_derive__0_7_0//:prost_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__bytes__1_0_1//:bytes",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.prost-build-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.prost-build-0.7.0.bazel
@@ -1,0 +1,95 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "prost_build_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]) + [
+        "@com_google_protobuf//:protoc",
+    ],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.0",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__which__4_1_0//:which",
+    ],
+)
+
+rust_library(
+    name = "prost_build",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.0",
+    # buildifier: leave-alone
+    deps = [
+        ":prost_build_build_script",
+        "@raze__bytes__1_0_1//:bytes",
+        "@raze__heck__0_3_2//:heck",
+        "@raze__itertools__0_9_0//:itertools",
+        "@raze__log__0_4_14//:log",
+        "@raze__multimap__0_8_3//:multimap",
+        "@raze__petgraph__0_5_1//:petgraph",
+        "@raze__prost__0_7_0//:prost",
+        "@raze__prost_types__0_7_0//:prost_types",
+        "@raze__tempfile__3_2_0//:tempfile",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.prost-derive-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.prost-derive-0.7.0.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "prost_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "proc-macro",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__anyhow__1_0_40//:anyhow",
+        "@raze__itertools__0_9_0//:itertools",
+        "@raze__proc_macro2__1_0_26//:proc_macro2",
+        "@raze__quote__1_0_9//:quote",
+        "@raze__syn__1_0_69//:syn",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.prost-types-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.prost-types-0.7.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "prost_types",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__bytes__1_0_1//:bytes",
+        "@raze__prost__0_7_0//:prost",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.quote-1.0.9.bazel
+++ b/third_party/cargo/remote/BUILD.quote-1.0.9.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "quote",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.9",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_26//:proc_macro2",
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.radium-0.6.2.bazel
+++ b/third_party/cargo/remote/BUILD.radium-0.6.2.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "radium",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.6.2",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.rand-0.7.3.bazel
+++ b/third_party/cargo/remote/BUILD.rand-0.7.3.bazel
@@ -1,0 +1,86 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "generators" with type "bench" omitted
+
+# Unsupported target "misc" with type "bench" omitted
+
+# Unsupported target "seq" with type "bench" omitted
+
+# Unsupported target "weighted" with type "bench" omitted
+
+# Unsupported target "monte-carlo" with type "example" omitted
+
+# Unsupported target "monty-hall" with type "example" omitted
+
+rust_library(
+    name = "rand",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+        "@raze__getrandom__0_1_16//:getrandom": "getrandom_package",
+    },
+    crate_features = [
+        "alloc",
+        "default",
+        "getrandom",
+        "getrandom_package",
+        "libc",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.3",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__getrandom__0_1_16//:getrandom",
+        "@raze__rand_chacha__0_2_2//:rand_chacha",
+        "@raze__rand_core__0_5_1//:rand_core",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_93//:libc",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/cargo/remote/BUILD.rand-0.8.3.bazel
+++ b/third_party/cargo/remote/BUILD.rand-0.8.3.bazel
@@ -1,0 +1,74 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rand",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "alloc",
+        "default",
+        "getrandom",
+        "libc",
+        "rand_chacha",
+        "rand_hc",
+        "std",
+        "std_rng",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.8.3",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__rand_chacha__0_3_0//:rand_chacha",
+        "@raze__rand_core__0_6_2//:rand_core",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_93//:libc",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.rand_chacha-0.2.2.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rand_chacha",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.2",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__ppv_lite86__0_2_10//:ppv_lite86",
+        "@raze__rand_core__0_5_1//:rand_core",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.rand_chacha-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.rand_chacha-0.3.0.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rand_chacha",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__ppv_lite86__0_2_10//:ppv_lite86",
+        "@raze__rand_core__0_6_2//:rand_core",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.rand_core-0.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.rand_core-0.5.1.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rand_core",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "getrandom",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.5.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__getrandom__0_1_16//:getrandom",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.rand_core-0.6.2.bazel
+++ b/third_party/cargo/remote/BUILD.rand_core-0.6.2.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rand_core",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "getrandom",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.6.2",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__getrandom__0_2_3//:getrandom",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.rand_hc-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.rand_hc-0.2.0.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rand_hc",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__rand_core__0_5_1//:rand_core",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.rand_hc-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.rand_hc-0.3.0.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rand_hc",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__rand_core__0_6_2//:rand_core",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.redox_syscall-0.2.6.bazel
+++ b/third_party/cargo/remote/BUILD.redox_syscall-0.2.6.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+alias(
+    name = "redox_syscall",
+    actual = ":syscall",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+rust_library(
+    name = "syscall",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.6",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__bitflags__1_2_1//:bitflags",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.remove_dir_all-0.5.3.bazel
+++ b/third_party/cargo/remote/BUILD.remove_dir_all-0.5.3.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "remove_dir_all",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.5.3",
+    # buildifier: leave-alone
+    deps = [
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@raze__winapi__0_3_9//:winapi",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/cargo/remote/BUILD.ryu-1.0.5.bazel
+++ b/third_party/cargo/remote/BUILD.ryu-1.0.5.bazel
@@ -1,0 +1,73 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR BSL-1.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+# Unsupported target "upstream_benchmark" with type "example" omitted
+
+rust_library(
+    name = "ryu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.5",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "common_test" with type "test" omitted
+
+# Unsupported target "d2s_table_test" with type "test" omitted
+
+# Unsupported target "d2s_test" with type "test" omitted
+
+# Unsupported target "exhaustive" with type "test" omitted
+
+# Unsupported target "f2s_test" with type "test" omitted
+
+# Unsupported target "s2d_test" with type "test" omitted
+
+# Unsupported target "s2f_test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.scopeguard-1.1.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "readme" with type "example" omitted
+
+rust_library(
+    name = "scopeguard",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.1.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.serde-1.0.126.bazel
+++ b/third_party/cargo/remote/BUILD.serde-1.0.126.bazel
@@ -1,0 +1,94 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "serde_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.126",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "serde",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    proc_macro_deps = [
+        "@raze__serde_derive__1_0_126//:serde_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.126",
+    # buildifier: leave-alone
+    deps = [
+        ":serde_build_script",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.serde_derive-1.0.126.bazel
+++ b/third_party/cargo/remote/BUILD.serde_derive-1.0.126.bazel
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "serde_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "proc-macro",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.126",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_26//:proc_macro2",
+        "@raze__quote__1_0_9//:quote",
+        "@raze__syn__1_0_69//:syn",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.serde_json-1.0.64.bazel
+++ b/third_party/cargo/remote/BUILD.serde_json-1.0.64.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "serde_json",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.64",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__itoa__0_4_7//:itoa",
+        "@raze__ryu__1_0_5//:ryu",
+        "@raze__serde__1_0_126//:serde",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.sha-1-0.9.6.bazel
+++ b/third_party/cargo/remote/BUILD.sha-1-0.9.6.bazel
@@ -1,0 +1,86 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "lib" with type "bench" omitted
+
+# Unsupported target "sha1sum" with type "example" omitted
+
+alias(
+    name = "sha_1",
+    actual = ":sha1",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+rust_library(
+    name = "sha1",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.6",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__block_buffer__0_9_0//:block_buffer",
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__digest__0_9_0//:digest",
+        "@raze__opaque_debug__0_3_0//:opaque_debug",
+    ] + selects.with_or({
+        # cfg(any(target_arch = "x86", target_arch = "x86_64"))
+        (
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__cpufeatures__0_1_4//:cpufeatures",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "lib" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.sha2-0.9.5.bazel
+++ b/third_party/cargo/remote/BUILD.sha2-0.9.5.bazel
@@ -1,0 +1,81 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "sha256" with type "bench" omitted
+
+# Unsupported target "sha512" with type "bench" omitted
+
+# Unsupported target "sha256sum" with type "example" omitted
+
+# Unsupported target "sha512sum" with type "example" omitted
+
+rust_library(
+    name = "sha2",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.5",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__block_buffer__0_9_0//:block_buffer",
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__digest__0_9_0//:digest",
+        "@raze__opaque_debug__0_3_0//:opaque_debug",
+    ] + selects.with_or({
+        # cfg(any(target_arch = "x86", target_arch = "x86_64"))
+        (
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__cpufeatures__0_1_4//:cpufeatures",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "lib" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.signature-1.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.signature-1.3.0.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "signature",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "digest",
+        "digest-preview",
+        "rand-preview",
+        "rand_core",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.3.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__digest__0_9_0//:digest",
+        "@raze__rand_core__0_6_2//:rand_core",
+    ],
+)
+
+# Unsupported target "signature_derive" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.smallvec-1.6.1.bazel
+++ b/third_party/cargo/remote/BUILD.smallvec-1.6.1.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "smallvec",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.6.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "macro" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.spki-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.spki-0.3.0.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "spki",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__der__0_3_5//:der",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.subtle-2.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.subtle-2.4.0.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # BSD-3-Clause from expression "BSD-3-Clause"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "subtle",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "i128",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "2.4.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "mod" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.syn-1.0.69.bazel
+++ b/third_party/cargo/remote/BUILD.syn-1.0.69.bazel
@@ -1,0 +1,124 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "file" with type "bench" omitted
+
+# Unsupported target "rust" with type "bench" omitted
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "syn",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "clone-impls",
+        "default",
+        "derive",
+        "extra-traits",
+        "full",
+        "parsing",
+        "printing",
+        "proc-macro",
+        "quote",
+        "visit",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.69",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_26//:proc_macro2",
+        "@raze__quote__1_0_9//:quote",
+        "@raze__unicode_xid__0_2_1//:unicode_xid",
+    ],
+)
+
+# Unsupported target "test_asyncness" with type "test" omitted
+
+# Unsupported target "test_attribute" with type "test" omitted
+
+# Unsupported target "test_derive_input" with type "test" omitted
+
+# Unsupported target "test_expr" with type "test" omitted
+
+# Unsupported target "test_generics" with type "test" omitted
+
+# Unsupported target "test_grouping" with type "test" omitted
+
+# Unsupported target "test_ident" with type "test" omitted
+
+# Unsupported target "test_item" with type "test" omitted
+
+# Unsupported target "test_iterators" with type "test" omitted
+
+# Unsupported target "test_lit" with type "test" omitted
+
+# Unsupported target "test_meta" with type "test" omitted
+
+# Unsupported target "test_parse_buffer" with type "test" omitted
+
+# Unsupported target "test_parse_stream" with type "test" omitted
+
+# Unsupported target "test_pat" with type "test" omitted
+
+# Unsupported target "test_path" with type "test" omitted
+
+# Unsupported target "test_precedence" with type "test" omitted
+
+# Unsupported target "test_receiver" with type "test" omitted
+
+# Unsupported target "test_round_trip" with type "test" omitted
+
+# Unsupported target "test_shebang" with type "test" omitted
+
+# Unsupported target "test_should_parse" with type "test" omitted
+
+# Unsupported target "test_size" with type "test" omitted
+
+# Unsupported target "test_stmt" with type "test" omitted
+
+# Unsupported target "test_token_trees" with type "test" omitted
+
+# Unsupported target "test_ty" with type "test" omitted
+
+# Unsupported target "test_visibility" with type "test" omitted
+
+# Unsupported target "zzz_stable" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.synstructure-0.12.4.bazel
+++ b/third_party/cargo/remote/BUILD.synstructure-0.12.4.bazel
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "synstructure",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.12.4",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_26//:proc_macro2",
+        "@raze__quote__1_0_9//:quote",
+        "@raze__syn__1_0_69//:syn",
+        "@raze__unicode_xid__0_2_1//:unicode_xid",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.tap-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.tap-1.0.1.bazel
@@ -1,0 +1,53 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "tap",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.tempfile-3.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.tempfile-3.2.0.bazel
@@ -1,0 +1,83 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "tempfile",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "3.2.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__rand__0_8_3//:rand",
+        "@raze__remove_dir_all__0_5_3//:remove_dir_all",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-apple-darwin",
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_93//:libc",
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(windows)
+        (
+            "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@raze__winapi__0_3_9//:winapi",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "namedtempfile" with type "test" omitted
+
+# Unsupported target "spooled" with type "test" omitted
+
+# Unsupported target "tempdir" with type "test" omitted
+
+# Unsupported target "tempfile" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.tink-core-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.tink-core-0.2.0.bazel
@@ -1,0 +1,69 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "tink_core",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "insecure",
+        "json",
+        "serde",
+        "serde_json",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__digest__0_9_0//:digest",
+        "@raze__hkdf__0_11_0//:hkdf",
+        "@raze__lazy_static__1_4_0//:lazy_static",
+        "@raze__prost__0_7_0//:prost",
+        "@raze__rand__0_7_3//:rand",
+        "@raze__serde__1_0_126//:serde",
+        "@raze__serde_json__1_0_64//:serde_json",
+        "@raze__sha2__0_9_5//:sha2",
+        "@raze__sha_1__0_9_6//:sha_1",
+        "@raze__subtle__2_4_0//:subtle",
+        "@raze__tink_proto__0_2_0//:tink_proto",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.tink-proto-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.tink-proto-0.2.0.bazel
@@ -1,0 +1,98 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "tink_proto_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+        "PROTOC": "$(execpath @com_google_protobuf//:protoc)",
+    },
+    crate_features = [
+        "base64",
+        "default",
+        "json",
+        "serde",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]) + [
+        "@com_google_protobuf//:protoc",
+    ],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.0",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__prost_build__0_7_0//:prost_build",
+    ],
+)
+
+rust_library(
+    name = "tink_proto",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "base64",
+        "default",
+        "json",
+        "serde",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.0",
+    # buildifier: leave-alone
+    deps = [
+        ":tink_proto_build_script",
+        "@raze__base64__0_13_0//:base64",
+        "@raze__prost__0_7_0//:prost",
+        "@raze__serde__1_0_126//:serde",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.tink-signature-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.tink-signature-0.2.0.bazel
@@ -1,0 +1,64 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "benchmarks" with type "bench" omitted
+
+rust_library(
+    name = "tink_signature",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__ecdsa__0_11_1//:ecdsa",
+        "@raze__ed25519_dalek__1_0_1//:ed25519_dalek",
+        "@raze__generic_array__0_14_4//:generic_array",
+        "@raze__p256__0_8_1//:p256",
+        "@raze__prost__0_7_0//:prost",
+        "@raze__rand__0_7_3//:rand",
+        "@raze__signature__1_3_0//:signature",
+        "@raze__tink_core__0_2_0//:tink_core",
+        "@raze__tink_proto__0_2_0//:tink_proto",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.typed-arena-2.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.typed-arena-2.0.1.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "benches" with type "bench" omitted
+
+rust_library(
+    name = "typed_arena",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "2.0.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.typenum-1.13.0.bazel
+++ b/third_party/cargo/remote/BUILD.typenum-1.13.0.bazel
@@ -1,0 +1,86 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "typenum_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build/main.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.13.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "typenum",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+        "--cfg=feature=\"force_unix_path_separator\"",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.13.0",
+    # buildifier: leave-alone
+    deps = [
+        ":typenum_build_script",
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.unicode-segmentation-1.7.1.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-segmentation-1.7.1.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "graphemes" with type "bench" omitted
+
+rust_library(
+    name = "unicode_segmentation",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.7.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-xid-0.2.1.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "unicode_xid",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "exhaustive_tests" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.uuid-0.8.2.bazel
+++ b/third_party/cargo/remote/BUILD.uuid-0.8.2.bazel
@@ -1,0 +1,74 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "format_str" with type "bench" omitted
+
+# Unsupported target "invalid_parse_str" with type "bench" omitted
+
+# Unsupported target "mod" with type "bench" omitted
+
+# Unsupported target "serde_support" with type "bench" omitted
+
+# Unsupported target "valid_parse_str" with type "bench" omitted
+
+rust_library(
+    name = "uuid",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.8.2",
+    # buildifier: leave-alone
+    deps = [
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/cargo/remote/BUILD.version_check-0.9.3.bazel
+++ b/third_party/cargo/remote/BUILD.version_check-0.9.3.bazel
@@ -1,0 +1,53 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "version_check",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel
+++ b/third_party/cargo/remote/BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR (Apache-2.0 OR MIT)"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "wasi",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.10.2+wasi-snapshot-preview1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
+++ b/third_party/cargo/remote/BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR (Apache-2.0 OR MIT)"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "wasi",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.0+wasi-snapshot-preview1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.which-4.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.which-4.1.0.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "which",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "4.1.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__either__1_6_1//:either",
+        "@raze__libc__0_2_93//:libc",
+    ],
+)
+
+# Unsupported target "basic" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -1,0 +1,64 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "winapi",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "errhandlingapi",
+        "fileapi",
+        "handleapi",
+        "minwindef",
+        "ntstatus",
+        "std",
+        "winbase",
+        "winerror",
+        "winnt",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.9",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "winapi_i686_pc_windows_gnu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "winapi_x86_64_pc_windows_gnu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.wyz-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.wyz-0.2.0.bazel
@@ -1,0 +1,53 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "wyz",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/cargo/remote/BUILD.zeroize-1.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.zeroize-1.3.0.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "zeroize",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "zeroize_derive",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__zeroize_derive__1_1_0//:zeroize_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.3.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "zeroize_derive" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.zeroize_derive-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.zeroize_derive-1.1.0.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "zeroize_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "proc-macro",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.1.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_26//:proc_macro2",
+        "@raze__quote__1_0_9//:quote",
+        "@raze__syn__1_0_69//:syn",
+        "@raze__synstructure__0_12_4//:synstructure",
+    ],
+)


### PR DESCRIPTION
This PR contains the following:
  - Adds some meta data to `Cargo.toml` that is required for `cargo raze`. 
  - Creates a BUILD file for `rust/tools/authorization-logic`
  - Other than that, this PR mostly contains the BUILD files that were _auto_-generated by running `cargo raze` on the `Cargo.toml`.

Makes progress towards fixing #78.