### PR TITLE
Replace claimHasTag relation with saysHasTag. 

### DIFF
--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -46,9 +46,7 @@
 
 .decl saysOwnsTag(speaker: Principal, owner: Principal, tag: Tag)
 
-// claimHasTag and saysHasTag are synonyms. They indicate that the `speaker`
-// claims that `path` definitely has `tag` taint.
-.decl claimHasTag(speaker: Principal, path: AccessPath, tag: Tag)
+// The `speaker` says that `path` definitely has `tag` taint.
 .decl saysHasTag(speaker: Principal, path: AccessPath, tag: Tag)
 
 // The `speaker` says that the `delegatee` can say that `path` has `tag`.
@@ -84,8 +82,6 @@ canSayRemoveTag(speaker, path, tag) :-
 
 removeTag(path, tag) :-
     canSayRemoveTag(speaker, path, tag), saysRemoveTag(speaker, path, tag).
-
-saysHasTag(principal, path, tag) :- claimHasTag(principal, path, tag).
 
 // The owner can say the tag is present anywhere.
 canSayHasTag(speaker, path, tag) :- isAccessPath(path), ownsTag(speaker, tag).

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -34,8 +34,8 @@
 // they have Tags).
 .decl mayHaveTag(accessPath: AccessPath, tag: Tag)
 
-// Manifests can produce base facts of this form, where usually the principal 
-// is a particle (and this fact is entered by a code reviewer with no knowledge 
+// Manifests can produce base facts of this form, where usually the principal
+// is a particle (and this fact is entered by a code reviewer with no knowledge
 // of the taint analysis).
 .decl claimNotEdge(principal: Principal, src: AccessPath, dst: AccessPath)
 
@@ -43,23 +43,23 @@
 // Rules
 //-----------------------------------------------------------------------------
 
-// This rule is meant to support the functionality of removing edges from 
+// This rule is meant to support the functionality of removing edges from
 // manifests:
 //      - that clearly does not introduce an unsafe escape hatch that could
-//      break policies (because it does not introduce removeTag that would not 
+//      break policies (because it does not introduce removeTag that would not
 //      otherwise be possible).
-//      - without data owners needing to know anything about the application 
+//      - without data owners needing to know anything about the application
 //      structure
-//      - without app behavior specification writers needing to know anything 
+//      - without app behavior specification writers needing to know anything
 //      about the taint analysis or the tags that might appear on a handle
 
 
-// claimNotEdge(p, src, tgt) is an _attempt_ to remove an edge from the 
+// claimNotEdge(p, src, tgt) is an _attempt_ to remove an edge from the
 // analysis (by principal p)
 // saysRemoveTag(p, path, tgt) is an _attempt_ to remove just one tag
 // from a path (by principal p).
 //
-// The rule for removeTag(p, t) in authorization_logic.dl describes when 
+// The rule for removeTag(p, t) in authorization_logic.dl describes when
 // removing a tag is "safe" and the removal really happens (by consulting the
 // owners).
 //
@@ -69,12 +69,12 @@
 // that source path. Instead, we remove all of the tags on the source from the
 // midpoint access path we add in the middle of each edge. This rule populates a
 // request to remove a tag on the edge midpoint.
-//      - it is safe because these requests are only accepted if they would 
+//      - it is safe because these requests are only accepted if they would
 //      normally be by the removeTag(_, _) rule
-//      - it does not require the manifest writer to know anything about the 
+//      - it does not require the manifest writer to know anything about the
 //      tags in the analysis
-//      - data owners do not need to know about paths, and they will grant 
-//      permission for edge removal indirectly by granting permission to remove 
+//      - data owners do not need to know about paths, and they will grant
+//      permission for edge removal indirectly by granting permission to remove
 //      tags (abstract representations of their data).
 
 saysRemoveTag(principal, midpoint, tag) :-

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -92,13 +92,12 @@ mayHaveTag(tgt, tag) :-
 // `isObject(..)`) whenever they are mentioned in other rules.
 
 // Any Principal used in a claim is in the universe of isPrincipal.
-isPrincipal(principal) :- claimHasTag(principal, _, _).
+isPrincipal(principal) :- saysHasTag(principal, _, _).
 
