### PR TITLE
Eliminate globs from build targets; explicitly state srcs and hdrs.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -21,25 +21,15 @@ load("//build_defs:test_helpers.bzl", "extracted_datalog_string_test")
 
 cc_library(
     name = "ir",
-    srcs = glob(
-        ["*.cc"],
-        exclude = [
-            "*_test.cc",
-            "predicate_textproto_to_rule_body_testdata.cc",
-        ],
-    ),
-    hdrs = glob(
-        ["*.h"],
-        exclude = [
-            "access_path.h",
-            "access_path_root.h",
-            "access_path_selectors.h",
-            "access_path_selectors_set.h",
-            "field_selector.h",
-            "selector.h",
-            "predicate_textproto_to_rule_body_testdata.h",
-        ],
-    ),
+    srcs = ["tag_claim.cc"],
+    hdrs = [
+        "datalog_print_context.h",
+        "derives_from_claim.h",
+        "edge.h",
+        "predicate.h",
+        "tag_check.h",
+        "tag_claim.h",
+    ],
     deps = [
         ":access_path",
         "//src/common/logging",

--- a/src/ir/types/BUILD
+++ b/src/ir/types/BUILD
@@ -2,11 +2,13 @@ package(default_visibility = ["//src:__subpackages__"])
 
 cc_library(
     name = "types",
-    srcs = glob(
-        ["*.cc"],
-        exclude = ["*_test.cc"],
-    ),
-    hdrs = glob(["*.h"]),
+    srcs = ["schema.cc"],
+    hdrs = [
+        "entity_type.h",
+        "primitive_type.h",
+        "schema.h",
+        "type.h",
+    ],
     deps = [
         "//src/common/logging",
         "//src/ir",

--- a/src/xform_to_datalog/arcs_manifest_tree/BUILD
+++ b/src/xform_to_datalog/arcs_manifest_tree/BUILD
@@ -18,11 +18,14 @@ package(default_visibility = ["//src:__subpackages__"])
 
 cc_library(
     name = "arcs_manifest_tree",
-    srcs = glob(
-        ["*.cc"],
-        exclude = ["*_test.cc"],
-    ),
-    hdrs = glob(["*.h"]),
+    srcs = [
+        "handle_connection_spec.cc",
+        "particle_spec.cc",
+    ],
+    hdrs = [
+        "handle_connection_spec.h",
+        "particle_spec.h",
+    ],
     deps = [
         "//src/common/logging",
         "//src/ir",


### PR DESCRIPTION
Clean up build rules to elminate globs from build rules. Now all build
rules explicitly state the sources and headers that they use. This fixes
issue #164.