### PR TITLE
Make output relations use IO=stdout for better test output behavior.

### DIFF
--- a/src/xform_to_datalog/datalog_facts.h
+++ b/src/xform_to_datalog/datalog_facts.h
@@ -60,11 +60,11 @@ class DatalogFacts {
 
 // Rules for detecting policy failures.
 .decl testFails(check_index: symbol)
-.output testFails
+.output testFails(IO=stdout)
 .decl allTests(check_index: symbol)
-.output allTests
+.output allTests(IO=stdout)
 .decl duplicateTestCaseNames(testAspectName: symbol)
-.output duplicateTestCaseNames
+.output duplicateTestCaseNames(IO=stdout)
 
 .decl isCheck(check_index: symbol)
 .decl check(check_index: symbol)

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -49,11 +49,11 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Rules for detecting policy failures.
 .decl testFails(check_index: symbol)
-.output testFails
+.output testFails(IO=stdout)
 .decl allTests(check_index: symbol)
-.output allTests
+.output allTests(IO=stdout)
 .decl duplicateTestCaseNames(testAspectName: symbol)
-.output duplicateTestCaseNames
+.output duplicateTestCaseNames(IO=stdout)
 
 .decl isCheck(check_index: symbol)
 .decl check(check_index: symbol)
@@ -118,11 +118,11 @@ grounded_dummy("dummy_var").
 
 // Rules for detecting policy failures.
 .decl testFails(check_index: symbol)
-.output testFails
+.output testFails(IO=stdout)
 .decl allTests(check_index: symbol)
-.output allTests
+.output allTests(IO=stdout)
 .decl duplicateTestCaseNames(testAspectName: symbol)
-.output duplicateTestCaseNames
+.output duplicateTestCaseNames(IO=stdout)
 
 .decl isCheck(check_index: symbol)
 .decl check(check_index: symbol)

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -4,11 +4,11 @@
 
 // Rules for detecting policy failures.
 .decl testFails(check_index: symbol)
-.output testFails
+.output testFails(IO=stdout)
 .decl allTests(check_index: symbol)
-.output allTests
+.output allTests(IO=stdout)
 .decl duplicateTestCaseNames(testAspectName: symbol)
-.output duplicateTestCaseNames
+.output duplicateTestCaseNames(IO=stdout)
 
 .decl isCheck(check_index: symbol)
 .decl check(check_index: symbol)


### PR DESCRIPTION
@aferr complained recently that he wasn't getting the contents of output
relations on test failures. When I looked into it, I discovered that
test outputs would not be printed to the test log by the printAll
function unless the output relations specified IO=stdout. If they did
not do this, then they would presumably use the Souffle default behavior
and print files out to some location in the Bazel workspace; I don't
know for certain because I never found those output files. Regardless,
setting IO=stdout appears to make the output of test relations appear in
the test logs as we would expect.