### PR TITLE
Sort the declarations in souffle_emitter

### DIFF
--- a/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
@@ -102,11 +102,12 @@ impl SouffleEmitter {
     }
 
     fn emit_declarations(&self) -> String {
-        self.decls
+        let mut decls = self.decls
             .iter()
             .map(|x| SouffleEmitter::emit_decl(x))
-            .collect::<Vec<_>>()
-            .join("\n")
+            .collect::<Vec<_>>();
+         decls.sort();
+         decls.join("\n")
     }
 
     fn emit_outputs(&self, p: &DLIRProgram) -> String {


### PR DESCRIPTION
The order of decls are not consistent across runs, which makes the tests brittle. This PR makes the order of decls  consistent by sorting them.