### PR TITLE
    Command line option to skip list of declarations

### DIFF
--- a/rust/tools/authorization-logic/src/compilation_top_level.rs
+++ b/rust/tools/authorization-logic/src/compilation_top_level.rs
@@ -38,9 +38,11 @@ fn source_file_to_ast(filename: &str, in_dir: &str) -> AstProgram {
     astconstructionvisitor::parse_program(&source[..])
 }
 
-pub fn compile(filename: &str, in_dir: &str, out_dir: &str) {
+pub fn compile(filename: &str, in_dir: &str, out_dir: &str,
+            decl_skip: &Vec<&str>) {
     let prog = source_file_to_ast(filename, in_dir);
     let prog_with_imports = import_assertions::handle_imports(&prog);
-    souffle_interface::ast_to_souffle_file(&prog_with_imports, filename, out_dir);
+    souffle_interface::ast_to_souffle_file(&prog_with_imports, filename,
+                                           out_dir, decl_skip);
     export_assertions::export_assertions(&prog_with_imports);
 }

--- a/rust/tools/authorization-logic/src/compilation_top_level.rs
+++ b/rust/tools/authorization-logic/src/compilation_top_level.rs
@@ -39,7 +39,7 @@ fn source_file_to_ast(filename: &str, in_dir: &str) -> AstProgram {
 }
 
 pub fn compile(filename: &str, in_dir: &str, out_dir: &str,
-            decl_skip: &Vec<&str>) {
+            decl_skip: &Option<Vec<String>>) {
     let prog = source_file_to_ast(filename, in_dir);
     let prog_with_imports = import_assertions::handle_imports(&prog);
     souffle_interface::ast_to_souffle_file(&prog_with_imports, filename,

--- a/rust/tools/authorization-logic/src/main.rs
+++ b/rust/tools/authorization-logic/src/main.rs
@@ -31,8 +31,15 @@ fn main() {
     let filename = &args[1];
     let in_dir = &args[2];
     let out_dir = &args[3];
-    let decl_skip = &args[4].split(',').collect::<Vec<_>>();
-    compilation_top_level::compile(filename, in_dir, out_dir, decl_skip);
+    let decl_skip: Option<Vec<String>> = if(args.len() >3) 
+        { Some(args[4]
+            .split(',')
+            .map(|s| s.to_string())
+            .collect())
+        } else {
+            None
+        };
+    compilation_top_level::compile(filename, in_dir, out_dir, &decl_skip);
     souffle::souffle_interface::run_souffle(&format!("{}/{}.dl", out_dir,
                                                     filename), out_dir);
 }

--- a/rust/tools/authorization-logic/src/main.rs
+++ b/rust/tools/authorization-logic/src/main.rs
@@ -31,6 +31,8 @@ fn main() {
     let filename = &args[1];
     let in_dir = &args[2];
     let out_dir = &args[3];
-    compilation_top_level::compile(filename, in_dir, out_dir);
-    souffle::souffle_interface::run_souffle(&format!("{}/{}.dl", out_dir, filename), out_dir);
+    let decl_skip = &args[4].split(',').collect::<Vec<_>>();
+    compilation_top_level::compile(filename, in_dir, out_dir, decl_skip);
+    souffle::souffle_interface::run_souffle(&format!("{}/{}.dl", out_dir,
+                                                    filename), out_dir);
 }

--- a/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
@@ -24,15 +24,15 @@ pub struct SouffleEmitter {
 }
 
 impl SouffleEmitter {
-    /// Produces Souffle code as a `String` when given A Datalog IR (DLIR) program.
-    pub fn emit_program(p: &DLIRProgram) -> String {
+    /// Produces Souffle code as a `String` when given a Datalog IR (DLIR) program.
+    pub fn emit_program(p: &DLIRProgram, decl_skip: Option<&Vec<&str>>) -> String {
         let mut emitter = SouffleEmitter::new();
         // It is important to generate the body first in this case
         // because the declarations are populated by side-effect while
         // generating the body.
         let body = emitter.emit_program_body(p);
         let outputs = emitter.emit_outputs(p);
-        let decls = emitter.emit_declarations();
+        let decls = emitter.emit_declarations(decl_skip.unwrap_or(&Vec::new()));
         vec![decls, body, outputs].join("\r\n")
     }
 
@@ -101,10 +101,13 @@ impl SouffleEmitter {
         )
     }
 
-    fn emit_declarations(&self) -> String {
+    fn emit_declarations(&self, decl_skip: &Vec<&str>) -> String {
         self.decls
             .iter()
-            .map(|x| SouffleEmitter::emit_decl(x))
+            .map(|x| 
+                 let name = &x.name: &str;
+                 if (&decl_skip).contains(name)
+                { "".to_string() } else { SouffleEmitter::emit_decl(x) })
             .collect::<Vec<_>>()
             .join("\r\n")
     }

--- a/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
@@ -25,14 +25,15 @@ pub struct SouffleEmitter {
 
 impl SouffleEmitter {
     /// Produces Souffle code as a `String` when given a Datalog IR (DLIR) program.
-    pub fn emit_program(p: &DLIRProgram, decl_skip: Option<&Vec<&str>>) -> String {
+    pub fn emit_program(p: &DLIRProgram, decl_skip: &Option<Vec<String>>) -> String {
         let mut emitter = SouffleEmitter::new();
         // It is important to generate the body first in this case
         // because the declarations are populated by side-effect while
         // generating the body.
         let body = emitter.emit_program_body(p);
         let outputs = emitter.emit_outputs(p);
-        let decls = emitter.emit_declarations(decl_skip.unwrap_or(&Vec::new()));
+        let decls = emitter.emit_declarations(
+            decl_skip.as_ref().unwrap_or(&Vec::new()));
         vec![decls, body, outputs].join("\r\n")
     }
 
@@ -101,12 +102,11 @@ impl SouffleEmitter {
         )
     }
 
-    fn emit_declarations(&self, decl_skip: &Vec<&str>) -> String {
+    fn emit_declarations(&self, decl_skip: &Vec<String>) -> String {
         self.decls
             .iter()
             .map(|x| 
-                 let name = &x.name: &str;
-                 if (&decl_skip).contains(name)
+                 if decl_skip.contains(&x.name)
                 { "".to_string() } else { SouffleEmitter::emit_decl(x) })
             .collect::<Vec<_>>()
             .join("\r\n")

--- a/rust/tools/authorization-logic/src/souffle/souffle_interface.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_interface.rs
@@ -32,7 +32,7 @@ pub fn emit_souffle(filename: &str) {
     let source = fs::read_to_string(filename).expect("failed to read input in emit_souffle");
     let prog = astconstructionvisitor::parse_program(&source[..]);
     let dlir_prog = LoweringToDatalogPass::lower(&prog);
-    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, None);
+    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, &None);
     println!("souffle code from {}, \n{}", &filename, souffle_code);
 }
 
@@ -44,7 +44,7 @@ pub fn input_to_souffle_file(filename: &str, in_dir: &str, out_dir: &str) {
         .expect("failed to read input in input_to_souffle_file");
     let prog = astconstructionvisitor::parse_program(&source[..]);
     let dlir_prog = LoweringToDatalogPass::lower(&prog);
-    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, None);
+    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, &None);
     fs::write(&format!("{}/{}.dl", out_dir, filename), souffle_code)
         .expect("failed to write output to file");
 }
@@ -54,9 +54,9 @@ pub fn input_to_souffle_file(filename: &str, in_dir: &str, out_dir: &str) {
 /// passes that work on the highest level IR besides the one used to emit the
 /// main code.
 pub fn ast_to_souffle_file(prog: &AstProgram, filename: &str,
-                           out_dir: &str, decl_skip: &Vec<&str>) {
+                           out_dir: &str, decl_skip: &Option<Vec<String>>) {
     let dlir_prog = LoweringToDatalogPass::lower(&prog);
-    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, Some(&decl_skip));
+    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, decl_skip);
     fs::write(&format!("{}/{}.dl", out_dir, filename), souffle_code)
         .expect("failed to write output to file");
 }

--- a/rust/tools/authorization-logic/src/souffle/souffle_interface.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_interface.rs
@@ -32,7 +32,7 @@ pub fn emit_souffle(filename: &str) {
     let source = fs::read_to_string(filename).expect("failed to read input in emit_souffle");
     let prog = astconstructionvisitor::parse_program(&source[..]);
     let dlir_prog = LoweringToDatalogPass::lower(&prog);
-    let souffle_code = SouffleEmitter::emit_program(&dlir_prog);
+    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, None);
     println!("souffle code from {}, \n{}", &filename, souffle_code);
 }
 
@@ -44,7 +44,7 @@ pub fn input_to_souffle_file(filename: &str, in_dir: &str, out_dir: &str) {
         .expect("failed to read input in input_to_souffle_file");
     let prog = astconstructionvisitor::parse_program(&source[..]);
     let dlir_prog = LoweringToDatalogPass::lower(&prog);
-    let souffle_code = SouffleEmitter::emit_program(&dlir_prog);
+    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, None);
     fs::write(&format!("{}/{}.dl", out_dir, filename), souffle_code)
         .expect("failed to write output to file");
 }
@@ -53,9 +53,10 @@ pub fn input_to_souffle_file(filename: &str, in_dir: &str, out_dir: &str) {
 /// This is needed in addition to the above function since there are other
 /// passes that work on the highest level IR besides the one used to emit the
 /// main code.
-pub fn ast_to_souffle_file(prog: &AstProgram, filename: &str, out_dir: &str) {
+pub fn ast_to_souffle_file(prog: &AstProgram, filename: &str,
+                           out_dir: &str, decl_skip: &Vec<&str>) {
     let dlir_prog = LoweringToDatalogPass::lower(&prog);
-    let souffle_code = SouffleEmitter::emit_program(&dlir_prog);
+    let souffle_code = SouffleEmitter::emit_program(&dlir_prog, Some(&decl_skip));
     fs::write(&format!("{}/{}.dl", out_dir, filename), souffle_code)
         .expect("failed to write output to file");
 }

--- a/rust/tools/authorization-logic/src/test/test_claim_importing.rs
+++ b/rust/tools/authorization-logic/src/test/test_claim_importing.rs
@@ -30,6 +30,7 @@ mod test {
             &t.filename.to_string(),
             &"test_inputs".to_string(),
             &"test_outputs".to_string(),
+            &None
         );
         run_souffle(
             &format!("test_outputs/{}.dl", t.filename),
@@ -53,6 +54,7 @@ mod test {
             &"importing_export_half".to_string(),
             &"test_inputs".to_string(),
             &"test_outputs".to_string(),
+            &None
         );
 
         // This code imports statements into test_inputs/importing

--- a/rust/tools/authorization-logic/src/test/test_export_signatures.rs
+++ b/rust/tools/authorization-logic/src/test/test_export_signatures.rs
@@ -33,6 +33,7 @@ mod test {
             &"exporting".to_string(),
             &"test_inputs".to_string(),
             &"test_outputs".to_string(),
+            &None
         );
 
         let deser_claim =


### PR DESCRIPTION
    This implements
    [#42](https://github.com/google-research/raksha/issues/102).
    There is now a fourth optional command line paramater which is a
    comma-separated list of strings that name relation declarations that the
    souffle emitter will skip when generating souffle code. If no list is
    given, this works as before. This exists for integration with the rest of
    Raksha. When we have
    [#8](https://github.com/google-research/raksha/issues/8), this should
    become a proper command-line option.