### PR TITLE
Skip declaration of `says_ownsTag` when generating authorization facts.

### DIFF
--- a/src/xform_to_datalog/authorization_logic_datalog_facts.cc
+++ b/src/xform_to_datalog/authorization_logic_datalog_facts.cc
@@ -32,7 +32,7 @@ AuthorizationLogicDatalogFacts::create(
   const std::filesystem::path &program_dir, absl::string_view program) {
   auto result_dir = std::filesystem::temp_directory_path();
   int res = generate_datalog_facts_from_authorization_logic(
-    program.data(), program_dir.c_str(), result_dir.c_str(), "");
+    program.data(), program_dir.c_str(), result_dir.c_str(), "says_ownsTag");
   if (res) {
     LOG(ERROR) << "Failure running the authorization logic compiler.\n";
     return std::nullopt;

--- a/src/xform_to_datalog/authorization_logic_datalog_facts_test.cc
+++ b/src/xform_to_datalog/authorization_logic_datalog_facts_test.cc
@@ -31,17 +31,20 @@ namespace raksha::xform_to_datalog {
 class AuthorizationLogicDatalogFactsTest : public AuthorizationLogicTest {};
 
 TEST_F(AuthorizationLogicDatalogFactsTest, InvokesRustToolAndGeneratesOutput) {
-  for (const std::string& program : {"simple_auth_logic", "empty_auth_logic"}) {
+  for (const std::string &program :
+       {"simple_auth_logic", "empty_auth_logic", "says_owns_tag"}) {
     fs::path test_data_dir = GetTestDataDir();
-    auto auth_facts = AuthorizationLogicDatalogFacts::create(test_data_dir.c_str(), program);
+    auto auth_facts =
+        AuthorizationLogicDatalogFacts::create(test_data_dir.c_str(), program);
     ASSERT_TRUE(auth_facts.has_value());
-  
+
     std::vector<std::string> actual_datalog =
       absl::StrSplit(auth_facts->ToDatalog(), "\n", absl::SkipEmpty());
     std::vector<std::string> expected_datalog =
-      ReadFileLines(test_data_dir / (program + ".dl"));
+        ReadFileLines(test_data_dir / (program + ".dl"));
 
-    // Need to compare individual lines as the output order is non-deterministic.
+    // Need to compare individual lines as the output order is
+    // non-deterministic.
     ASSERT_THAT(actual_datalog,
                 testing::UnorderedElementsAreArray(expected_datalog));
   }

--- a/src/xform_to_datalog/testdata/BUILD
+++ b/src/xform_to_datalog/testdata/BUILD
@@ -24,6 +24,8 @@ filegroup(
         "empty_auth_logic.dl",
         "simple_auth_logic",
         "simple_auth_logic.dl",
+        "says_owns_tag",
+        "says_owns_tag.dl",
     ],
     testonly = True
 )

--- a/src/xform_to_datalog/testdata/says_owns_tag
+++ b/src/xform_to_datalog/testdata/says_owns_tag
@@ -1,0 +1,1 @@
+"prin1" says ownsTag("particle", "foo").

--- a/src/xform_to_datalog/testdata/says_owns_tag.dl
+++ b/src/xform_to_datalog/testdata/says_owns_tag.dl
@@ -1,0 +1,3 @@
+.decl grounded_dummy(x0: symbol)
+says_ownsTag("prin1", "particle", "foo").
+grounded_dummy("dummy_var").


### PR DESCRIPTION
Part of the fix for #78