### PR TITLE
Add the code required for Kokoro build on GCP/Ubuntu on the Raksha side.

### DIFF
--- a/kokoro/gcp_ubuntu/continuous.cfg
+++ b/kokoro/gcp_ubuntu/continuous.cfg
@@ -1,0 +1,5 @@
+# -*- protobuffer -*-
+# proto-file: google3/devtools/kokoro/config/proto/build.proto
+# proto-message: BuildConfig
+
+build_file: "raksha/kokoro/gcp_ubuntu/kokoro_build.sh"

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+cd "${KOKORO_ARTIFACTS_DIR}/github/raksha"
+bazel build ...
+bazel test ...

--- a/kokoro/gcp_ubuntu/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/presubmit.cfg
@@ -1,0 +1,5 @@
+# -*- protobuffer -*-
+# proto-file: google3/devtools/kokoro/config/proto/build.proto
+# proto-message: BuildConfig
+
+build_file: "raksha/kokoro/gcp_ubuntu/kokoro_build.sh"


### PR DESCRIPTION
Very simple Raksha-side configuration that just builds and tests as continuous integration and presubmit setup.