### PR TITLE
Refactor facts to instantiate with pointers rather than copies.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -1,10 +1,29 @@
+#-----------------------------------------------------------------------------
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#----------------------------------------------------------------------------
+
 package(default_visibility = ["//src:__subpackages__"])
 
 cc_library(
     name = "ir",
     srcs = glob(
         ["*.cc"],
-        exclude = ["*_test.cc"],
+        exclude = [
+            "*_test.cc",
+            "access_path_root.cc",
+        ],
     ),
     hdrs = glob(
         ["*.h"],
@@ -14,6 +33,9 @@ cc_library(
             "access_path_selectors.h",
             "access_path_selectors_set.h",
             "field_selector.h",
+            "instantiator.h",
+            "map_instantiator.h",
+            "noop_instantiator.h",
             "selector.h",
         ],
     ),
@@ -32,12 +54,18 @@ cc_library(
 
 cc_library(
     name = "access_path",
+    srcs = [
+        "access_path_root.cc",
+    ],
     hdrs = [
         "access_path.h",
         "access_path_root.h",
         "access_path_selectors.h",
         "access_path_selectors_set.h",
         "field_selector.h",
+        "instantiator.h",
+        "map_instantiator.h",
+        "noop_instantiator.h",
         "selector.h",
     ],
     deps = [

--- a/src/ir/access_path.h
+++ b/src/ir/access_path.h
@@ -5,6 +5,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "src/ir/access_path_selectors.h"
 #include "src/ir/access_path_root.h"
+#include "src/ir/instantiator.h"
 
 namespace raksha::ir {
 
@@ -19,40 +20,11 @@ class AccessPath {
       access_path_selectors_(std::move(access_path_selectors)) {}
 
   // Express the AccessPath as a string. This is accomplished by
-  // concatenating the root string and the selectors string.
-  std::string ToString() const {
-    return absl::StrCat(root_.ToString(), access_path_selectors_.ToString());
-  }
-
-  // Return a new AccessPath, identical to *this, except with the AccessPath
-  // root replaced with the indicated instantiated root. Note that this expects
-  // the current access path to not already be instantiated.
-  AccessPath Instantiate(AccessPathRoot new_root) const {
-    CHECK(!root_.IsInstantiated())
-      << "Attempt to instantiate an AccessPath that is already instantiated.";
-    CHECK(new_root.IsInstantiated())
-      << "Attempt to instantiate an AccessPath with an uninstantiated root.";
-    return AccessPath(std::move(new_root), access_path_selectors_);
-  }
-
-  // This is used to allow this AccessPath to participate in a bulk
-  // instantiation of AccessPaths (such as, for instance, all of the
-  // AccessPaths referenced by a particular ParticleSpec).
-  AccessPath BulkInstantiate(
-      const absl::flat_hash_map<AccessPathRoot, AccessPathRoot>
-      &instantiation_map) const {
-    // Check that the root is not already instantiated. This may not be
-    // the correct long-term behavior; we may want to just returning the
-    // current instantiated AccessPath. Asserting it is not instantiated,
-    // however, is safe and easy short-term behavior.
-    CHECK(!root_.IsInstantiated())
-      << "Expected to instantiate only uninstantiated roots.";
-    auto find_res = instantiation_map.find(root_);
-    CHECK(find_res != instantiation_map.end())
-      << "Could not find entry to instantiate access path in "
-      << "instantiation_map.";
-    AccessPathRoot new_root = find_res->second;
-    return Instantiate(std::move(new_root));
+  // concatenating the string of the instantiated root with the selectors
+  // string.
+  std::string ToString(const Instantiator &instantiator) const {
+    return absl::StrCat(
+        root_.ToString(instantiator), access_path_selectors_.ToString());
   }
 
   const AccessPathRoot &root() const { return root_; }

--- a/src/ir/access_path_root.cc
+++ b/src/ir/access_path_root.cc
@@ -1,0 +1,34 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#include "src/ir/access_path_root.h"
+
+#include "src/ir/instantiator.h"
+#include "src/ir/noop_instantiator.h"
+
+namespace raksha::ir {
+
+// Replace the root with the instantiated root provided by instantiator, then
+// call ToString on that root. Pass in the NoopInstantiator rather than the
+// given instantiator because we expect the returned root to already be
+// instantiated.
+std::string HandleConnectionSpecAccessPathRoot::ToString(
+    const Instantiator &instantiator) const {
+  return instantiator.GetInstantiatedRoot(AccessPathRoot(*this))
+    .ToString(NoopInstantiator::Get());
+}
+
+}  // namespace raksha::ir

--- a/src/ir/access_path_root_test.cc
+++ b/src/ir/access_path_root_test.cc
@@ -1,7 +1,25 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
 #include "src/ir/access_path_root.h"
 
 #include "absl/hash/hash_testing.h"
 #include "src/common/testing/gtest.h"
+#include "src/ir/noop_instantiator.h"
+#include "src/ir/map_instantiator.h"
 
 namespace raksha::ir {
 
@@ -9,11 +27,18 @@ TEST(HandleConnectionSpecAccessPathRootBehaviorTest,
     HandleConnectionSpecAccessPathRootBehaviorTest) {
   HandleConnectionSpecAccessPathRoot spec_access_path_root
     ("particle_spec_name", "handle_access_path_spec_name");
+  const MapInstantiator kMapInstantiator(
+      absl::flat_hash_map<AccessPathRoot, AccessPathRoot>{ {
+        AccessPathRoot(spec_access_path_root),
+        AccessPathRoot(HandleConnectionAccessPathRoot(
+            "recipe", "particle", "handle_conn")) } });
   AccessPathRoot test_access_path_root(spec_access_path_root);
   EXPECT_FALSE(test_access_path_root.IsInstantiated());
-  EXPECT_DEATH(test_access_path_root.ToString(),
-               "Attempted to print out an AccessPath before connecting it "
-                  "to a fully-instantiated root!");
+  EXPECT_EQ(test_access_path_root.ToString(kMapInstantiator),
+            "recipe.particle.handle_conn");
+  EXPECT_DEATH(test_access_path_root.ToString(NoopInstantiator::Get()),
+               "Attempt to instantiate a non-instantiated root with the "
+               "NoopInstantiator!");
 }
 
 TEST(HandleConnectionAccessPathRootTest, HandleConnectionAccessPathRootTest) {
@@ -21,14 +46,16 @@ TEST(HandleConnectionAccessPathRootTest, HandleConnectionAccessPathRootTest) {
       "recipe", "particle", "handle");
   AccessPathRoot test_access_path_root(handle_connection_access_path_root);
   EXPECT_TRUE(test_access_path_root.IsInstantiated());
-  EXPECT_EQ(test_access_path_root.ToString(), "recipe.particle.handle");
+  EXPECT_EQ(test_access_path_root.ToString(NoopInstantiator::Get()),
+            "recipe.particle.handle");
 }
 
 TEST(HandleAccessPathRootTest, HandleAccessPathRootTest) {
   HandleAccessPathRoot handle_connection_access_path_root("recipe", "handle");
   AccessPathRoot test_access_path_root(handle_connection_access_path_root);
   EXPECT_TRUE(test_access_path_root.IsInstantiated());
-  EXPECT_EQ(test_access_path_root.ToString(), "recipe.handle");
+  EXPECT_EQ(test_access_path_root.ToString(NoopInstantiator::Get()),
+            "recipe.handle");
 }
 
 enum AccessPathRootKind {

--- a/src/ir/edge.h
+++ b/src/ir/edge.h
@@ -1,7 +1,24 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
 #ifndef SRC_IR_EDGE_H_
 #define SRC_IR_EDGE_H_
 
 #include "src/ir/access_path.h"
+#include "src/ir/instantiator.h"
 #include "absl/strings/str_format.h"
 
 namespace raksha::ir {
@@ -15,21 +32,14 @@ class Edge {
     : from_(std::move(from)), to_(std::move(to)) {}
 
   // Print the edge as a string containing a Datalog fact.
-  std::string ToDatalog() const {
+  std::string ToDatalog(const ir::Instantiator &instantiator) const {
     constexpr absl::string_view kEdgeFormat = R"(edge("%s", "%s").)";
-    return absl::StrFormat(kEdgeFormat, from_.ToString(), to_.ToString());
+    return absl::StrFormat(
+        kEdgeFormat, from_.ToString(instantiator), to_ .ToString(instantiator));
   }
 
   bool operator==(const Edge &other) const {
     return (from_ == other.from_) && (to_ == other.to_);
-  }
-
-  Edge BulkInstantiate(
-      const absl::flat_hash_map<AccessPathRoot, AccessPathRoot>
-          &instantiation_map) const {
-    return Edge(
-        from_.BulkInstantiate(instantiation_map),
-        to_.BulkInstantiate(instantiation_map));
   }
 
  private:

--- a/src/ir/edge_test.cc
+++ b/src/ir/edge_test.cc
@@ -1,7 +1,24 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
 #include "src/ir/edge.h"
 
 #include "src/common/testing/gtest.h"
 #include "src/ir/access_path_root.h"
+#include "src/ir/noop_instantiator.h"
 
 namespace raksha::ir {
 
@@ -45,7 +62,7 @@ TEST_P(EdgeToDatalogTest, EdgeToDatalogTest) {
   const Edge &edge = std::get<0>(GetParam());
   const std::string &expected_to_string = std::get<1>(GetParam());
 
-  EXPECT_EQ(edge.ToDatalog(), expected_to_string);
+  EXPECT_EQ(edge.ToDatalog(NoopInstantiator::Get()), expected_to_string);
 }
 
 INSTANTIATE_TEST_SUITE_P(EdgeToDatalogTest, EdgeToDatalogTest,

--- a/src/ir/instance_fact.h
+++ b/src/ir/instance_fact.h
@@ -1,0 +1,119 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#ifndef SRC_IR_INSTANCE_FACT_H_
+#define SRC_IR_INSTANCE_FACT_H_
+
+#include "src/ir/instantiator.h"
+#include "src/ir/noop_instantiator.h"
+
+// An InstanceFact is an instantation of some other fact that may be
+// initially not fully instantiated.
+//
+// Consider, for instance, the case of checks and claims on a ParticleSpec.
+// Checks and claims describe the check or claim they wish to perform on
+// AccessPaths rooted at the ParticleSpec. At some point, however, they must be
+// printed out as performing those claims and checks upon the access paths of
+// an actual instantiated particle.
+//
+// To do this, we create an InstanceFact upon the check or claim (or any
+// other instantiatable fact). The InstanceFact points at the original,
+// uninstantiated fact, and an Instantiator, which is just an object that
+// will give us a map from uninstantiated AccessPath roots to instantiated
+// AccessPath roots. Using the mapping provided by the instantiator, we can
+// transform details of the uninstantiated fact to be instantiated on the fly.
+// This prevents having to copy the data initially on the uninstantiated
+// fact, sidestepping the pointer ownership quandries and performance
+// penalties we may otherwise have to deal with.
+
+namespace raksha::ir {
+
+// This class represents an instantiation of a fact that was originally
+// stated about some uninstantiated root (such as a HandleConnectionSpec)
+// using an Instantiator.
+template<class T>
+class InstantiatedInstanceFact {
+ public:
+  InstantiatedInstanceFact(
+      const T &original_fact, const Instantiator &instantiator)
+      : original_fact_(&original_fact), instantiator_(&instantiator) {}
+
+  std::string ToDatalog() const {
+    return original_fact_->ToDatalog(*instantiator_);
+  }
+
+ private:
+  const T *original_fact_;
+  const Instantiator *instantiator_;
+};
+
+// This class represents a fact that was instantiated at its creation, and
+// thus is directly embedded into the InstanceFact. Because it is already
+// instantiated, we always use the NoopInstantiator when calling methods upon
+// it.
+template<class T>
+class ImmediateInstanceFact {
+ public:
+  ImmediateInstanceFact(T fact) : inner_fact_(std::move(fact)) { }
+
+  std::string ToDatalog() const {
+    return inner_fact_.ToDatalog(NoopInstantiator::Get());
+  }
+ private:
+  T inner_fact_;
+};
+
+// The InstanceFact wraps a std::variant containing both of the above cases
+// and acts as if it were an interface-style abstract class.
+template<class T>
+class InstanceFact {
+ public:
+  using SpecificFactInstantiation =
+      std::variant<InstantiatedInstanceFact<T>, ImmediateInstanceFact<T>>;
+
+  explicit InstanceFact(SpecificFactInstantiation specific_fact_instantiation)
+    : specific_fact_instantiation_(std::move(specific_fact_instantiation)) {}
+
+  std::string ToDatalog() const {
+    return std::visit(
+        [](const auto &specific_fact_instantiation) {
+          return specific_fact_instantiation.ToDatalog();
+        }, specific_fact_instantiation_);
+  }
+
+ private:
+  SpecificFactInstantiation specific_fact_instantiation_;
+};
+
+// We define these factory functions outside of the InstanceFact class to
+// allow for less boilerplate when calling the function.
+
+// A factory helper function for creating an ImmediateInstanceFact.
+template<class F>
+static InstanceFact<F> CreateImmediateInstanceFact(F fact) {
+  return InstanceFact<F>(ImmediateInstanceFact(fact));
+}
+
+// A factory helper function for creating an InstantiatedInstanceFact.
+template<class F>
+static InstanceFact<F> CreateInstantiatedInstanceFact(
+    const F &original_fact, const Instantiator &instantiator) {
+  return InstanceFact<F>(InstantiatedInstanceFact(original_fact, instantiator));
+}
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_INSTANCE_FACT_H_

--- a/src/ir/instantiator.h
+++ b/src/ir/instantiator.h
@@ -1,0 +1,40 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#ifndef SRC_IR_INSTANTIATOR_H_
+#define SRC_IR_INSTANTIATOR_H_
+
+#include "absl/container/flat_hash_map.h"
+
+namespace raksha::ir {
+
+// Forward declaration needed to break inclusion cycle between AccessPathRoot
+// and Instantiator.
+class AccessPathRoot;
+
+// Classes that implement this interface can provide an instantiated root
+// that should be used in place of an uninstantiated root.
+class Instantiator {
+ public:
+  virtual ~Instantiator() {}
+
+  virtual const AccessPathRoot &GetInstantiatedRoot(
+      const AccessPathRoot &original_root) const = 0;
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_INSTANTIATOR_H_

--- a/src/ir/map_instantiator.h
+++ b/src/ir/map_instantiator.h
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#ifndef SRC_IR_MAP_INSTANTIATOR_H_
+#define SRC_IR_MAP_INSTANTIATOR_H_
+
+#include "absl/container/flat_hash_map.h"
+#include "src/ir/instantiator.h"
+
+namespace raksha::ir {
+
+// An instantiator that just directly holds an instantiation map. In the
+// future, we probably want to prefer to use an Instantiator that corresponds
+// to some language feature (like a Particle in the Arcs manifest) but for
+// now, this allows us to perform instantiation without having to directly
+// tackle refactoring our traversal of arcs protos (issue #107).
+class MapInstantiator : public Instantiator {
+ public:
+  MapInstantiator(absl::flat_hash_map<AccessPathRoot, AccessPathRoot>
+      instantiation_map) : instantiation_map_(std::move(instantiation_map)) {}
+
+  const AccessPathRoot &GetInstantiatedRoot(
+      const AccessPathRoot &original_root) const override {
+    auto find_res = instantiation_map_.find(original_root);
+    CHECK(find_res != instantiation_map_.end())
+      << "Could not find match to instantiate original root"
+      << " in GetInstantiatedRoot.";
+    return find_res->second;
+  }
+
+ private:
+  const absl::flat_hash_map<AccessPathRoot, AccessPathRoot>
+      instantiation_map_;
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_MAP_INSTANTIATOR_H_

--- a/src/ir/noop_instantiator.h
+++ b/src/ir/noop_instantiator.h
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#ifndef SRC_IR_NOOP_INSTANTIATOR_H_
+#define SRC_IR_NOOP_INSTANTIATOR_H_
+
+#include "src/ir/access_path_root.h"
+#include "src/ir/instantiator.h"
+
+namespace raksha::ir {
+
+// This trivial implementation of Instantiator does no instantiation. It just
+// checks that the AccessPathRoot is already instantiated. There is one
+// single canonical instance of it.
+class NoopInstantiator : public Instantiator {
+ public:
+  static NoopInstantiator Get() {
+    static NoopInstantiator instance_;
+    return instance_;
+  }
+
+  const AccessPathRoot &GetInstantiatedRoot(
+      const AccessPathRoot &original) const {
+    CHECK(original.IsInstantiated())
+      << "Attempt to instantiate a non-instantiated root with the "
+      << "NoopInstantiator!";
+    return original;
+  }
+ private:
+  NoopInstantiator() {}
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_NOOP_INSTANTIATOR_H_

--- a/src/ir/proto/access_path_test.cc
+++ b/src/ir/proto/access_path_test.cc
@@ -17,6 +17,8 @@
 
 #include "google/protobuf/text_format.h"
 #include "src/common/testing/gtest.h"
+#include "src/ir/map_instantiator.h"
+#include "src/ir/noop_instantiator.h"
 
 namespace raksha::ir::proto {
 
@@ -35,13 +37,13 @@ TEST_P(AccessPathFromProtoTest, AccessPathFromProtoTest) {
 
   AccessPathRoot root(
       HandleConnectionAccessPathRoot("recipe", "particle", "handle"));
+  absl::flat_hash_map<AccessPathRoot, AccessPathRoot> instantiation_map {
+      {AccessPathRoot(HandleConnectionSpecAccessPathRoot("ps", "hc")),
+       AccessPathRoot(root)}
+  };
   ASSERT_EQ(
-      access_path.Instantiate(root).ToString(),
+      access_path.ToString(MapInstantiator(instantiation_map)),
       "recipe.particle.handle" + expected_tostring_suffix);
-  ASSERT_DEATH(
-      access_path.ToString(),
-      "Attempted to print out an AccessPath before connecting it to a "
-      "fully-instantiated root!");
 }
 
 static const std::tuple<std::string, std::string>

--- a/src/ir/tag_annotation_on_access_path.h
+++ b/src/ir/tag_annotation_on_access_path.h
@@ -66,18 +66,6 @@ class TagAnnotationOnAccessPath {
     return TagAnnotationOnAccessPath(access_path, label.semantic_tag());
   }
 
-  TagAnnotationOnAccessPath Instantiate(AccessPathRoot new_root) const {
-    return TagAnnotationOnAccessPath(
-        access_path_.Instantiate(std::move(new_root)), tag_);
-  }
-
-  TagAnnotationOnAccessPath BulkInstantiate(
-      const absl::flat_hash_map<AccessPathRoot, AccessPathRoot>
-          &instantiation_map) const {
-    return TagAnnotationOnAccessPath(
-        access_path_.BulkInstantiate(instantiation_map), tag_);
-  }
-
   explicit TagAnnotationOnAccessPath(
       AccessPath access_path, std::string tag)
       : access_path_(access_path), tag_(tag) {}

--- a/src/ir/tag_check.h
+++ b/src/ir/tag_check.h
@@ -1,8 +1,25 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
 #ifndef SRC_IR_TAG_CHECK_H_
 #define SRC_IR_TAG_CHECK_H_
 
 #include "absl/strings/str_format.h"
 #include "src/ir/tag_annotation_on_access_path.h"
+#include "src/ir/instantiator.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
@@ -20,29 +37,15 @@ class TagCheck {
   TagCheck(TagAnnotationOnAccessPath tag_annotation_on_access_path)
     : tag_annotation_on_access_path_(tag_annotation_on_access_path) {}
 
-  TagCheck Instantiate(AccessPathRoot access_path_root) const {
-    return TagCheck(
-        tag_annotation_on_access_path_.Instantiate(access_path_root));
-  }
-
-  // Allow this TagCheck to participate in a bulk instantiation of multiple
-  // uninstantiated AccessPaths.
-  TagCheck BulkInstantiate(
-      const absl::flat_hash_map<AccessPathRoot, AccessPathRoot>
-          &instantiation_map) const {
-    return TagCheck(tag_annotation_on_access_path_.BulkInstantiate(
-        instantiation_map));
-  }
-
   // Print out the tag check as a Datalog fact. This is currently very
   // simplified relative to the arbitrary boolean expression predicate we
   // will eventually want, but is enough to get some simple Arcs tests
   // passing for the MVP.
-  std::string ToDatalog() const {
+  std::string ToDatalog(const Instantiator &instantiator) const {
     constexpr absl::string_view kCheckHasTagFormat =
         R"(checkHasTag("%s", "%s") :- mayHaveTag("%s", "%s").)";
     std::string access_path =
-        tag_annotation_on_access_path_.access_path().ToString();
+        tag_annotation_on_access_path_.access_path().ToString(instantiator);
     std::string tag = tag_annotation_on_access_path_.tag();
 
     return absl::StrFormat(kCheckHasTagFormat, access_path, tag, access_path,

--- a/src/xform_to_datalog/BUILD
+++ b/src/xform_to_datalog/BUILD
@@ -1,3 +1,4 @@
+#-------------------------------------------------------------------------------
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +19,7 @@ licenses(["notice"])
 cc_library(
     name = "authorization_logic",
     hdrs = ["authorization_logic.h"],
-    deps = ["//rust/tools/authorization-logic:authorization_logic_lib"]
+    deps = ["//rust/tools/authorization-logic:authorization_logic_lib"],
 )
 
 cc_test(
@@ -28,7 +29,7 @@ cc_test(
     deps = [
         ":authorization_logic",
         "//src/common/testing:gtest",
-    ]
+    ],
 )
 
 cc_library(
@@ -42,11 +43,24 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "manifest_datalog_facts_to_datalog_test",
+    testonly = True,
+    hdrs = ["manifest_datalog_facts_to_datalog_test.h"],
+    deps = [
+        ":datalog_facts",
+        "//src/common/testing:gtest",
+        "//src/ir",
+        "//src/ir:access_path",
+    ],
+)
+
 cc_test(
     name = "datalog_facts_test",
     srcs = ["datalog_facts_test.cc"],
     deps = [
         ":datalog_facts",
+        ":manifest_datalog_facts_to_datalog_test",
         "//src/common/testing:gtest",
     ],
 )
@@ -68,6 +82,7 @@ cc_test(
     srcs = ["manifest_datalog_facts_test.cc"],
     deps = [
         ":manifest_datalog_facts",
+        ":manifest_datalog_facts_to_datalog_test",
         "//src/common/testing:gtest",
     ],
 )

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -17,23 +17,24 @@
 
 #include "src/common/testing/gtest.h"
 #include "src/xform_to_datalog/manifest_datalog_facts.h"
+#include "src/xform_to_datalog/manifest_datalog_facts_to_datalog_test.h"
 
 namespace raksha::xform_to_datalog {
 
-class DatalogFactsTest : public testing::TestWithParam<
-                             std::pair<ManifestDatalogFacts, std::string>> {};
-
-TEST_P(DatalogFactsTest, IncludesManifestFactsWithCorrectPrefixAndSuffix) {
-  const auto& [manifest_datalog_facts, expected_string] = GetParam();
-  DatalogFacts datalog_facts(manifest_datalog_facts);
-  EXPECT_EQ(datalog_facts.ToDatalog(), expected_string);
+TEST_P(ManifestDatalogFactsToDatalogTest,
+       IncludesManifestFactsWithCorrectPrefixAndSuffix) {
+  DatalogFacts datalog_facts(GetDatalogFacts());
+  EXPECT_EQ(datalog_facts.ToDatalog(), expected_result_string_);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    DatalogFactsTest, DatalogFactsTest,
+    DatalogFactsTest, ManifestDatalogFactsToDatalogTest,
     testing::Values(
-        std::make_pair(ManifestDatalogFacts({}, {}, {}),
-                       R"(// GENERATED FILE, DO NOT EDIT!
+        std::tuple<
+            std::vector<raksha::ir::InstanceFact<raksha::ir::TagClaim>>,
+            std::vector<raksha::ir::InstanceFact<raksha::ir::TagCheck>>,
+            std::vector<raksha::ir::InstanceFact<raksha::ir::Edge>>,
+            std::string>{ {}, {}, {}, R"(// GENERATED FILE, DO NOT EDIT!
 
 #include "taint.dl"
 .output checkHasTag
@@ -46,10 +47,13 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Edges:
 
-)"),
-        std::make_pair(
-            ManifestDatalogFacts(
-                {ir::TagClaim(
+)" },
+   std::tuple<
+      std::vector<raksha::ir::InstanceFact<raksha::ir::TagClaim>>,
+      std::vector<raksha::ir::InstanceFact<raksha::ir::TagCheck>>,
+      std::vector<raksha::ir::InstanceFact<raksha::ir::Edge>>,
+      std::string>{ {
+      ir::CreateImmediateInstanceFact(ir::TagClaim(
                     "particle",
                       ir::AccessPath(
                           ir::AccessPathRoot(
@@ -57,9 +61,7 @@ INSTANTIATE_TEST_SUITE_P(
                                   "recipe", "particle", "out")),
                       ir::AccessPathSelectors()),
                       true,
-                      "tag")},
-                {}, {}),
-            R"(// GENERATED FILE, DO NOT EDIT!
+                      "tag")) }, {}, {}, R"(// GENERATED FILE, DO NOT EDIT!
 
 #include "taint.dl"
 .output checkHasTag
@@ -72,6 +74,6 @@ claimHasTag("particle", "recipe.particle.out", "tag").
 
 // Edges:
 
-)")));
+)"} ));
 
 }  // namespace raksha::xform_to_datalog

--- a/src/xform_to_datalog/manifest_datalog_facts_to_datalog_test.h
+++ b/src/xform_to_datalog/manifest_datalog_facts_to_datalog_test.h
@@ -1,0 +1,63 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#ifndef SRC_XFORM_TO_DATALOG_MANIFEST_DATALOG_FACTS_TO_DATALOG_TEST_H_
+#define SRC_XFORM_TO_DATALOG_MANIFEST_DATALOG_FACTS_TO_DATALOG_TEST_H_
+
+#include <string>
+#include <vector>
+
+#include "src/ir/edge.h"
+#include "src/ir/instance_fact.h"
+#include "src/ir/tag_claim.h"
+#include "src/ir/tag_check.h"
+#include "src/xform_to_datalog/manifest_datalog_facts.h"
+
+// A test fixture used for constructing a ManifestDatalogFacts from the given
+// arguments, each of which is already instantiated with an instantiator that
+// does not have to be handled by this class. Test parameterization is
+// unhappy with types that cannot be copied (ManifestDatalogFacts is one of
+// those due to the owned instantiators), so it's useful to have a fixture
+// that will construct a ManifestDatalogFacts from arguments.
+
+namespace raksha::xform_to_datalog {
+
+class ManifestDatalogFactsToDatalogTest :
+   public testing::TestWithParam<
+    std::tuple<
+      std::vector<raksha::ir::InstanceFact<raksha::ir::TagClaim>>,
+      std::vector<raksha::ir::InstanceFact<raksha::ir::TagCheck>>,
+      std::vector<raksha::ir::InstanceFact<raksha::ir::Edge>>,
+      std::string>> {
+ protected:
+  ManifestDatalogFactsToDatalogTest()
+    : expected_result_string_(std::get<3>(GetParam())) {}
+
+  // Note: We provide the ManifestDatalogFacts to the test via this method
+  // rather than the usual way of via a protected field to work around the
+  // single-copy property of std::unique_ptr.
+  ManifestDatalogFacts GetDatalogFacts() const {
+    return ManifestDatalogFacts(
+        std::get<0>(GetParam()), std::get<1>(GetParam()),
+        std::get<2>(GetParam()), {}, {});
+  }
+
+  std::string expected_result_string_;
+};
+
+}  // namespace raksha::xform_to_datalog
+
+#endif  // SRC_XFORM_TO_DATALOG_MANIFEST_DATALOG_FACTS_TO_DATALOG_TEST_H_


### PR DESCRIPTION
Previously, we have instantiated facts such as checks, claims, and edges
by creating a copy of the original fact with a new AccessPathRoot
indicating the instantiated root. This was always dubious from
a performance standpoint. However, as I started another PR in which
I was introducing we have started introducing complex checks with
predicate trees pointed to by unique_ptrs, the memory ownership
considerations became too complex to keep the status quo.

This commit instead introduces a wrapper for facts that may not be
instantiated called InstanceFact. InstanceFact contains a variant that
associates a pointer to the original fact with an Instantiator, which
contains the information needed to replace the uninstantiated root with
an instantiated root. There is another variant for facts that were
instantiated initially that just wraps that fact and implicitly
associates it with a NoopInstantiator (which just asserts that the roots
it encounters are already instantiated).

Rather than having an instantiated copy, Instantiators allow for
instantiating AccessPathRoots as they are encountered, preventing a copy
from being necessary.

The use of pointers rather than copies introduced lifetime
considerations in a number of places where they were not present before,
most notably in ManifestDatalogFacts, which now must store a list of
unique_ptrs to ParticleSpecs and Instantiators that it relies upon being
live at least as long as its component InstanceFacts.