### PR TITLE
Extract Arcs proto decoding from ir::TagClaim.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -21,7 +21,6 @@ load("//build_defs:test_helpers.bzl", "extracted_datalog_string_test")
 
 cc_library(
     name = "ir",
-    srcs = ["tag_claim.cc"],
     hdrs = [
         "datalog_print_context.h",
         "derives_from_claim.h",
@@ -139,6 +138,7 @@ cc_test(
     deps = [
         ":ir",
         "//src/common/testing:gtest",
+        "//src/ir/proto:tag_claim",
         "@absl//absl/strings",
         "@absl//absl/strings:str_format",
     ],

--- a/src/ir/proto/BUILD
+++ b/src/ir/proto/BUILD
@@ -77,6 +77,17 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "tag_claim",
+    srcs = ["tag_claim.cc"],
+    hdrs = ["tag_claim.h"],
+    deps = [
+        "//src/ir",
+        "//src/ir:access_path",
+        "//third_party/arcs/proto:manifest_cc_proto",
+    ],
+)
+
 cc_test(
     name = "access_path_test",
     srcs = ["access_path_test.cc"],

--- a/src/ir/proto/tag_claim.cc
+++ b/src/ir/proto/tag_claim.cc
@@ -1,3 +1,19 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
 #include "src/ir/proto/tag_claim.h"
 
 namespace raksha::ir::proto {

--- a/src/ir/proto/tag_claim.h
+++ b/src/ir/proto/tag_claim.h
@@ -1,0 +1,17 @@
+#ifndef SRC_IR_PROTO_TAG_CLAIM_H_
+#define SRC_IR_PROTO_TAG_CLAIM_H_
+
+#include "src/ir/tag_claim.h"
+#include "third_party/arcs/proto/manifest.pb.h"
+
+namespace raksha::ir::proto {
+
+  // Create a list of TagClaims from an Assume proto. Each of these will be
+  // uninstantiated and thus rooted at the ParticleSpec.
+  std::vector<TagClaim> Decode(
+    std::string claiming_particle_name,
+    const arcs::ClaimProto_Assume &assume_proto);
+
+}  // namespace raksha::ir::proto
+
+#endif  // SRC_IR_PROTO_TAG_CLAIM_H_

--- a/src/ir/proto/tag_claim.h
+++ b/src/ir/proto/tag_claim.h
@@ -1,3 +1,19 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
 #ifndef SRC_IR_PROTO_TAG_CLAIM_H_
 #define SRC_IR_PROTO_TAG_CLAIM_H_
 

--- a/src/ir/tag_claim.h
+++ b/src/ir/tag_claim.h
@@ -22,7 +22,6 @@
 #include "src/ir/access_path.h"
 #include "src/ir/datalog_print_context.h"
 #include "src/ir/proto/access_path.h"
-#include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
 
@@ -30,27 +29,6 @@ namespace raksha::ir {
 // access path.
 class TagClaim {
  public:
-  // Create a list of TagClaims from an Assume proto. Each of these will be
-  // uninstantiated and thus rooted at the ParticleSpec.
-  static std::vector<TagClaim> CreateFromProto(
-    std::string claiming_particle_name,
-    const arcs::ClaimProto_Assume &assume_proto) {
-    CHECK(assume_proto.has_access_path())
-      << "Expected Assume message to have access_path field.";
-    const arcs::AccessPathProto &access_path_proto = assume_proto.access_path();
-    AccessPath access_path = proto::Decode(access_path_proto);
-    CHECK(assume_proto.has_predicate())
-      << "Expected Assume message to have predicate field.";
-    const arcs::InformationFlowLabelProto_Predicate &predicate =
-        assume_proto.predicate();
-
-    // Now that we have gathered the top-level information from the Assume
-    // proto, descend into the predicate to construct the list of claims.
-    return GetTagClaimsFromPredicate(
-        std::move(claiming_particle_name), std::move(access_path), predicate,
-        /*in_negation=*/false);
-  }
-
   explicit TagClaim(
       std::string claiming_particle_name,
       AccessPath access_path,
@@ -104,14 +82,6 @@ class TagClaim {
   }
 
  private:
-  // Helper function for CreateFromProto that descends recursively into
-  // predicate to gather all TagClaims contained within it.
-  static std::vector<TagClaim> GetTagClaimsFromPredicate(
-    std::string claiming_particle_name,
-    AccessPath access_path,
-    const arcs::InformationFlowLabelProto_Predicate &predicate,
-    const bool in_negation);
-
   // The name of the particle performing this claim. Important for connecting
   // the claim to a principal for authorization logic purposes.
   std::string claiming_particle_name_;

--- a/src/ir/tag_claim_test.cc
+++ b/src/ir/tag_claim_test.cc
@@ -22,6 +22,7 @@
 #include "absl/strings/str_format.h"
 #include "src/common/testing/gtest.h"
 #include "src/ir/access_path_selectors.h"
+#include "src/ir/proto/tag_claim.h"
 
 namespace raksha::ir {
 
@@ -53,7 +54,7 @@ TEST_P(TagClaimToDatalogWithRootTest, TagClaimToDatalogWithRootTest) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       assume_textproto, &assume_proto));
   std::vector<TagClaim> unrooted_tag_claim_vec =
-      TagClaim::CreateFromProto(particle_spec_name, assume_proto);
+      proto::Decode(particle_spec_name, assume_proto);
   std::vector<TagClaim> rooted_tag_claim_vec;
   for (const TagClaim &unrooted_claim : unrooted_tag_claim_vec) {
     rooted_tag_claim_vec.push_back(unrooted_claim.Instantiate(root));

--- a/src/xform_to_datalog/arcs_manifest_tree/BUILD
+++ b/src/xform_to_datalog/arcs_manifest_tree/BUILD
@@ -32,6 +32,7 @@ cc_library(
         "//src/ir/proto:derives_from_claim",
         "//src/ir/proto:predicate",
         "//src/ir/proto:tag_check",
+        "//src/ir/proto:tag_claim",
         "//src/ir/proto:types",
         "//src/ir/types",
         "//third_party/arcs/proto:manifest_cc_proto",

--- a/src/xform_to_datalog/arcs_manifest_tree/particle_spec.cc
+++ b/src/xform_to_datalog/arcs_manifest_tree/particle_spec.cc
@@ -17,6 +17,7 @@
 #include "src/ir/proto/derives_from_claim.h"
 #include "src/ir/proto/predicate.h"
 #include "src/ir/proto/tag_check.h"
+#include "src/ir/proto/tag_claim.h"
 #include "src/xform_to_datalog/arcs_manifest_tree/particle_spec.h"
 
 namespace raksha::xform_to_datalog::arcs_manifest_tree {
@@ -48,7 +49,7 @@ ParticleSpec ParticleSpec::CreateFromProto(
       }
       case arcs::ClaimProto::kAssume: {
         std::vector<ir::TagClaim> current_assume_claims =
-            ir::TagClaim::CreateFromProto(name, claim.assume());
+            ir::proto::Decode(name, claim.assume());
         tag_claims.insert(
             tag_claims.end(),
             std::make_move_iterator(current_assume_claims.begin()),


### PR DESCRIPTION
Part of the ongoing effort to detangle Arcs protos from the Raksha IR
(issue #118).