### PR TITLE
Update prologue of the generated datalog file and associated tests

### DIFF
--- a/src/xform_to_datalog/datalog_facts.h
+++ b/src/xform_to_datalog/datalog_facts.h
@@ -75,9 +75,7 @@ testFails(check_index) :-
 
 // Rules for linking generated relations with the ones in the dl program.
 .decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
-.decl says_hasTag(speaker: Principal, path: AccessPath, t: Tag)
 saysOwnsTag(x, y, z) :- says_ownsTag(x, y, z).
-saysHasTag(x, y, z) :- says_hasTag(x, y, z).
 
 // Manifest
 %s

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -64,9 +64,7 @@ testFails(check_index) :-
 
 // Rules for linking generated relations with the ones in the dl program.
 .decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
-.decl says_hasTag(speaker: Principal, path: AccessPath, t: Tag)
 saysOwnsTag(x, y, z) :- says_ownsTag(x, y, z).
-saysHasTag(x, y, z) :- says_hasTag(x, y, z).
 
 // Manifest
 
@@ -118,9 +116,7 @@ testFails(check_index) :-
 
 // Rules for linking generated relations with the ones in the dl program.
 .decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
-.decl says_hasTag(speaker: Principal, path: AccessPath, t: Tag)
 saysOwnsTag(x, y, z) :- says_ownsTag(x, y, z).
-saysHasTag(x, y, z) :- says_hasTag(x, y, z).
 
 // Manifest
 


### PR DESCRIPTION
This is necessary to hook the generated datalog with fact_test_driver.cc.

Makes progress towards fixing #78 