### PR TITLE
Convert most escaped strings to raw strings.

### DIFF
--- a/src/ir/edge_test.cc
+++ b/src/ir/edge_test.cc
@@ -36,8 +36,7 @@ static const std::tuple<Edge, std::string> edge_todatalog_pairs[] = {
             AccessPathRoot(HandleConnectionAccessPathRoot(
                 "recipe2", "particle2", "handle2")),
             AccessPathSelectors(Selector(FieldSelector("field2"))))),
-        "edge(\"recipe.particle.handle.field1\", "
-        "\"recipe2.particle2.handle2.field2\")."},
+        R"(edge("recipe.particle.handle.field1", "recipe2.particle2.handle2.field2").)"},
     { Edge(
             AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
                 "r", "p", "h")),
@@ -45,7 +44,7 @@ static const std::tuple<Edge, std::string> edge_todatalog_pairs[] = {
             AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
                 "r", "p", "h2")),
                        x_y_access_path_selectors)),
-      "edge(\"r.p.h.x.y\", \"r.p.h2.x.y\")." },
+      R"(edge("r.p.h.x.y", "r.p.h2.x.y").)" },
     { Edge(
           AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
               "pre", "fix", "1")),
@@ -53,7 +52,7 @@ static const std::tuple<Edge, std::string> edge_todatalog_pairs[] = {
           AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
               "pre", "fix", "2")),
                      AccessPathSelectors())),
-      "edge(\"pre.fix.1\", \"pre.fix.2\")."} };
+      R"(edge("pre.fix.1", "pre.fix.2").)"} };
 
 class EdgeToDatalogTest :
     public testing::TestWithParam<std::tuple<Edge, std::string>> {};

--- a/src/ir/proto/access_path_selector_test.cc
+++ b/src/ir/proto/access_path_selector_test.cc
@@ -67,10 +67,9 @@ TEST_P(AccessPathSelectorsFromProtoTest, AccessPathSelectorsFromProtoTest) {
 static const std::tuple<std::string, std::string>
     access_path_selectors_proto_tostring_pairs[]{
         {"", ""},
-        {"selectors: { field: \"foo\" }", ".foo"},
-        {"selectors: [{ field: \"foo\" }, { field: \"bar\" }]", ".foo.bar"},
-        {"selectors: [{ field: \"foo\" }, { field: \"bar\" }, { field: \"baz\" "
-         "}]",
+        {R"(selectors: { field: "foo" })", ".foo"},
+        {R"(selectors: [{ field: "foo" }, { field: "bar" }])", ".foo.bar"},
+        {R"(selectors: [{ field: "foo" }, { field: "bar" }, { field: "baz" }])",
          ".foo.bar.baz"},
     };
 

--- a/src/ir/types/type_test.cc
+++ b/src/ir/types/type_test.cc
@@ -260,42 +260,41 @@ const std::tuple<std::string, std::vector<std::string>>
     // Entity with no fields.
     {"entity: { schema: { } }", { "" } },
     // Entity with one primitive field, field1.
-    {
-    "entity: { "
-    "  schema: { "
-    "    fields [ { key: \"field1\", value: { primitive: TEXT } } ]"
-    " } }", { ".field1" } },
+    {R"(
+entity: {
+  schema: {
+    fields [ { key: "field1", value: { primitive: TEXT } } ]} })",
+    { ".field1" } },
     // Entity with one primitive field and a named schema
-    {
-    "entity: { "
-    "  schema: { "
-    "    names: [\"my_schema\"] "
-    "    fields: [ { key: \"field1\", value: { primitive: TEXT } } ]"
-    " } }", { ".field1" } },
+    {R"(
+entity: {
+  schema: {
+    names: ["my_schema"]
+      fields: [ { key: "field1", value: { primitive: TEXT } } ] } })",
+     { ".field1" } },
     // Entity with multiple primitive fields.
-    {
-    "entity: { "
-    "  schema: { "
-    "    fields: [ "
-    "      { key: \"field1\", value: { primitive: TEXT } },"
-    "      { key: \"x\", value: { primitive: TEXT } },"
-    "      { key: \"hello\", value: { primitive: TEXT } }"
-    "    ]"
-    " } }", {".field1", ".x", ".hello"} },
+    {R"(
+entity: {
+  schema: {
+    fields: [
+      { key: "field1", value: { primitive: TEXT } },
+      { key: "x", value: { primitive: TEXT } },
+      { key: "hello", value: { primitive: TEXT } } ] } })",
+      {".field1", ".x", ".hello"} },
     // Entity with sub entities and primitive fields.
