### PR TITLE
Make Cargo Test Great Again

### DIFF
--- a/rust/tools/authorization-logic/src/souffle/lowering_ast_datalog.rs
+++ b/rust/tools/authorization-logic/src/souffle/lowering_ast_datalog.rs
@@ -86,16 +86,18 @@
 //! Neither Souffle nor SecPal support queries, but this language does.
 //! Queries check of a single unconditional assertion is true. A query of
 //! the form:
-//!
-//!      // Q_NAME = query ASSERTION(<ARGS>) ?
+//! ```Datalog
+//!      Q_NAME = query ASSERTION(<ARGS>) ?
+//! ```
 //!
 //! is translated into an assertion with just one argument, and this
 //! assertion is made an output, so we can simply check the CSV that
 //! souffle emits as in:
-//!
-//!      // Q_NAME("dummy_var") :- grounded("dummy_var"), ASSERTION(<ARGS>).
-//!      // grounded("dummy_var").
-//!      // .output Q_NAME
+//! ```Datalog
+//!      Q_NAME("dummy_var") :- grounded("dummy_var"), ASSERTION(<ARGS>).
+//!      grounded("dummy_var").
+//!      .output Q_NAME
+//! ```
 
 use crate::{ast::*, souffle::datalog_ir::*};
 

--- a/rust/tools/authorization-logic/src/souffle/lowering_ast_datalog.rs
+++ b/rust/tools/authorization-logic/src/souffle/lowering_ast_datalog.rs
@@ -87,15 +87,15 @@
 //! Queries check of a single unconditional assertion is true. A query of
 //! the form:
 //!
-//!      Q_NAME = query ASSERTION(<ARGS>) ?
+//!      // Q_NAME = query ASSERTION(<ARGS>) ?
 //!
 //! is translated into an assertion with just one argument, and this
 //! assertion is made an output, so we can simply check the CSV that
 //! souffle emits as in:
 //!
-//!      Q_NAME("dummy_var") :- grounded("dummy_var"), ASSERTION(<ARGS>).
-//!      grounded("dummy_var").
-//!      .output Q_NAME
+//!      // Q_NAME("dummy_var") :- grounded("dummy_var"), ASSERTION(<ARGS>).
+//!      // grounded("dummy_var").
+//!      // .output Q_NAME
 
 use crate::{ast::*, souffle::datalog_ir::*};
 


### PR DESCRIPTION
Just prior to this commit cargo test would fail. It looks like this is
the commit where the regression began:
[PR 148](https://github.com/google-research/raksha/pull/148).
Rustdoc executes code examples, causing syntax errors to be thrown because these comments are not
rust code. This fixes that by making rustdoc aware that this code is actually datalog.