### PR TITLE
Mention the included files  explicitly in `souffle_cc_library`.

### DIFF
--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -24,6 +24,12 @@ cc_test(
 souffle_cc_library(
     name = "taint_dl",
     src = "taint.dl",
+    included_dl_scripts = [
+        "access_path.dl",
+        "authorization_logic.dl",
+        "dataflow_graph.dl",
+        "tags.dl",
+    ],
 )
 
 exports_files([


### PR DESCRIPTION
If the files are not specified, the builds don't work when executed remotely.