### PR TITLE
Create an authorization_logic_lib target for use in C++

### DIFF
--- a/rust/tools/authorization-logic/BUILD
+++ b/rust/tools/authorization-logic/BUILD
@@ -61,12 +61,12 @@ rust_library(
     ]
 )
 
-rust_binary(
-    name = "authorization_logic",
+filegroup(
+    name = "lib_sources",
     srcs = [
         "src/ast.rs",
         "src/compilation_top_level.rs",
-        "src/main.rs",
+        "src/lib.rs",
         "src/parsing/astconstructionvisitor.rs",
         "src/parsing/mod.rs",
         "src/signing/export_assertions.rs",
@@ -78,11 +78,43 @@ rust_binary(
         "src/souffle/mod.rs",
         "src/souffle/souffle_emitter.rs",
         "src/souffle/souffle_interface.rs",
+    ],
+)
+
+filegroup(
+    name = "test_sources",
+    srcs = [
         "src/test/mod.rs",
         "src/test/test_claim_importing.rs",
         "src/test/test_export_signatures.rs",
         "src/test/test_queries.rs",
         "src/test/test_signing.rs",
+    ],
+)
+
+rust_library(
+    name = "authorization_logic_lib",
+    srcs = [":lib_sources"],
+    rustc_flags = [
+        "--cfg=feature=\"bazel_build\"",
+    ],
+    deps = [
+        ":antlr_gen",
+        "//rust/tools/authorization-logic/cargo:antlr_rust",
+        "//rust/tools/authorization-logic/cargo:bincode",
+        "//rust/tools/authorization-logic/cargo:serde",
+        "//rust/tools/authorization-logic/cargo:tink_core",
+        "//rust/tools/authorization-logic/cargo:tink_signature",
+    ],
+    crate_type = "staticlib",
+)
+
+rust_binary(
+    name = "authorization_logic",
+    srcs = [
+        "src/main.rs",
+        ":lib_sources",
+        ":test_sources",
     ],
     rustc_flags = [
         "--cfg=feature=\"bazel_build\""

--- a/rust/tools/authorization-logic/src/lib.rs
+++ b/rust/tools/authorization-logic/src/lib.rs
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 The Raksha Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Try blocks are used in antlr4-rust.
 #![feature(try_blocks)]
 
 mod ast;
@@ -17,16 +34,10 @@ pub extern "C" fn generate_datalog_facts_from_authorization_logic(
     c_out_dir: *const c_char
 ) -> c_int {
   let result = std::panic::catch_unwind(|| {
-    let filename = unsafe {
-      CStr::from_ptr(c_filename).to_str().unwrap()
-     };
-     let in_dir = unsafe {
-       CStr::from_ptr(c_in_dir).to_str().unwrap()
-     };
-     let out_dir = unsafe {
-       CStr::from_ptr(c_out_dir).to_str().unwrap()
-     };
-     compilation_top_level::compile(filename, in_dir, out_dir);
+    let filename = unsafe { CStr::from_ptr(c_filename) }.to_str().unwrap();
+    let in_dir = unsafe { CStr::from_ptr(c_in_dir) }.to_str().unwrap();
+    let out_dir = unsafe { CStr::from_ptr(c_out_dir) }.to_str().unwrap();
+    compilation_top_level::compile(filename, in_dir, out_dir);
   });
   if result.is_err() {
     eprintln!("error: rust panicked");

--- a/rust/tools/authorization-logic/src/lib.rs
+++ b/rust/tools/authorization-logic/src/lib.rs
@@ -1,0 +1,36 @@
+#![feature(try_blocks)]
+
+mod ast;
+mod compilation_top_level;
+mod parsing;
+mod signing;
+mod souffle;
+
+use std::os::raw::c_char;
+use std::os::raw::c_int;
+use std::ffi::CStr;
+
+#[no_mangle]
+pub extern "C" fn generate_datalog_facts_from_authorization_logic(
+    c_filename:  *const c_char,
+    c_in_dir: *const c_char,
+    c_out_dir: *const c_char
+) -> c_int {
+  let result = std::panic::catch_unwind(|| {
+    let filename = unsafe {
+      CStr::from_ptr(c_filename).to_str().unwrap()
+     };
+     let in_dir = unsafe {
+       CStr::from_ptr(c_in_dir).to_str().unwrap()
+     };
+     let out_dir = unsafe {
+       CStr::from_ptr(c_out_dir).to_str().unwrap()
+     };
+     compilation_top_level::compile(filename, in_dir, out_dir);
+  });
+  if result.is_err() {
+    eprintln!("error: rust panicked");
+    return 1;
+  }
+  return 0;
+}

--- a/src/xform_to_datalog/BUILD
+++ b/src/xform_to_datalog/BUILD
@@ -16,6 +16,22 @@
 licenses(["notice"])
 
 cc_library(
+    name = "authorization_logic",
+    hdrs = ["authorization_logic.h"],
+    deps = ["//rust/tools/authorization-logic:authorization_logic_lib"]
+)
+
+cc_test(
+    name = "authorization_logic_test",
+    srcs = ["authorization_logic_test.cc"],
+    data = ["//src/xform_to_datalog/testdata:auth_logic"],
+    deps = [
+        ":authorization_logic",
+        "//src/common/testing:gtest",
+    ]
+)
+
+cc_library(
     name = "datalog_facts",
     hdrs = ["datalog_facts.h"],
     deps = [

--- a/src/xform_to_datalog/authorization_logic.h
+++ b/src/xform_to_datalog/authorization_logic.h
@@ -1,0 +1,28 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#ifndef SRC_XFORM_TO_DATALOG_AUTHORIZATION_LOGIC_H_
+#define SRC_XFORM_TO_DATALOG_AUTHORIZATION_LOGIC_H_
+
+namespace raksha::xform_to_datalog {
+
+// Generates datalog facts from the given program.
+extern "C" int generate_datalog_facts_from_authorization_logic(
+  const char* program, const char* program_path, const char* out_dir);
+ 
+}
+
+#endif  // SRC_XFORM_TO_DATALOG_AUTHORIZATION_LOGIC_H_
+

--- a/src/xform_to_datalog/authorization_logic_test.cc
+++ b/src/xform_to_datalog/authorization_logic_test.cc
@@ -1,0 +1,80 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#include "src/xform_to_datalog/authorization_logic.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+#include "src/common/testing/gtest.h"
+
+namespace fs = std::filesystem;
+
+#include <iostream>
+
+namespace raksha::xform_to_datalog {
+
+class AuthorizationLogicTest : public ::testing::Test {
+public:
+  static fs::path GetTestDataDir() {
+    const char* test_srcdir_env = std::getenv("TEST_SRCDIR");
+    const char* test_workspace_env = std::getenv("TEST_WORKSPACE");
+    EXPECT_NE(test_srcdir_env,  nullptr);
+    EXPECT_NE(test_workspace_env, nullptr);
+    return fs::path(test_srcdir_env) / fs::path(test_workspace_env) /
+      "src" / "xform_to_datalog" / "testdata";
+  }
+
+  static std::vector<std::string> ReadFileLines(const fs::path& file) {
+    // Probably not quite efficient, but should serve the purpose for tests.
+    std::ifstream file_stream(file);
+    EXPECT_TRUE(file_stream) << "Unable to open file " << file;
+
+    std::vector<std::string> result;
+    for (std::string line; std::getline(file_stream, line);) {
+      result.push_back(line);
+    }    
+    return result;
+  }
+};
+
+TEST_F(AuthorizationLogicTest, InvokesRustToolAndGeneratesOutput) {
+  const fs::path& test_data_dir = GetTestDataDir();
+  fs::path output_dir = fs::temp_directory_path();
+  int res = generate_datalog_facts_from_authorization_logic(
+    "simple_auth_logic", test_data_dir.c_str(), output_dir.c_str());
+
+  ASSERT_EQ(res, 0) << "Invoking authorization logic compiler failed.";
+
+  std::vector<std::string> actual_datalog =
+    ReadFileLines(output_dir / "simple_auth_logic.dl");
+  std::vector<std::string> expected_datalog =
+    ReadFileLines(test_data_dir / "simple_auth_logic.dl");
+
+  // Need to compare individual lines as the output order is non-deterministic.
+  ASSERT_THAT(actual_datalog,
+	      testing::UnorderedElementsAreArray(expected_datalog));
+}
+
+TEST_F(AuthorizationLogicTest, ErrorsInRustToolReturnsNonZeroValue) {
+  // Force the tool to return error by specifying non-existent files.
+  int res = generate_datalog_facts_from_authorization_logic(
+    "simple_auth_logic", "blah", "blah");
+  ASSERT_EQ(res, 1);
+}
+  
+}  // namespace raksha::xform_to_datalog

--- a/src/xform_to_datalog/authorization_logic_test.cc
+++ b/src/xform_to_datalog/authorization_logic_test.cc
@@ -24,8 +24,6 @@
 
 namespace fs = std::filesystem;
 
-#include <iostream>
-
 namespace raksha::xform_to_datalog {
 
 class AuthorizationLogicTest : public ::testing::Test {

--- a/src/xform_to_datalog/testdata/BUILD
+++ b/src/xform_to_datalog/testdata/BUILD
@@ -25,4 +25,3 @@ filegroup(
     ],
     testonly = True
 )
-    

--- a/src/xform_to_datalog/testdata/BUILD
+++ b/src/xform_to_datalog/testdata/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------------------------
+package(default_visibility = ["//src:__subpackages__"])
+
+licenses(["notice"])
+
+filegroup(
+    name = "auth_logic",
+    srcs = [
+        "simple_auth_logic",
+        "simple_auth_logic.dl",
+    ],
+    testonly = True
+)
+    

--- a/src/xform_to_datalog/testdata/simple_auth_logic
+++ b/src/xform_to_datalog/testdata/simple_auth_logic
@@ -1,0 +1,2 @@
+"prin1" says fact1(thing_x) :- cond1(thing_x).
+"prin1" says cond1("foo").

--- a/src/xform_to_datalog/testdata/simple_auth_logic.dl
+++ b/src/xform_to_datalog/testdata/simple_auth_logic.dl
@@ -1,0 +1,6 @@
+.decl says_cond1(x0: symbol, x1: symbol)
+.decl grounded_dummy(x0: symbol)
+.decl says_fact1(x0: symbol, x1: symbol)
+says_fact1("prin1", thing_x) :- says_cond1("prin1", thing_x).
+says_cond1("prin1", "foo").
+grounded_dummy("dummy_var").


### PR DESCRIPTION
This PR adds a `rust_library` target named  `authorization_logic_lib` that can be used to call the authorization logic compiler in rust from C++. 