-isAccessPath(path) :- claimHasTag(_, path, _).
 isAccessPath(path) :- saysHasTag(_, path, _).
 
 // Symbols used in hasTag or mayHaveTag are tags
-isTag(tag) :- claimHasTag(_, _, tag).
+isTag(tag) :- saysHasTag(_, _, tag).
 
 // A pair of (base, member) is in this set if the base access path is a non-trivial subpath of the
 // member access path.

--- a/src/analysis/souffle/tests/arcs_fact_tests/claim_not_edge_two_inputs_two_outputs.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/claim_not_edge_two_inputs_two_outputs.dl
@@ -22,8 +22,8 @@ isPrincipal("ParticleX").
 ownsTag("Claimer", "tag1").
 ownsTag("Claimer", "tag2").
 
-claimHasTag("Claimer", "R.foo.hc1", "tag1").
-claimHasTag("Claimer", "R.foo.hc2", "tag2").
+saysHasTag("Claimer", "R.foo.hc1", "tag1").
+saysHasTag("Claimer", "R.foo.hc2", "tag2").
 
 // ParticleX claims that hc2 does not flow to hco1.
 // TODO(#146) In the case where we expect this claim to be upheld, how does that

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
@@ -22,8 +22,8 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-claimHasTag("P1", "R.P1.foo.a", "userSelection").
-claimHasTag("P1", "R.P1.foo.b", "screenContent").
+saysHasTag("P1", "R.P1.foo.a", "userSelection").
+saysHasTag("P1", "R.P1.foo.b", "screenContent").
 
 edge("R.P1.foo.a", "R.h.Foo.a").
 edge("R.P1.foo.b", "R.h.Foo.b").

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
@@ -21,7 +21,7 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-claimHasTag("P1", "R.P1.foo", "userSelection").
+saysHasTag("P1", "R.P1.foo", "userSelection").
 edge("R.P1.foo", "R.h.Foo").
 edge("R.h.Foo", "R.P2.bar").
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
@@ -25,7 +25,7 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-claimHasTag("P1", "R.P1.foo", "userSelection").
+saysHasTag("P1", "R.P1.foo", "userSelection").
 edge("R.P1.foo", "R.h1.Foo").
 edge("R.h1.Foo", "R.P2.bar").
 edge("R.P2.bar", "R.P2.foo").

--- a/src/ir/tag_claim.h
+++ b/src/ir/tag_claim.h
@@ -67,7 +67,7 @@ class TagClaim {
     constexpr absl::string_view kClaimTagFormat =
         R"(%s("%s", "%s", "%s").)";
     absl::string_view relation_name =
-        (claim_tag_is_present_) ? "claimHasTag" : "saysRemoveTag";
+        (claim_tag_is_present_) ? "saysHasTag" : "saysRemoveTag";
     return absl::StrFormat(
         kClaimTagFormat, relation_name, claiming_particle_name_,
         access_path_.ToString(), tag_);

--- a/src/ir/tag_claim_test.cc
+++ b/src/ir/tag_claim_test.cc
@@ -105,19 +105,19 @@ access_path: {
   selectors: { field: "field1" } },
 predicate: { label: { semantic_tag: "tag"} })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.field1", "tag").)") } },
+          R"(saysHasTag("%s", "%s.field1", "tag").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" } },
 predicate: { label: { semantic_tag: "tag2"} })",
-      { absl::ParsedFormat<'s', 's'>(R"(claimHasTag("%s", "%s", "tag2").)") } },
+      { absl::ParsedFormat<'s', 's'>(R"(saysHasTag("%s", "%s", "tag2").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" },
   selectors: [{ field: "x" }, { field: "y" }] },
 predicate: { label: { semantic_tag: "user_selection"} })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.x.y", "user_selection").)") } },
+          R"(saysHasTag("%s", "%s.x.y", "user_selection").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" },
@@ -134,9 +134,9 @@ predicate: { and: {
   conjunct0: { label: { semantic_tag: "tag"} }
   conjunct1: { label: { semantic_tag: "tag2"} } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.field1", "tag").)"),
+          R"(saysHasTag("%s", "%s.field1", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.field1", "tag2").)") } },
+          R"(saysHasTag("%s", "%s.field1", "tag2").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -147,7 +147,7 @@ predicate: { and: {
       { absl::ParsedFormat<'s', 's'>(
           R"(saysRemoveTag("%s", "%s.field1", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.field1", "tag2").)") } },
