### PR TITLE
Move proto decoding out of ir::DerivesFromClaim into proto package.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -173,6 +173,7 @@ cc_test(
     deps = [
         ":ir",
         "//src/common/testing:gtest",
+        "//src/ir/proto:derives_from_claim",
         "@absl//absl/strings",
         "@absl//absl/strings:str_format",
     ],

--- a/src/ir/derives_from_claim.h
+++ b/src/ir/derives_from_claim.h
@@ -20,7 +20,6 @@
 #include "src/ir/access_path.h"
 #include "src/ir/edge.h"
 #include "src/ir/proto/access_path.h"
-#include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
 
@@ -32,16 +31,6 @@ namespace raksha::ir {
 // which all inputs are connected to all outputs.
 class DerivesFromClaim {
  public:
-  static DerivesFromClaim CreateFromProto(
-      const arcs::ClaimProto_DerivesFrom &derives_from_proto) {
-    CHECK(derives_from_proto.has_source())
-      << "DerivesFrom proto does not have required field source.";
-    CHECK(derives_from_proto.has_target())
-      << "DerivesFrom proto does not have required field target.";
-    return DerivesFromClaim(proto::Decode(derives_from_proto.target()),
-                            proto::Decode(derives_from_proto.source()));
-  }
-
   explicit DerivesFromClaim(AccessPath target, AccessPath source)
     : target_(target), source_(source) {}
 

--- a/src/ir/derives_from_claim_test.cc
+++ b/src/ir/derives_from_claim_test.cc
@@ -22,6 +22,7 @@
 #include "absl/strings/string_view.h"
 #include "src/common/testing/gtest.h"
 #include "src/ir/proto/access_path.h"
+#include "src/ir/proto/derives_from_claim.h"
 
 namespace raksha::ir {
 
@@ -61,7 +62,7 @@ class DerivesFromAsAccessPathPairTest :
                 std::get<1>(GetParam()));
       google::protobuf::TextFormat::ParseFromString(
           textproto, &derives_from_proto);
-      return DerivesFromClaim::CreateFromProto(derives_from_proto);
+      return proto::Decode(derives_from_proto);
   }
 
   template<int ParamNum>

--- a/src/ir/proto/BUILD
+++ b/src/ir/proto/BUILD
@@ -67,6 +67,16 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "derives_from_claim",
+    hdrs = ["derives_from_claim.h"],
+    deps = [
+        "//src/ir",
+        "//src/ir:access_path",
+        "//third_party/arcs/proto:manifest_cc_proto",
+    ],
+)
+
 cc_test(
     name = "access_path_test",
     srcs = ["access_path_test.cc"],

--- a/src/ir/proto/derives_from_claim.h
+++ b/src/ir/proto/derives_from_claim.h
@@ -1,0 +1,36 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#ifndef SRC_IR_PROTO_DERIVES_FROM_CLAIM_H_
+#define SRC_IR_PROTO_DERIVES_FROM_CLAIM_H_
+
+#include "src/ir/derives_from_claim.h"
+#include "third_party/arcs/proto/manifest.pb.h"
+
+namespace raksha::ir::proto {
+
+DerivesFromClaim Decode(const arcs::ClaimProto_DerivesFrom &proto) {
+    CHECK(proto.has_source())
+      << "DerivesFrom proto does not have required field source.";
+    CHECK(proto.has_target())
+      << "DerivesFrom proto does not have required field target.";
+    return DerivesFromClaim(proto::Decode(proto.target()),
+                            proto::Decode(proto.source()));
+}
+
+}  // namespace raksha::ir::proto
+
+#endif  // SRC_IR_PROTO_DERIVES_FROM_CLAIM_H_

--- a/src/xform_to_datalog/arcs_manifest_tree/BUILD
+++ b/src/xform_to_datalog/arcs_manifest_tree/BUILD
@@ -29,6 +29,7 @@ cc_library(
     deps = [
         "//src/common/logging",
         "//src/ir",
+        "//src/ir/proto:derives_from_claim",
         "//src/ir/proto:predicate",
         "//src/ir/proto:tag_check",
         "//src/ir/proto:types",

--- a/src/xform_to_datalog/arcs_manifest_tree/particle_spec.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/particle_spec.cc
@@ -14,6 +14,7 @@
 // limitations under the License.
 //-----------------------------------------------------------------------------
 
+#include "src/ir/proto/derives_from_claim.h"
 #include "src/ir/proto/predicate.h"
 #include "src/ir/proto/tag_check.h"
 #include "src/xform_to_datalog/arcs_manifest_tree/particle_spec.h"
@@ -42,8 +43,7 @@ ParticleSpec ParticleSpec::CreateFromProto(
         // TODO(#120): Also attach the particle name to these DerivesFrom
         //  claims to allow authorization logic to mediate whether edges are
         //  drawn for these claims or not.
-        derives_from_claims.push_back(
-            ir::DerivesFromClaim::CreateFromProto(claim.derives_from()));
+        derives_from_claims.push_back(ir::proto::Decode(claim.derives_from()));
         continue;
       }
       case arcs::ClaimProto::kAssume: {


### PR DESCRIPTION
Part of the continuing effort to detangle the arcs protos from the
Raksha ir data structures as described in issue #118.