-    {
-    "entity: { "
-    "  schema: { "
-    "    fields: [ "
-    "      { key: \"field1\", value: { primitive: TEXT }},"
-    "      { key: \"x\", value: { "
-    "        entity: { schema: { names: [\"embedded\"], fields: ["
-    "          { key: \"sub_field1\", value: { primitive: TEXT } },"
-    "          { key: \"sub_field2\", value: { primitive: TEXT } }"
-    "       ]}}}},"
-    "      { key: \"hello\", value: { primitive: TEXT } }"
-    "    ]"
-    " } }", {".field1", ".x.sub_field1", ".x.sub_field2", ".hello"}},
+    {R"(
+entity: {
+  schema: {
+    fields: [
+      { key: "field1", value: { primitive: TEXT } },
+      { key: "x",
+        value: {
+          entity: { schema: { names: ["embedded"], fields: [
+            { key: "sub_field1", value: { primitive: TEXT } },
+            { key: "sub_field2", value: { primitive: TEXT } }
+           ]}}}},
+      { key: "hello", value: { primitive: TEXT } } ] } })",
+      {".field1", ".x.sub_field1", ".x.sub_field2", ".hello"}},
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/test_utils/dl_string_extractor/dl_string_test_file_generator.cc
+++ b/src/test_utils/dl_string_extractor/dl_string_test_file_generator.cc
@@ -53,6 +53,10 @@ int main(int argc, char **argv) {
   }
 
   // Output headers we may need and declarations for relations.
+  // Note: Most other escaped strings in the file have turned into raw
+  // strings to improve readability. This one has been left because the
+  // amount of newlines in it makes it actually more readable as an escaped
+  // string.
   datalog_test_stream << "#include \"taint.dl\"\n\n"
                       << ".decl dummy(input_num: number)\n\n";
 

--- a/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec_test.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/handle_connection_spec_test.cc
@@ -44,13 +44,15 @@ TEST_P(RoundTripHandleConnectionSpecProtoTest,
 // and we are checking that it can be made back into an identical proto, so
 // that suffices for this test.
 static const ProtoStringAndExpectations string_and_expections_array[] = {
-    { .proto_str = "name: \"foo\" direction: READS type: { primitive: TEXT }",
+    { .proto_str =
+        R"(name: "foo" direction: READS type: { primitive: TEXT })",
       .expected_name = "foo", .expected_reads = true, .expected_writes = false},
-    { .proto_str = "name: \"bar\" direction: WRITES type: { primitive: TEXT }",
+    { .proto_str =
+        R"(name: "bar" direction: WRITES type: { primitive: TEXT })",
       .expected_name = "bar", .expected_reads = false,
       .expected_writes = true },
     { .proto_str =
-        "name: \"baz\" direction: READS_WRITES type: { primitive: TEXT }",
+        R"(name: "baz" direction: READS_WRITES type: { primitive: TEXT })",
       .expected_name = "baz", .expected_reads = true, .expected_writes = true}
 };
 
@@ -101,33 +103,25 @@ std::string sample_particle_spec_names[] = {
 };
 
 ProtoStringAndExpectedAccessPathPieces protos_and_access_path_info[] = {
-    { .textproto = "name: \"handle_spec\" direction: READS "
-                   "type: { primitive: TEXT }",
+    { .textproto =
+        R"(name: "handle_spec" direction: READS type: { primitive: TEXT })",
       .handle_connection_name = "handle_spec",
       .access_path_selectors_tostrings = { "" } },
-    { .textproto =
-         "name: \"hs\" direction: READS_WRITES "
-         "type: { entity: { "
-         "      schema: { "
-         "        fields [ { key: \"field1\", value: { primitive: TEXT } } ]"
-         "     } } }",
+    { .textproto = R"(
+name: "hs" direction: READS_WRITES
+type: { entity: { schema: { fields [
+  { key: "field1", value: { primitive: TEXT } } ] } } })",
          .handle_connection_name = "hs",
          .access_path_selectors_tostrings = { ".field1" }},
-    { .textproto =
-      "name: \"spechandle\" direction: WRITES "
-      "type {"
-      "entity: { "
-      "  schema: { "
-      "    fields: [ "
-      "      { key: \"field1\", value: { primitive: TEXT }},"
-      "      { key: \"x\", value: { "
-      "        entity: { schema: { names: [\"embedded\"], fields: ["
-      "          { key: \"sub_field1\", value: { primitive: TEXT } },"
-      "          { key: \"sub_field2\", value: { primitive: TEXT } }"
-      "       ]}}}},"
-      "      { key: \"hello\", value: { primitive: TEXT } }"
-      "    ]"
-      " } } }",
+    { .textproto = R"(
+name: "spechandle" direction: WRITES
+type { entity: { schema: { fields: [
+  { key: "field1", value: { primitive: TEXT } },
+  { key: "x", value: {
+      entity: { schema: { names: ["embedded"], fields: [
+        { key: "sub_field1", value: { primitive: TEXT } },
+        { key: "sub_field2", value: { primitive: TEXT } } ]}}}},
+  { key: "hello", value: { primitive: TEXT } } ] } } })",
       .handle_connection_name = "spechandle",
       .access_path_selectors_tostrings = {
         ".field1", ".x.sub_field1", ".x.sub_field2", ".hello"


### PR DESCRIPTION
This commit converts most strings with high amounts of escaping within
the project to raw strings to make them more readable. At least one
string was spared conversion because it was heavy with newlines and less
readable as a raw string. This commit fixes #109.