+          R"(saysHasTag("%s", "%s.field1", "tag2").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" } },
@@ -155,7 +155,7 @@ predicate: { and: {
   conjunct0: { label: { semantic_tag: "tag"} }
   conjunct1: { not: { predicate: { label: { semantic_tag: "tag2"} } } } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s", "tag").)"),
+          R"(saysHasTag("%s", "%s", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
           R"(saysRemoveTag("%s", "%s", "tag2").)") } },
      { R"(
@@ -168,11 +168,11 @@ predicate: { and: {
     conjunct1: { not: { predicate: { label: { semantic_tag: "tag2"} } } } } }
   conjunct1: { label: { semantic_tag: "tag3"} } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.field1", "tag").)"),
+          R"(saysHasTag("%s", "%s.field1", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
           R"(saysRemoveTag("%s", "%s.field1", "tag2").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.field1", "tag3").)") } },
+          R"(saysHasTag("%s", "%s.field1", "tag3").)") } },
      { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -185,13 +185,13 @@ predicate: { and: {
     conjunct0: { not: { predicate: { label: { semantic_tag: "tag3"} } } }
     conjunct1: { label: { semantic_tag: "tag4" } } } } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.field1", "tag").)"),
+          R"(saysHasTag("%s", "%s.field1", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
           R"(saysRemoveTag("%s", "%s.field1", "tag2").)"),
         absl::ParsedFormat<'s', 's'>(
           R"(saysRemoveTag("%s", "%s.field1", "tag3").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(claimHasTag("%s", "%s.field1", "tag4").)")
+          R"(saysHasTag("%s", "%s.field1", "tag4").)")
           } },
 };
 

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -155,7 +155,7 @@ saysRemoveTag(x, y, z) :- says_removeTag(x, y, z).
 // Manifest
 
 // Claims:
-claimHasTag("particle", "recipe.particle.out", "tag").
+saysHasTag("particle", "recipe.particle.out", "tag").
 
 // Checks:
 

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -82,7 +82,7 @@ static std::tuple<ManifestDatalogFacts, std::string>
            ir::Edge(kHandleConnectionOutAccessPath, kHandleH2AccessPath)}),
       R"(
 // Claims:
-claimHasTag("particle", "recipe.particle.out", "tag").
+saysHasTag("particle", "recipe.particle.out", "tag").
 
 // Checks:
 isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("recipe.particle.in", "tag2").
@@ -281,12 +281,12 @@ class ParseBigManifestTest : public testing::Test {
 };
 
 static const std::string kExpectedClaimStrings[] = {
-    R"(claimHasTag("PS1", "NamedR.PS1#0.out_handle.field1", "tag1").)",
-    R"(claimHasTag("PS1", "NamedR.PS1#1.out_handle.field1", "tag1").)",
-    R"(claimHasTag("PS2", "NamedR.PS2#2.out_handle.field1", "tag3").)",
-    R"(claimHasTag("PS1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "tag1").)",
-    R"(claimHasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "tag3").)",
-    R"(claimHasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "tag3").)",
+    R"(saysHasTag("PS1", "NamedR.PS1#0.out_handle.field1", "tag1").)",
+    R"(saysHasTag("PS1", "NamedR.PS1#1.out_handle.field1", "tag1").)",
+    R"(saysHasTag("PS2", "NamedR.PS2#2.out_handle.field1", "tag3").)",
+    R"(saysHasTag("PS1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "tag1").)",
+    R"(saysHasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "tag3").)",
+    R"(saysHasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "tag3").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -41,7 +41,7 @@ saysRemoveTag(x, y, z) :- says_removeTag(x, y, z).
 // Manifest
 
 // Claims:
-claimHasTag("P1", "R.P1#0.foo", "userSelection").
+saysHasTag("P1", "R.P1#0.foo", "userSelection").
 
 // Checks:
 isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("R.P3#2.bar", "userSelection").


### PR DESCRIPTION
These are equivalent relations. `saysHasTag` is more aligned with authorization logic claims and we should just use that going forward.