### PR TITLE
Make will operate on handles

### DIFF
--- a/rust/tools/authorization-logic/raksha_examples/VisionPipelineAuthLogic
+++ b/rust/tools/authorization-logic/raksha_examples/VisionPipelineAuthLogic
@@ -43,9 +43,6 @@
     "LocalDevice" may("do_pure_computation", "raw_video_tag").
     "LocalDevice" may("egress_to_shopping_service", "product_id_tag").
 
-    // Could also give different permissions to RemoteService for once it
-    // has "product_id_tag".
-
     // These are rules we should get rid of in the real thing.
     // The universe relations probably don't need to be decentralized. We could
     // have rules that populate a "centralized" universe and passes this 
@@ -75,36 +72,32 @@
         isAccessPath(pathX).
 }
 
-// Maybe we want this part of the policy to sit closer to the particles
-// because sometimes relations will refer to path names ?
-// (We can ostensibly do this as long as we can write
-// `claim <RelationName(...)>` in manifests)
-//
-// NOTE: maybe the "will" relations should refer to handles rather than tags, 
-// but the "may"s still refer to the tags, and we figure out which tags to
-// get permissions about based on the taint analysis (for now both still 
-// operate on the tags).
 "ImageDetector" says "ImageDetector"
-    will("do_pure_computation", "raw_video_tag").
+    will("do_pure_computation", "id_sensor_packet.camera_feed").
 "ImageSelector" says {
-    "ImageSelector" will("do_pure_computation", "raw_video_tag").
+    "ImageSelector" will("do_pure_computation", "is_detection_boxes").
     declassifies("is_select_image_id", "raw_video_tag").
     hasTag("is_select_image_id", "product_id_tag").
     objectSelected("EndUser", "is_selected_image_id").
 }
 "ProductIdOutput" says 
-    "ProductIdOutput" will("egress_to_shopping_service", "product_id_tag").
+    "ProductIdOutput" will("egress_to_shopping_service", "pio_remote_service").
 
 // May / Will check:
-// May - used by data owners to describe how data may be used.
-// Will - used by data stewards to describe how they'd like to use data.
+// May - used by data owners to describe how data may be used. May refers to 
+// the tags (the abstraction of the data).
+// Will - used by data stewards to describe how they'd like to use data. The 
+// will relation refers to handles so that app behavior specifiers do not need 
+// to know what the taint analysis is doing. The taint analysis is used to 
+// figure out what abstract data (tags) may have influenced the handle.
+//
 // The taint analysis tracks sensitive data as it moves, and this taint
 // analysis is used to check that all the uses described with `will` are 
 // permitted by the owners (using `may'). Roughly this is:
 //
 // For each particle P, for each tag t in union over tags in read edges of P,
 //      for each statement of the form:
-//          `P says will <RELATION> using <TAG>`
+//          `P says will <RELATION> using <HANDLE>`
 //      prove
 //          `ownsTag(Q, <TAG>)`
 //          `Q says may <RELATION> using <TAG>`
@@ -122,7 +115,7 @@
 //    taint(id_sensor_packet.video_resolution) = { }
 //    taint(id_image_detection_model) = { }
 // Usage:
-//    will("do_pure_computation", "raw_video_tag").
+//    will("do_pure_computation", "id_sensor_packet.camera_feed").
 //      Owner("raw_video_tag") = "EndUser"
 may_video_do_computation = query "EndUser" says 
     "ImageDetector" may("do_pure_computation", "raw_video_tag")?
@@ -146,7 +139,7 @@ may_selector_do_computation = query "EndUser" says
 //   after declassification:
 //      taint(pio_select_image_id) = { "product_id_tag" }
 // usage:
-//      will("egress_to_shopping_service", "product_id_tag")
+//      will("egress_to_shopping_service", "pio_remote_service")
 may_shopping_service_egress = query "EndUser" says
     "ProductIdOutput" may("egress_to_shopping_service", "product_id_tag")?
 

--- a/third_party/arcs/examples/VisionPipeline.arcs
+++ b/third_party/arcs/examples/VisionPipeline.arcs
@@ -52,6 +52,7 @@ particle ImageSelector
 
 particle ProductIdOutput
     pio_select_image_id: reads SelectImageId {}
+    pio_remote_service: writes RemoteService {}
 
 recipe VisionPipeline
     DataSource
@@ -69,4 +70,5 @@ recipe VisionPipeline
         is_select_image_id: writes select_image_id
     ProductIdOutput
         pio_select_image_id: reads select_image_id
+        pio_remote_service: writes pio_remote_service
      


### PR DESCRIPTION
Previously both will and may would operate on tags, but it makes more
sense for will to operate on handles. By allowing the "will" relation to
work on handles, the app behavior spec writer does not need to know
anything about the taint analysis, and can describe usgae in terms of
handles. This also seems more likely to prevent errors since the spec
writer does not have the option of forgetting to mention some tags in
the usage.

As a side-effect, some more comments are removed from the example.