### PR TITLE
Add `-Wno-deprecated-declarations` for deprecated syscall warnings.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --cxxopt='-std=c++17' --cxxopt='-Werror' --cxxopt='-Wall'
+build --cxxopt='-std=c++17' --cxxopt='-Werror' --cxxopt='-Wall' --cxxopt='-Wno-deprecated-declarations'

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
+# TODO(#167): Remove `-Wno-deprecated-declarations` when glog is updated.
 build --cxxopt='-std=c++17' --cxxopt='-Werror' --cxxopt='-Wall' --cxxopt='-Wno-deprecated-declarations'


### PR DESCRIPTION
This is a temporary fix for #167 