### PR TITLE
Add `override` spec to `EntityType::GetAccessPathSelectorsSet`

### DIFF
--- a/src/ir/types/entity_type.h
+++ b/src/ir/types/entity_type.h
@@ -16,7 +16,8 @@ class EntityType : public Type {
 
   Type::Kind kind() const override { return Type::Kind::kEntity; }
 
-  raksha::ir::AccessPathSelectorsSet GetAccessPathSelectorsSet() const {
+  raksha::ir::AccessPathSelectorsSet
+  GetAccessPathSelectorsSet() const override {
     return schema_.GetAccessPathSelectorsSet();
   }
 


### PR DESCRIPTION
This causes test failure when using `clang` because `clang` warns about the absence of `override` spec.