### PR TITLE
Add ownership directly to tags and access paths.

### DIFF
--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -43,6 +43,10 @@
 // The `speaker` says this party is the owner of an access path.
 .decl says_ownsAccessPath(speaker: Principal, owner: Principal, path: AccessPath)
 
+// The `speaker` says this party is the owner of an access path.
+.decl says_canSay_ownsAccessPath(speaker: Principal, delegatee: Principal,
+                                 owner: Principal, path: AccessPath)
+
 // This party is the owner of a taint Tag (they have the privilege to remove
 // it).
 .decl ownsTag(owner: Principal, tag: Tag)

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -93,5 +93,6 @@ ownsTag(owner, tag) :- says_ownsTag(_, owner, tag).
 // isTag(tag) :- ownsTag(_, tag).
 
 isPrincipal(owner) :- ownsTag(owner, _).
+isPrincipal(owner) :- ownsAccessPath(owner, _).
 
 #endif // SRC_ANALYSIS_SOUFFLE_AUTHORIZATION_LOGIC_DL_

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -35,9 +35,6 @@
 .decl says_canSay_removeTag(
   speaker: Principal, delegatee: Principal, path: AccessPath, owner:Principal, tag: Tag)
 
-// Indicates that a speaker is allowed to say removeTag.
-.decl canSayRemoveTag(speaker: Principal, path: AccessPath, owner: Principal, tag: Tag)
-
 .decl isPrincipal(principal: Principal)
 
 // This party is the owner of a taint Tag (they have the privilege to remove
@@ -59,9 +56,6 @@
 .decl says_canSay_hasTag(
   speaker: Principal, delegatee: Principal, path: AccessPath, owner: Principal, tag: Tag)
 
-// Indicates that a speaker is allowed to say a path has a particular tag.
-.decl canSayHasTag(speaker: Principal, path: AccessPath, owner: Principal, tag: Tag)
-
 // Rules for linking generated relations with the ones in the dl program.
 .decl says_ownsAccessPath(speaker: Principal, owner: Principal, path: AccessPath)
 
@@ -79,29 +73,6 @@
 //-----------------------------------------------------------------------------
 // Rules
 //-----------------------------------------------------------------------------
-
-// // The owner can always say removeTag.
-// canSayRemoveTag(speaker, path, owner, tag) :-
-//     isAccessPath(path), ownsTag(speaker, tag).
-
-// // If the owner says a speaker can say removeTag, the speaker can say
-// // removeTag.
-// canSayRemoveTag(speaker, path, tag) :-
-//   ownsTag(owner, tag), says_canSay_removeTag(owner, speaker, path, tag).
-
-// removeTag(path, tag) :-
-//     canSayRemoveTag(speaker, path, tag), says_removeTag(speaker, path, tag).
-
-// The owner can say the tag is present anywhere.
-// canSayHasTag(speaker, path, tag) :- isAccessPath(path), ownsTag(speaker, tag).
-
-// The speaker can also speak about the tag if the owner said so.
-// canSayHasTag(speaker, path, tag) :-
-//   ownsTag(owner, tag), says_canSay_hasTag(owner, speaker, path, tag).
-
-// // The path has a tag if an authorized speaker says it does.
-// hasTag(path, tag) :-
-//   says_hasTag(speaker, path, tag), canSayHasTag(speaker, path, tag).
 
 // This rule says that any principal can say that another principal owns a tag.
 // This rule is just a starting point to allow all aspects of the policy to

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -32,13 +32,19 @@
 
 // The `speaker` says that `delegatee` is allowed to indicate that a `path` does
 // not have a `tag`.
-// .decl says_canSay_removeTag(
-//   speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
+.decl says_canSay_removeTag(
+  speaker: Principal, delegatee: Principal, path: AccessPath, owner:Principal, tag: Tag)
 
 // Indicates that a speaker is allowed to say removeTag.
-.decl canSayRemoveTag(speaker: Principal, path: AccessPath, tag: Tag)
+.decl canSayRemoveTag(speaker: Principal, path: AccessPath, owner: Principal, tag: Tag)
 
 .decl isPrincipal(principal: Principal)
+
+// This party is the owner of a taint Tag (they have the privilege to remove
+// it).
+.decl ownsAccessPath(owner: Principal, path: AccessPath)
+
+.decl saysOwnsAccessPath(speaker: Principal, owner: Principal, path: AccessPath)
 
 // This party is the owner of a taint Tag (they have the privilege to remove
 // it).
@@ -51,10 +57,13 @@
 
 // The `speaker` says that the `delegatee` can say that `path` has `tag`.
 // .decl says_canSay_hasTag(
-//   speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
+//   speaker: Principal, delegatee: Principal, path: AccessPath, owner: Principal, tag: Tag)
 
-// // Indicates that a speaker is allowed to say a path has a particular tag.
-// .decl canSayHasTag(speaker: Principal, path: AccessPath, tag: Tag)
+// Indicates that a speaker is allowed to say a path has a particular tag.
+.decl canSayHasTag(speaker: Principal, path: AccessPath, owner: Principal, tag: Tag)
+
+// Rules for linking generated relations with the ones in the dl program.
+.decl says_ownsAccessPath(speaker: Principal, owner: Principal, path: AccessPath)
 
 // // Indicates that a `tag` is definitely present upon a `path` because a speaker
 // // delegated to by the owner said so.

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -33,15 +33,15 @@
 // The `speaker` says that `delegatee` is allowed to indicate that a `path` does
 // not have a `tag`.
 .decl says_canSay_removeTag(
-  speaker: Principal, delegatee: Principal, path: AccessPath, owner:Principal, tag: Tag)
+  speaker: Principal, delegatee: Principal, path: AccessPath, owner: Principal, tag: Tag)
 
 .decl isPrincipal(principal: Principal)
 
-// This party is the owner of a taint Tag (they have the privilege to remove
-// it).
+// This party is the owner of an access path.
 .decl ownsAccessPath(owner: Principal, path: AccessPath)
 
-.decl saysOwnsAccessPath(speaker: Principal, owner: Principal, path: AccessPath)
+// The `speaker` says this party is the owner of an access path.
+.decl says_ownsAccessPath(speaker: Principal, owner: Principal, path: AccessPath)
 
 // This party is the owner of a taint Tag (they have the privilege to remove
 // it).
@@ -55,20 +55,6 @@
 // The `speaker` says that the `delegatee` can say that `path` has `tag`.
 .decl says_canSay_hasTag(
   speaker: Principal, delegatee: Principal, path: AccessPath, owner: Principal, tag: Tag)
-
-// Rules for linking generated relations with the ones in the dl program.
-.decl says_ownsAccessPath(speaker: Principal, owner: Principal, path: AccessPath)
-
-// // Indicates that a `tag` is definitely present upon a `path` because a speaker
-// // delegated to by the owner said so.
-// .decl hasTag(path: AccessPath, tag: Tag)
-
-// The tag for some accessPath is actually removed (by taking into consideration
-// the privileges of a party trying to remove it, and as a result of that party
-// deciding to remove it). Because here IFC labels are sets of tags (ordered
-// by the subset or equals relation), removing a tag from the set corresponds to
-// a downgrade by making set of tags on the access path "lower" in the order.
-// .decl removeTag(path: AccessPath, owner: Principal, tag: Tag)
 
 //-----------------------------------------------------------------------------
 // Rules

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -32,8 +32,8 @@
 
 // The `speaker` says that `delegatee` is allowed to indicate that a `path` does
 // not have a `tag`.
-.decl says_canSay_removeTag(
-  speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
+// .decl says_canSay_removeTag(
+//   speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
 
 // Indicates that a speaker is allowed to say removeTag.
 .decl canSayRemoveTag(speaker: Principal, path: AccessPath, tag: Tag)
@@ -50,49 +50,49 @@
 .decl says_hasTag(speaker: Principal, path: AccessPath, tag: Tag)
 
 // The `speaker` says that the `delegatee` can say that `path` has `tag`.
-.decl says_canSay_hasTag(
-  speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
+// .decl says_canSay_hasTag(
+//   speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
 
-// Indicates that a speaker is allowed to say a path has a particular tag.
-.decl canSayHasTag(speaker: Principal, path: AccessPath, tag: Tag)
+// // Indicates that a speaker is allowed to say a path has a particular tag.
+// .decl canSayHasTag(speaker: Principal, path: AccessPath, tag: Tag)
 
-// Indicates that a `tag` is definitely present upon a `path` because a speaker
-// delegated to by the owner said so.
-.decl hasTag(path: AccessPath, tag: Tag)
+// // Indicates that a `tag` is definitely present upon a `path` because a speaker
+// // delegated to by the owner said so.
+// .decl hasTag(path: AccessPath, tag: Tag)
 
 // The tag for some accessPath is actually removed (by taking into consideration
 // the privileges of a party trying to remove it, and as a result of that party
 // deciding to remove it). Because here IFC labels are sets of tags (ordered
 // by the subset or equals relation), removing a tag from the set corresponds to
 // a downgrade by making set of tags on the access path "lower" in the order.
-.decl removeTag(path: AccessPath, tag: Tag)
+// .decl removeTag(path: AccessPath, owner: Principal, tag: Tag)
 
 //-----------------------------------------------------------------------------
 // Rules
 //-----------------------------------------------------------------------------
 
-// The owner can always say removeTag.
-canSayRemoveTag(speaker, path, tag) :-
-    isAccessPath(path), ownsTag(speaker, tag).
+// // The owner can always say removeTag.
+// canSayRemoveTag(speaker, path, owner, tag) :-
+//     isAccessPath(path), ownsTag(speaker, tag).
 
-// If the owner says a speaker can say removeTag, the speaker can say
-// removeTag.
-canSayRemoveTag(speaker, path, tag) :-
-  ownsTag(owner, tag), says_canSay_removeTag(owner, speaker, path, tag).
+// // If the owner says a speaker can say removeTag, the speaker can say
+// // removeTag.
+// canSayRemoveTag(speaker, path, tag) :-
+//   ownsTag(owner, tag), says_canSay_removeTag(owner, speaker, path, tag).
 
-removeTag(path, tag) :-
-    canSayRemoveTag(speaker, path, tag), says_removeTag(speaker, path, tag).
+// removeTag(path, tag) :-
+//     canSayRemoveTag(speaker, path, tag), says_removeTag(speaker, path, tag).
 
 // The owner can say the tag is present anywhere.
-canSayHasTag(speaker, path, tag) :- isAccessPath(path), ownsTag(speaker, tag).
+// canSayHasTag(speaker, path, tag) :- isAccessPath(path), ownsTag(speaker, tag).
 
 // The speaker can also speak about the tag if the owner said so.
-canSayHasTag(speaker, path, tag) :-
-  ownsTag(owner, tag), says_canSay_hasTag(owner, speaker, path, tag).
+// canSayHasTag(speaker, path, tag) :-
+//   ownsTag(owner, tag), says_canSay_hasTag(owner, speaker, path, tag).
 
-// The path has a tag if an authorized speaker says it does.
-hasTag(path, tag) :-
-  says_hasTag(speaker, path, tag), canSayHasTag(speaker, path, tag).
+// // The path has a tag if an authorized speaker says it does.
+// hasTag(path, tag) :-
+//   says_hasTag(speaker, path, tag), canSayHasTag(speaker, path, tag).
 
 // This rule says that any principal can say that another principal owns a tag.
 // This rule is just a starting point to allow all aspects of the policy to

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -28,7 +28,7 @@
 
 // Some party asserts the claim that the label of an access path should
 // remove the referenced tag from the set.
-.decl says_removeTag(speaker: Principal, path: AccessPath, tag: Tag)
+.decl says_removeTag(speaker: Principal, path: AccessPath, owner: Principal, tag: Tag)
 
 // The `speaker` says that `delegatee` is allowed to indicate that a `path` does
 // not have a `tag`.
@@ -53,11 +53,11 @@
 .decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
 
 // The `speaker` says that `path` definitely has `tag` taint.
-.decl says_hasTag(speaker: Principal, path: AccessPath, tag: Tag)
+.decl says_hasTag(speaker: Principal, path: AccessPath, owner: Principal, tag: Tag)
 
 // The `speaker` says that the `delegatee` can say that `path` has `tag`.
-// .decl says_canSay_hasTag(
-//   speaker: Principal, delegatee: Principal, path: AccessPath, owner: Principal, tag: Tag)
+.decl says_canSay_hasTag(
+  speaker: Principal, delegatee: Principal, path: AccessPath, owner: Principal, tag: Tag)
 
 // Indicates that a speaker is allowed to say a path has a particular tag.
 .decl canSayHasTag(speaker: Principal, path: AccessPath, owner: Principal, tag: Tag)

--- a/src/analysis/souffle/dataflow_graph.dl
+++ b/src/analysis/souffle/dataflow_graph.dl
@@ -52,7 +52,7 @@
 // to the tgt. That allows us to effectively eliminate edges that are the
 // subject of a claimNotEdge from the dataflow graph by eliminating all tags
 // from the midway point. Paths are defined in terms of resolvedEdges.
-.decl resolvedEdge(src: AccessPath, tgt: AccessPath)
+.decl resolvedEdge(for: Principal, src: AccessPath, tgt: AccessPath)
 
 // A direct or transitive data flow path.
 .decl path(src: AccessPath, tgt: AccessPath)
@@ -62,23 +62,28 @@
 //-----------------------------------------------------------------------------
 // Generate a midpoint access path for each edge that is the subject of a
 // claimNotEdge from any principal.
-edgeToMidpointAccessPath(src, tgt, cat("##midpoint_", to_string($))) :-
-  edge(src, tgt), claimNotEdge(_, src, tgt).
+// edgeToMidpointAccessPath(src, tgt, cat("##midpoint_", to_string($))) :-
+//   edge(src, tgt), claimNotEdge(_, src, tgt).
 
-// Generate inner edges to and from that midpoint for each edge with a midpoint.
-resolvedEdge(src, midpoint), resolvedEdge(midpoint, tgt) :-
-  edgeToMidpointAccessPath(src, tgt, midpoint).
+// // Generate inner edges to and from that midpoint for each edge with a midpoint.
+// resolvedEdge(src, midpoint), resolvedEdge(midpoint, tgt) :-
+//   edgeToMidpointAccessPath(src, tgt, midpoint).
 
-// For edges for which a midpoint was not generated, generate an resolvedEdge
-// corresponding to the original edge.
-resolvedEdge(src, tgt) :- edge(src, tgt), !edgeToMidpointAccessPath(src, tgt, _).
+// // For edges for which a midpoint was not generated, generate an resolvedEdge
+// // corresponding to the original edge.
+// resolvedEdge(src, tgt) :- edge(src, tgt), !edgeToMidpointAccessPath(src, tgt, _).
+resolvedEdge(principal, src, tgt) :-
+   isPrincipal(principal),
+   edge(src, tgt),
+   !claimNotEdge(principal, src, tgt).
 
 // Transitive paths
-path(from, to) :- resolvedEdge(from, to).
-path(from, to) :- resolvedEdge(from, intermediate), path(intermediate, to).
+//TODO(bgogul): We don't use these at all.
+path(from, to) :- resolvedEdge(_, from, to).
+path(from, to) :- resolvedEdge(_, from, intermediate), path(intermediate, to).
 
 // Symbols used in resolvedEdges are access paths
-isAccessPath(x) :- resolvedEdge(x, _).
-isAccessPath(y) :- resolvedEdge(_, y).
+isAccessPath(x) :- resolvedEdge(_, x, _).
+isAccessPath(y) :- resolvedEdge(_, _, y).
 
 #endif // SRC_ANALYSIS_SOUFFLE_DATAFLOW_GRAPH_DL_

--- a/src/analysis/souffle/dataflow_graph.dl
+++ b/src/analysis/souffle/dataflow_graph.dl
@@ -60,18 +60,6 @@
 //-----------------------------------------------------------------------------
 // Rules
 //-----------------------------------------------------------------------------
-// Generate a midpoint access path for each edge that is the subject of a
-// claimNotEdge from any principal.
-// edgeToMidpointAccessPath(src, tgt, cat("##midpoint_", to_string($))) :-
-//   edge(src, tgt), claimNotEdge(_, src, tgt).
-
-// // Generate inner edges to and from that midpoint for each edge with a midpoint.
-// resolvedEdge(src, midpoint), resolvedEdge(midpoint, tgt) :-
-//   edgeToMidpointAccessPath(src, tgt, midpoint).
-
-// // For edges for which a midpoint was not generated, generate an resolvedEdge
-// // corresponding to the original edge.
-// resolvedEdge(src, tgt) :- edge(src, tgt), !edgeToMidpointAccessPath(src, tgt, _).
 resolvedEdge(principal, src, tgt) :-
    isPrincipal(principal),
    edge(src, tgt),

--- a/src/analysis/souffle/dataflow_graph.dl
+++ b/src/analysis/souffle/dataflow_graph.dl
@@ -66,7 +66,6 @@ resolvedEdge(principal, src, tgt) :-
    !claimNotEdge(principal, src, tgt).
 
 // Transitive paths
-//TODO(bgogul): We don't use these at all.
 path(from, to) :- resolvedEdge(_, from, to).
 path(from, to) :- resolvedEdge(_, from, intermediate), path(intermediate, to).
 

--- a/src/analysis/souffle/examples/multimic/multimic.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic.authlogic
@@ -1,9 +1,10 @@
 // UserC is a very privacy sensitive user. They do not trust anyone to perform
 // ASR on their voice data.
 "UserC" says {
-
+  // TODO(bgogul): we should claim ownership at the level of handles rather recipe access paths.
+  ownsAccessPath("UserC", "DoASRUserAAndUserBAndUserC.UserCTainter#5.audio").
   // We want to use canSay hasTag but cannot due to issue #195.
-  "UserCTainter" canSay hasTag(pathX, "asrDisallowed") :- isAccessPath(pathX).
+  "UserCTainter" canSay hasTag(pathX, "UserC", "asrDisallowed") :- isAccessPath(pathX).
   // TODO(#195) remove this ownership claim.
   ownsTag("UserCTainter", "asrDisallowed").
 }

--- a/src/analysis/souffle/examples/multimic/multimic.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic.authlogic
@@ -11,7 +11,7 @@
 // UserC is a very privacy sensitive user. They do not trust anyone to perform
 // ASR on their voice data.
 "UserC" says {
-  // TODO(bgogul): we should claim ownership at the level of handles rather recipe access paths.
+  // TODO(#220): we should claim ownership at the level of handles rather recipe access paths.
   ownsAccessPath("UserC", "DoASRUserAAndUserBAndUserC.UserCTainter#5.audio").
   // We want to use canSay hasTag but cannot due to issue #195.
   "UserCTainter" canSay hasTag(pathX, "UserC", "asrDisallowed") :- isAccessPath(pathX).

--- a/src/analysis/souffle/examples/multimic/multimic.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic.authlogic
@@ -1,3 +1,13 @@
+"UserA" says {
+  ownsAccessPath("UserA", "DoASRUserAAndUserB.UserATainter#3.audioIn").
+  ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.UserATainter#3.audioIn").
+}
+
+"UserB" says {
+  ownsAccessPath("UserB", "DoASRUserAAndUserB.UserBTainter#4.audioIn").
+  ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.UserBTainter#4.audioIn").
+}
+
 // UserC is a very privacy sensitive user. They do not trust anyone to perform
 // ASR on their voice data.
 "UserC" says {
@@ -8,14 +18,3 @@
   // TODO(#195) remove this ownership claim.
   ownsTag("UserCTainter", "asrDisallowed").
 }
-
-"UserA" says ownsAccessPath("UserA", "DoASRNoGuests.MicCompute#0.audioIn").
-"UserB" says ownsAccessPath("UserB", "DoASRNoGuests.MicCompute#0.audioIn").
-"UserC" says ownsAccessPath("UserC", "DoASRNoGuests.MicCompute#0.audioIn").
-"UserA" says ownsAccessPath("UserA", "DoASRUserAAndUserB.MicCompute#0.audioIn").
-"UserB" says ownsAccessPath("UserB", "DoASRUserAAndUserB.MicCompute#0.audioIn").
-"UserC" says ownsAccessPath("UserC", "DoASRUserAAndUserB.MicCompute#0.audioIn").
-"UserA" says ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.MicCompute#0.audioIn").
-"UserB" says ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.MicCompute#0.audioIn").
-"UserC" says ownsAccessPath("UserC", "DoASRUserAAndUserBAndUserC.MicCompute#0.audioIn").
-

--- a/src/analysis/souffle/examples/multimic/multimic.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic.authlogic
@@ -8,3 +8,14 @@
   // TODO(#195) remove this ownership claim.
   ownsTag("UserCTainter", "asrDisallowed").
 }
+
+"UserA" says ownsAccessPath("UserA", "DoASRNoGuests.MicCompute#0.audioIn").
+"UserB" says ownsAccessPath("UserB", "DoASRNoGuests.MicCompute#0.audioIn").
+"UserC" says ownsAccessPath("UserC", "DoASRNoGuests.MicCompute#0.audioIn").
+"UserA" says ownsAccessPath("UserA", "DoASRUserAAndUserB.MicCompute#0.audioIn").
+"UserB" says ownsAccessPath("UserB", "DoASRUserAAndUserB.MicCompute#0.audioIn").
+"UserC" says ownsAccessPath("UserC", "DoASRUserAAndUserB.MicCompute#0.audioIn").
+"UserA" says ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.MicCompute#0.audioIn").
+"UserB" says ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.MicCompute#0.audioIn").
+"UserC" says ownsAccessPath("UserC", "DoASRUserAAndUserBAndUserC.MicCompute#0.audioIn").
+

--- a/src/analysis/souffle/examples/multimic/multimic_no_userc_tag.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic_no_userc_tag.authlogic
@@ -1,8 +1,9 @@
+"UserA" says {
+  ownsAccessPath("UserA", "DoASRUserAAndUserB.UserATainter#3.audioIn").
+  ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.UserATainter#3.audioIn").
+}
 
-"UserA" says ownsAccessPath("UserA", "DoASRUserAAndUserB.MicIn#1.audio").
-"UserB" says ownsAccessPath("UserB", "DoASRUserAAndUserB.MicIn#1.audio").
-"UserA" says ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.MicIn#1.audio").
-"UserB" says ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.MicIn#1.audio").
-
-
-
+"UserB" says {
+  ownsAccessPath("UserB", "DoASRUserAAndUserB.UserBTainter#4.audioIn").
+  ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.UserBTainter#4.audioIn").
+}

--- a/src/analysis/souffle/examples/multimic/multimic_no_userc_tag.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic_no_userc_tag.authlogic
@@ -1,3 +1,4 @@
+// TODO(#220): we should claim ownership at the level of handles rather recipe access paths.
 "UserA" says {
   ownsAccessPath("UserA", "DoASRUserAAndUserB.UserATainter#3.audioIn").
   ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.UserATainter#3.audioIn").

--- a/src/analysis/souffle/examples/multimic/multimic_no_userc_tag.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic_no_userc_tag.authlogic
@@ -1,0 +1,8 @@
+
+"UserA" says ownsAccessPath("UserA", "DoASRUserAAndUserB.MicIn#1.audio").
+"UserB" says ownsAccessPath("UserB", "DoASRUserAAndUserB.MicIn#1.audio").
+"UserA" says ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.MicIn#1.audio").
+"UserB" says ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.MicIn#1.audio").
+
+
+

--- a/src/analysis/souffle/examples/simple/ok_claim_propagates.raksha
+++ b/src/analysis/souffle/examples/simple/ok_claim_propagates.raksha
@@ -18,3 +18,6 @@ recipe R
 // __AUTH_LOGIC__
 "EndUser" says "P1" canSay ownsTag("P1", "userSelection").
 "P1" says ownsTag("P1", "userSelection").
+"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
+"EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).
+

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted.authlogic
@@ -1,5 +1,5 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
-//TODO(bgogul): This should be at the level of handles which correspond to stores,
+//TODO(#220): This should be at the level of handles which correspond to stores,
 // where ownership makes more sense.
 "EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
 "EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted.authlogic
@@ -1,3 +1,6 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
-"EndUser" says "P1" canSay hasTag(accessPathX, "userSelection") :- isAccessPath(accessPathX).
-"EndUser" says "P2" canSay removeTag(accessPathX, "userSelection") :- isAccessPath(accessPathX).
+//TODO(bgogul): This should be at the level of handles which correspond to stores,
+// where ownership makes more sense.
+"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
+"EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).
+"EndUser" says "P2" canSay removeTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted_by_non_owner.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted_by_non_owner.authlogic
@@ -1,2 +1,3 @@
-"EndUser" says "P1" canSay hasTag(accessPathX,  "EndUser", "userSelection") :- isAccessPath(accessPathX).
-"EndUser" says "P2" canSay removeTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).
+"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
+"P1" says "P1" canSay hasTag(accessPathX,  "EndUser", "userSelection") :- isAccessPath(accessPathX).
+"P1" says "P2" canSay removeTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted_by_non_owner.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted_by_non_owner.authlogic
@@ -1,2 +1,2 @@
-"EndUser" says "P1" canSay hasTag(accessPathX, "userSelection") :- isAccessPath(accessPathX).
-"EndUser" says "P2" canSay removeTag(accessPathX, "userSelection") :- isAccessPath(accessPathX).
+"EndUser" says "P1" canSay hasTag(accessPathX,  "EndUser", "userSelection") :- isAccessPath(accessPathX).
+"EndUser" says "P2" canSay removeTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_not_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_not_granted.authlogic
@@ -1,2 +1,2 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
-"EndUser" says "P1" canSay hasTag(accessPathX, "userSelection") :- isAccessPath(accessPathX).
+"EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_not_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_not_granted.authlogic
@@ -1,2 +1,3 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
+"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
 "EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_granted.authlogic
@@ -1,5 +1,5 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
-//TODO(bgogul): We should claim ownership at the level of handles that correspond
+//TODO(#220): We should claim ownership at the level of handles that correspond
 // to stores where ownership makes more sense.
 "EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
 "EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_granted.authlogic
@@ -1,2 +1,2 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
-"EndUser" says "P1" canSay hasTag(accessPathX, "userSelection") :- isAccessPath(accessPathX).
+"EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_granted.authlogic
@@ -1,2 +1,5 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
+//TODO(bgogul): We should claim ownership at the level of handles that correspond
+// to stores where ownership makes more sense.
+"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
 "EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection") :- isAccessPath(accessPathX).

--- a/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_not_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_not_granted.authlogic
@@ -1,4 +1,4 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
-//TODO(bgogul): We should claim ownership at the level of handles that correspond
+//TODO(#220): We should claim ownership at the level of handles that correspond
 // to stores where ownership makes more sense.
 "EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").

--- a/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_not_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_not_granted.authlogic
@@ -1,1 +1,4 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
+//TODO(bgogul): We should claim ownership at the level of handles that correspond
+// to stores where ownership makes more sense.
+"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").

--- a/src/analysis/souffle/examples/simple_may_will/simple_may_will_fail.authlogic
+++ b/src/analysis/souffle/examples/simple_may_will/simple_may_will_fail.authlogic
@@ -17,7 +17,8 @@
 
 "EndUser" says {
     ownsTag("EndUser", "rawVideo").
-    "P1" canSay hasTag(PathX, "rawVideo") :- isAccessPath(PathX).
+    ownsAccessPath("EndUser", "R.P1#0.foo").
+    "P1" canSay hasTag(PathX, "EndUser", "rawVideo") :- isAccessPath(PathX).
 }
 
 // It would be better if we could change the manifest frontend and write it 

--- a/src/analysis/souffle/examples/simple_may_will/simple_may_will_pass.authlogic
+++ b/src/analysis/souffle/examples/simple_may_will/simple_may_will_pass.authlogic
@@ -17,7 +17,7 @@
 
 "EndUser" says {
     ownsTag("EndUser", "rawVideo").
-    "P1" canSay hasTag(PathX, "rawVideo") :- isAccessPath(PathX).
+    "P1" canSay hasTag(PathX, "EndUser", "rawVideo") :- isAccessPath(PathX).
     may("P2", "doLocalComputation", "rawVideo").
 }
 

--- a/src/analysis/souffle/fact_test_helper.dl
+++ b/src/analysis/souffle/fact_test_helper.dl
@@ -58,14 +58,14 @@ ownsTag(principal, tag) :- isPrincipal(principal), isTag(tag).
   allTestsAndCaseNum(test_aspect_name, $) :- 1 = 1. \
   testPasses(test_aspect_name)
 
-#define CHECK_TAG_PRESENT(access_path, tag) \
+#define CHECK_TAG_PRESENT(access_path, owner, tag) \
   isAccessPath(access_path). \
   TEST_CASE(cat(cat(cat("is_", tag), "_present_in_"), access_path)) :- \
-    isAccessPath(access_path), mayHaveTag(access_path, tag)
+    isAccessPath(access_path), mayHaveTag(access_path, owner, tag)
 
-#define CHECK_TAG_NOT_PRESENT(access_path, tag) \
+#define CHECK_TAG_NOT_PRESENT(access_path, owner, tag) \
   isAccessPath(access_path). \
   TEST_CASE(cat(cat(cat("is_", tag), "_not_present_in_"), access_path)) :- \
-    isAccessPath(access_path), !mayHaveTag(access_path, tag)
+    isAccessPath(access_path), !mayHaveTag(access_path, owner, tag)
 
 #endif // SRC_ANALYSIS_SOUFFLE_ANALYZE_TAG_CHECKS_TEST_HELPER_DL_

--- a/src/analysis/souffle/may_will.dl
+++ b/src/analysis/souffle/may_will.dl
@@ -21,16 +21,16 @@
 //          `ownsTag(Q, <TAG>)`
 //          `Q says P may <RELATION> using <TAG>`
 
-.decl permittedUsage(actor: Principal, usage: Usage, tag: Tag)
+.decl permittedUsage(actor: Principal, usage: Usage, owner: Principal, tag: Tag)
 
-permittedUsage(consumer, usage, tag) :- ownsTag(owner, tag),
+permittedUsage(consumer, usage, owner, tag) :- ownsTag(owner, tag),
     saysMay(owner, consumer, usage, tag).
 
-.decl disallowedUsage(dataConsumer: Principal, usage: Usage, tag: Tag)
+.decl disallowedUsage(dataConsumer: Principal, usage: Usage, owner: Principal, tag: Tag)
 
-disallowedUsage(dataConsumer, usage, tag) :-
-    saysWill(dataConsumer, usage, path), mayHaveTag(path, tag),
-    !permittedUsage(dataConsumer, usage, tag).
+disallowedUsage(dataConsumer, usage, owner, tag) :-
+    saysWill(dataConsumer, usage, path), mayHaveTag(path, owner, tag),
+    !permittedUsage(dataConsumer, usage, owner, tag).
 
 // This is a 0-ary relation that says all data usages are allowed. 
 // Because souffle does not have 0-ary relations, it uses one dummy variable.
@@ -38,7 +38,7 @@ disallowedUsage(dataConsumer, usage, tag) :-
 
 .decl isUsage(usage: Usage)
 
-allUsagesAllowed("dummy_var") :- !disallowedUsage(dataConsumer, usage, tag),
-    isPrincipal(dataConsumer), isUsage(usage), isTag(tag).
+allUsagesAllowed("dummy_var") :- !disallowedUsage(dataConsumer, usage, owner, tag),
+    isPrincipal(dataConsumer), isUsage(usage), isTag(tag), ownsTag(owner, tag).
 
 #endif // MAY_WILL_DL_

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -56,47 +56,9 @@
 // Rules
 //-----------------------------------------------------------------------------
 
-// This rule is meant to support the functionality of removing edges from
-// manifests:
-//      - that clearly does not introduce an unsafe escape hatch that could
-//      break policies (because it does not introduce removeTag that would not
-//      otherwise be possible).
-//      - without data owners needing to know anything about the application
-//      structure
-//      - without app behavior specification writers needing to know anything
-//      about the taint analysis or the tags that might appear on a handle
-
-
-// claimNotEdge(p, src, tgt) is an _attempt_ to remove an edge from the
-// analysis (by principal p)
-// says_removeTag(p, path, tgt) is an _attempt_ to remove just one tag
-// from a path (by principal p).
-//
-// The rule for removeTag(p, t) in authorization_logic.dl describes when
-// removing a tag is "safe" and the removal really happens (by consulting the
-// owners).
-//
-// Because the analysis propagates the tags on source edges to dest edges, it is safe
-// to remove an edge when ALL of the tags on the source edge can be removed.
-// However, we do not want to interfere with other edges that may flow from
-// that source path. Instead, we remove all of the tags on the source from the
-// midpoint access path we add in the middle of each edge. This rule populates a
-// request to remove a tag on the edge midpoint.
-//      - it is safe because these requests are only accepted if they would
-//      normally be by the removeTag(_, _) rule
-//      - it does not require the manifest writer to know anything about the
-//      tags in the analysis
-//      - data owners do not need to know about paths, and they will grant
-//      permission for edge removal indirectly by granting permission to remove
-//      tags (abstract representations of their data).
-
-
 ownsAccessPath(principal, path) :- says_ownsAccessPath(principal, principal, path).
 ownsAccessPath(principal, tgt) :-
   resolvedEdge(principal, src, tgt), ownsAccessPath(principal, src).
-
-// says_removeTag(principal, midpoint, principal, tag) :-
-//   isTag(tag), claimNotEdge(principal, src, tgt), edgeToMidpointAccessPath(src, tgt, midpoint).
 
 removeTag(path, owner, tag) :-
    says_removeTag(owner, path, owner, tag).

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -25,6 +25,11 @@
 // Relation Declarations
 //-----------------------------------------------------------------------------
 
+// Indicates that an access path definitely has a tag. Differs from mayHaveTag
+// below in that mayHaveTag indicates only that it is possible that an
+// accessPath has a tag.
+.decl hasTag(accessPath: AccessPath, owner: Principal, tag: Tag)
+
 // Declares that `accessPath` may have been tainted with `tag`.
 // If false, `accessPath` *definitely* does not have `tag` taint at runtime.
 // If true, `accessPath` may have the `tag` taint at runtime.
@@ -32,7 +37,15 @@
 // indirection in which accessPaths have IFCLabels and just IFCLabels have Tags.
 // In this formalization, accessPaths also act as IFCLabels (in the sense that
 // they have Tags).
-.decl mayHaveTag(accessPath: AccessPath, tag: Tag)
+.decl mayHaveTag(accessPath: AccessPath, owner: Principal, tag: Tag)
+
+// The tag for some accessPath is actually removed (by taking into consideration
+// the privileges of a party trying to remove it, and as a result of that party
+// deciding to remove it). Because here IFC labels are sets of tags (ordered
+// by the subset or equals relation), removing a tag from the set corresponds to
+// a downgrade by making set of tags on the access path "lower" in the order.
+.decl removeTag(path: AccessPath, owner: Principal, tag: Tag)
+
 
 // Manifests can produce base facts of this form, where usually the principal
 // is a particle (and this fact is entered by a code reviewer with no knowledge
@@ -77,13 +90,18 @@
 //      permission for edge removal indirectly by granting permission to remove
 //      tags (abstract representations of their data).
 
-says_removeTag(principal, midpoint, tag) :-
+says_removeTag(principal, midpoint, principal, tag) :-
   isTag(tag), claimNotEdge(principal, src, tgt), edgeToMidpointAccessPath(src, tgt, midpoint).
 
-mayHaveTag(tgt, tag) :- hasTag(tgt, tag).
+removeTag(path, owner, tag) :-
+   saysRemoveTag(owner, path, owner, tag).
 
-mayHaveTag(tgt, tag) :-
-    resolvedEdge(src, tgt), mayHaveTag(src, tag), !removeTag(tgt, tag).
+hasTag(path, owner, tag) :- saysHasTag(owner, path, owner, tag).
+
+mayHaveTag(tgt, owner, tag) :- hasTag(tgt, owner, tag).
+
+mayHaveTag(tgt, owner, tag) :-
+    resolvedEdge(src, tgt), mayHaveTag(src, owner, tag), !removeTag(tgt, owner, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules
@@ -92,12 +110,12 @@ mayHaveTag(tgt, tag) :-
 // `isObject(..)`) whenever they are mentioned in other rules.
 
 // Any Principal used in a claim is in the universe of isPrincipal.
-isPrincipal(principal) :- says_hasTag(principal, _, _).
+isPrincipal(principal) :- says_hasTag(principal, _, _, _).
 
-isAccessPath(path) :- says_hasTag(_, path, _).
+isAccessPath(path) :- says_hasTag(_, path, _, _).
 
 // Symbols used in hasTag or mayHaveTag are tags
-isTag(tag) :- says_hasTag(_, _, tag).
+isTag(tag) :- says_hasTag(_, _, _, tag).
 
 // A pair of (base, member) is in this set if the base access path is a non-trivial subpath of the
 // member access path.
@@ -113,10 +131,10 @@ isMemberOf(base, member) :-
 // An access path may have a tag if some subpath to a member field has that tag. This allows
 // checking for some inner node in the access path whether any leaf node of that node might have
 // a particular tag.
-mayHaveTag(base, tag) :-
+mayHaveTag(base, owner, tag) :-
   isAccessPath(base),
   isAccessPath(member),
-  mayHaveTag(member, tag),
+  mayHaveTag(member,owner, tag),
   isMemberOf(base, member).
 
 #endif // SRC_ANALYSIS_SOUFFLE_TAINT_DL_

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -60,6 +60,7 @@ ownsAccessPath(principal, path) :- says_ownsAccessPath(principal, principal, pat
 ownsAccessPath(principal, tgt) :-
   resolvedEdge(principal, src, tgt), ownsAccessPath(principal, src).
 
+// This rule says that a tag may be removed only if the owner of the tag says so.
 removeTag(path, owner, tag) :-
    says_removeTag(owner, path, owner, tag).
 

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -99,9 +99,9 @@ ownsAccessPath(principal, tgt) :-
 //   isTag(tag), claimNotEdge(principal, src, tgt), edgeToMidpointAccessPath(src, tgt, midpoint).
 
 removeTag(path, owner, tag) :-
-   saysRemoveTag(owner, path, owner, tag).
+   says_removeTag(owner, path, owner, tag).
 
-hasTag(path, owner, tag) :- saysHasTag(owner, path, owner, tag).
+hasTag(path, owner, tag) :- says_hasTag(owner, path, owner, tag).
 
 mayHaveTag(tgt, owner, tag) :- hasTag(tgt, owner, tag).
 

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -93,10 +93,10 @@
 
 ownsAccessPath(principal, path) :- says_ownsAccessPath(principal, principal, path).
 ownsAccessPath(principal, tgt) :-
-  resolvedEdge(src, tgt), ownsAccessPath(principal, src).
+  resolvedEdge(principal, src, tgt), ownsAccessPath(principal, src).
 
-says_removeTag(principal, midpoint, principal, tag) :-
-  isTag(tag), claimNotEdge(principal, src, tgt), edgeToMidpointAccessPath(src, tgt, midpoint).
+// says_removeTag(principal, midpoint, principal, tag) :-
+//   isTag(tag), claimNotEdge(principal, src, tgt), edgeToMidpointAccessPath(src, tgt, midpoint).
 
 removeTag(path, owner, tag) :-
    saysRemoveTag(owner, path, owner, tag).
@@ -106,7 +106,7 @@ hasTag(path, owner, tag) :- saysHasTag(owner, path, owner, tag).
 mayHaveTag(tgt, owner, tag) :- hasTag(tgt, owner, tag).
 
 mayHaveTag(tgt, owner, tag) :-
-    resolvedEdge(src, tgt), mayHaveTag(src, owner, tag), !removeTag(tgt, owner, tag).
+    resolvedEdge(owner, src, tgt), mayHaveTag(src, owner, tag), !removeTag(tgt, owner, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -90,6 +90,11 @@
 //      permission for edge removal indirectly by granting permission to remove
 //      tags (abstract representations of their data).
 
+
+ownsAccessPath(principal, path) :- says_ownsAccessPath(principal, principal, path).
+ownsAccessPath(principal, tgt) :-
+  resolvedEdge(src, tgt), ownsAccessPath(principal, src).
+
 says_removeTag(principal, midpoint, principal, tag) :-
   isTag(tag), claimNotEdge(principal, src, tgt), edgeToMidpointAccessPath(src, tgt, midpoint).
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/claim_not_edge_two_inputs_two_outputs.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/claim_not_edge_two_inputs_two_outputs.dl
@@ -22,30 +22,34 @@ isPrincipal("ParticleX").
 ownsTag("Claimer", "tag1").
 ownsTag("Claimer", "tag2").
 
-says_hasTag("Claimer", "R.foo.hc1", "tag1").
-says_hasTag("Claimer", "R.foo.hc2", "tag2").
+says_hasTag("Claimer", "R.foo.hc1", "Claimer", "tag1").
+says_hasTag("Claimer", "R.foo.hc2", "Claimer", "tag2").
 
-// ParticleX claims that hc2 does not flow to hco1.
+
+#ifdef ALL_PRINCIPALS_OWN_ALL_TAGS
+
+// Claimer claims that hc2 does not flow to hco1.
 // TODO(#146) In the case where we expect this claim to be upheld, how does that
 // work without an explicit delegation of tags to ParticleX? Well, we're
 // currently somewhat hackily turning on and off the helper rule that causes
 // all particles to own all tags, and in the case where all particles own all
 // tags, ParticleX is a co-owner of all tags. We should introduce a more
 // principled way to do different test variants at some point.
-claimNotEdge("ParticleX", "R.foo.hc2", "R.foo.hco1").
+// The edge will not be removed only if "Claimer" says that the edge is removed.
+// Otherwise, the removal of the edge will not be considered at all. 
+claimNotEdge("Claimer", "R.foo.hc2", "R.foo.hco1").
 
-#ifdef ALL_PRINCIPALS_OWN_ALL_TAGS
 // If we believe it, we should find only tag1 on hco1, but we should still find
 // both tag1 and tag2 on hco2.
-TEST_CASE("hco1_tag1_as_expected") :- mayHaveTag("R.foo.hco1", "tag1").
+TEST_CASE("hco1_tag1_as_expected") :- mayHaveTag("R.foo.hco1", "Claimer", "tag1").
 TEST_CASE("hco1_tag2_as_expected") :-
-  isTag("tag2"), isAccessPath("R.foo.hco1"), !mayHaveTag("R.foo.hco1", "tag2").
-TEST_CASE("hco2_tag1_as_expected") :- mayHaveTag("R.foo.hco2", "tag1").
-TEST_CASE("hco2_tag2_as_expected") :- mayHaveTag("R.foo.hco2", "tag2").
+  isTag("tag2"), isAccessPath("R.foo.hco1"), !mayHaveTag("R.foo.hco1", "Claimer", "tag2").
+TEST_CASE("hco2_tag1_as_expected") :- mayHaveTag("R.foo.hco2", "Claimer", "tag1").
+TEST_CASE("hco2_tag2_as_expected") :- mayHaveTag("R.foo.hco2", "Claimer", "tag2").
 #else
 // If we don't believe it, all tags should flow to all outputs
-TEST_CASE("hco1_tag1_as_expected") :- mayHaveTag("R.foo.hco1", "tag1").
-TEST_CASE("hco1_tag2_as_expected") :- mayHaveTag("R.foo.hco1", "tag2").
-TEST_CASE("hco2_tag1_as_expected") :- mayHaveTag("R.foo.hco2", "tag1").
-TEST_CASE("hco2_tag2_as_expected") :- mayHaveTag("R.foo.hco2", "tag2").
+TEST_CASE("hco1_tag1_as_expected") :- mayHaveTag("R.foo.hco1", "Claimer", "tag1").
+TEST_CASE("hco1_tag2_as_expected") :- mayHaveTag("R.foo.hco1", "Claimer", "tag2").
+TEST_CASE("hco2_tag1_as_expected") :- mayHaveTag("R.foo.hco2", "Claimer", "tag1").
+TEST_CASE("hco2_tag2_as_expected") :- mayHaveTag("R.foo.hco2", "Claimer", "tag2").
 #endif

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
@@ -22,8 +22,8 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-says_hasTag("P1", "R.P1.foo.a", "userSelection").
-says_hasTag("P1", "R.P1.foo.b", "screenContent").
+says_hasTag("P1", "R.P1.foo.a", "P1", "userSelection").
+says_hasTag("P1", "R.P1.foo.b", "P1", "screenContent").
 
 edge("R.P1.foo.a", "R.h.Foo.a").
 edge("R.P1.foo.b", "R.h.Foo.b").
@@ -31,8 +31,8 @@ edge("R.P1.foo.b", "R.h.Foo.b").
 edge("R.h.Foo.a", "R.P2.foo.a").
 edge("R.h.Foo.b", "R.P2.foo.b").
 
-CHECK_TAG_PRESENT("R.P2.foo.a", "userSelection").
-CHECK_TAG_PRESENT("R.P2.foo.b", "screenContent").
+CHECK_TAG_PRESENT("R.P2.foo.a", "P1", "userSelection").
+CHECK_TAG_PRESENT("R.P2.foo.b", "P1", "screenContent").
 
-CHECK_TAG_PRESENT("R.P2.foo", "userSelection").
-CHECK_TAG_PRESENT("R.P2.foo", "screenContent").
+CHECK_TAG_PRESENT("R.P2.foo", "P1", "userSelection").
+CHECK_TAG_PRESENT("R.P2.foo", "P1", "screenContent").

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
@@ -21,9 +21,9 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-says_hasTag("P1", "R.P1.foo", "userSelection").
+says_hasTag("P1", "R.P1.foo", "P1", "userSelection").
 edge("R.P1.foo", "R.h.Foo").
 edge("R.h.Foo", "R.P2.bar").
 
-CHECK_TAG_NOT_PRESENT("R.P2.bar", "screenContent").
-CHECK_TAG_PRESENT("R.P2.bar", "userSelection").
+CHECK_TAG_NOT_PRESENT("R.P2.bar", "P1", "screenContent").
+CHECK_TAG_PRESENT("R.P2.bar", "P1", "userSelection").

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
@@ -25,7 +25,7 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-says_hasTag("P1", "R.P1.foo", "userSelection").
+says_hasTag("P1", "R.P1.foo", "P1", "userSelection").
 edge("R.P1.foo", "R.h1.Foo").
 edge("R.h1.Foo", "R.P2.bar").
 edge("R.P2.bar", "R.P2.foo").
@@ -33,4 +33,4 @@ edge("R.P2.foo", "R.h2.Foo").
 edge("R.h2.Foo", "R.P3.bar").
 
 // This test passes if R.P3.bar has the trusted tag.
-CHECK_TAG_PRESENT("R.P3.bar", "userSelection").
+CHECK_TAG_PRESENT("R.P3.bar", "P1", "userSelection").

--- a/src/ir/predicate.h
+++ b/src/ir/predicate.h
@@ -266,14 +266,17 @@ class TagPresence : public Predicate {
   // in the mayHaveTag relation.
   std::string ToDatalogRuleBody(const AccessPath &access_path) const override {
     constexpr absl::string_view kFormatStr =
-        R"(ownsAccessPath(owner, "%s"), mayHaveTag("%s", owner, "%s"))";
-    return absl::StrFormat(kFormatStr, access_path.ToString(),
-                           access_path.ToString(), tag_);
+        R"(mayHaveTag("%s", owner, "%s"))";
+    return absl::StrFormat(kFormatStr, access_path.ToString(), tag_);
+    // ownsAccessPath(owner, "%s"),
   }
 
   std::optional<std::string> ToGroundingRules(
       const AccessPath &ap) const override {
-    return "isPrincipal(owner)";
+    constexpr absl::string_view kFormatStr =
+        R"(isPrincipal(owner))";
+    // , ownsAccessPath(owner, "%s")
+    return absl::StrFormat(kFormatStr, ap.ToString());
   }
 
   static PredicateKind GetKind() {

--- a/src/ir/predicate.h
+++ b/src/ir/predicate.h
@@ -266,7 +266,7 @@ class TagPresence : public Predicate {
   // in the mayHaveTag relation.
   std::string ToDatalogRuleBody(const AccessPath &access_path) const override {
     constexpr absl::string_view kFormatStr =
-        R"(isPrincipal(owner), !ownsAccessPath(owner, "%s"); mayHaveTag("%s", owner, "%s"))";
+        R"(ownsAccessPath(owner, "%s"), mayHaveTag("%s", owner, "%s"))";
     return absl::StrFormat(kFormatStr, access_path.ToString(),
                            access_path.ToString(), tag_);
   }

--- a/src/ir/predicate.h
+++ b/src/ir/predicate.h
@@ -265,9 +265,10 @@ class TagPresence : public Predicate {
   // The tag presence just turns into a check for the tag on the access_path
   // in the mayHaveTag relation.
   std::string ToDatalogRuleBody(const AccessPath &access_path) const override {
-    // TODO(bgogul): Check needs to be mapped with a tag owner.
-    constexpr absl::string_view kFormatStr = R"(mayHaveTag("%s", _, "%s"))";
-    return absl::StrFormat(kFormatStr, access_path.ToString(), tag_);
+    constexpr absl::string_view kFormatStr =
+        R"(isPrincipal(owner), !ownsAccessPath(owner, "%s"); mayHaveTag("%s", owner, "%s"))";
+    return absl::StrFormat(kFormatStr, access_path.ToString(),
+                           access_path.ToString(), tag_);
   }
 
   std::optional<std::string> ToGroundingRules(

--- a/src/ir/predicate.h
+++ b/src/ir/predicate.h
@@ -17,8 +17,6 @@
 #ifndef SRC_IR_PREDICATES_PREDICATE_H_
 #define SRC_IR_PREDICATES_PREDICATE_H_
 
-#include <optional>
-
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "src/ir/access_path.h"

--- a/src/ir/predicate.h
+++ b/src/ir/predicate.h
@@ -218,7 +218,8 @@ class TagPresence : public Predicate {
   // The tag presence just turns into a check for the tag on the access_path
   // in the mayHaveTag relation.
   std::string ToDatalogRuleBody(const AccessPath &access_path) const override {
-    constexpr absl::string_view kFormatStr = R"(mayHaveTag("%s", "%s"))";
+    // TODO(bgogul): Check needs to be mapped with a tag owner.
+    constexpr absl::string_view kFormatStr = R"(mayHaveTag("%s", _, "%s"))";
     return absl::StrFormat(kFormatStr, access_path.ToString(), tag_);
   }
 

--- a/src/ir/predicate_test.cc
+++ b/src/ir/predicate_test.cc
@@ -40,7 +40,7 @@ class ToDatalogRuleBodyTest :
 
     textproto_ = textproto;
     std::string may_have_subst = absl::StrFormat(
-        R"(isPrincipal(owner), !ownsAccessPath(owner, "%s"); mayHaveTag("%s", owner)",
+        R"(ownsAccessPath(owner, "%s"), mayHaveTag("%s", owner)",
         access_path_.ToString(), access_path_.ToString());
     expected_rule_body_ =
         absl::Substitute(expected_rule_body_format, may_have_subst);

--- a/src/ir/predicate_test.cc
+++ b/src/ir/predicate_test.cc
@@ -39,11 +39,8 @@ class ToDatalogRuleBodyTest :
         std::get<0>(GetParam());
 
     textproto_ = textproto;
-    std::string may_have_subst = absl::StrFormat(
-        R"(ownsAccessPath(owner, "%s"), mayHaveTag("%s", owner)",
-        access_path_.ToString(), access_path_.ToString());
-    expected_rule_body_ =
-        absl::Substitute(expected_rule_body_format, may_have_subst);
+    expected_rule_body_ = absl::Substitute(expected_rule_body_format,
+                                           access_path_.ToString(), "owner");
   }
 
  protected:

--- a/src/ir/predicate_test.cc
+++ b/src/ir/predicate_test.cc
@@ -39,8 +39,11 @@ class ToDatalogRuleBodyTest :
         std::get<0>(GetParam());
 
     textproto_ = textproto;
+    std::string may_have_subst = absl::StrFormat(
+        R"(isPrincipal(owner), !ownsAccessPath(owner, "%s"); mayHaveTag("%s", owner)",
+        access_path_.ToString(), access_path_.ToString());
     expected_rule_body_ =
-        absl::Substitute(expected_rule_body_format, access_path_.ToString());
+        absl::Substitute(expected_rule_body_format, may_have_subst);
   }
 
  protected:

--- a/src/ir/predicate_textproto_to_rule_body_testdata.cc
+++ b/src/ir/predicate_textproto_to_rule_body_testdata.cc
@@ -28,7 +28,8 @@ std::vector<DatalogString> GatherDatalogStrings() {
   for (const auto &[textproto, dl_string] :
       raksha::ir::predicate_textproto_to_rule_body_format) {
     results.push_back(DatalogString(
-        kDlRuleBody, absl::Substitute(dl_string, "example_ap")));
+        kDlRuleBody,
+        absl::Substitute(dl_string, "mayHaveTag(\"example_ap\", _")));
   }
   return results;
 }

--- a/src/ir/predicate_textproto_to_rule_body_testdata.cc
+++ b/src/ir/predicate_textproto_to_rule_body_testdata.cc
@@ -29,7 +29,7 @@ std::vector<DatalogString> GatherDatalogStrings() {
       raksha::ir::predicate_textproto_to_rule_body_format) {
     results.push_back(DatalogString(
         kDlRuleBody,
-        absl::Substitute(dl_string, "mayHaveTag(\"example_ap\", _")));
+        absl::Substitute(dl_string, "example_ap", "_")));
   }
   return results;
 }

--- a/src/ir/predicate_textproto_to_rule_body_testdata.h
+++ b/src/ir/predicate_textproto_to_rule_body_testdata.h
@@ -34,32 +34,32 @@ predicate_textproto_to_rule_body_format[] = {
 
     // ap is tag1
     { R"(label: { semantic_tag: "tag1"})",
-      R"(mayHaveTag("$0", "tag1"))" },
+      R"(mayHaveTag("$0", _, "tag1"))" },
 
     // ap is tag1 and is tag2
     { R"(
 and: {
   conjunct0: { label: { semantic_tag: "tag1"} }
   conjunct1: { label: { semantic_tag: "tag2"} } })",
-  R"(((mayHaveTag("$0", "tag1")), (mayHaveTag("$0", "tag2"))))"},
+  R"(((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2"))))"},
 
   // ap is tag1 or is tag2
   { R"(
 or: {
   disjunct0: { label: { semantic_tag: "tag1"} }
   disjunct1: { label: { semantic_tag: "tag2"} } })",
-  R"(((mayHaveTag("$0", "tag1")); (mayHaveTag("$0", "tag2"))))"},
+  R"(((mayHaveTag("$0", _, "tag1")); (mayHaveTag("$0", _, "tag2"))))"},
 
   // ap is not tag1
   { R"(not: { predicate: { label: { semantic_tag: "tag1"} } })",
-    R"(!(mayHaveTag("$0", "tag1")))"},
+    R"(!(mayHaveTag("$0", _, "tag1")))"},
 
   // ap is tag1 implies is tag2
   { R"(
 implies: {
   antecedent: { label: { semantic_tag: "tag1"} }
   consequent: { label: { semantic_tag: "tag2"} } })",
-     R"(!(mayHaveTag("$0", "tag1")); ((mayHaveTag("$0", "tag1")), (mayHaveTag("$0", "tag2"))))"
+     R"(!(mayHaveTag("$0", _, "tag1")); ((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2"))))"
   },
 
   // ap is tag1 and (is tag2 or is tag3)
@@ -69,7 +69,7 @@ and: {
   conjunct1: {  or: {
     disjunct0: { label: { semantic_tag: "tag2"} }
     disjunct1: { label: { semantic_tag: "tag3"} } } } })",
-  R"(((mayHaveTag("$0", "tag1")), (((mayHaveTag("$0", "tag2")); (mayHaveTag("$0", "tag3"))))))"},
+  R"(((mayHaveTag("$0", _, "tag1")), (((mayHaveTag("$0", _, "tag2")); (mayHaveTag("$0", _, "tag3"))))))"},
 
   // ap (is tag1 or tag2) and is tag3
   { R"(
@@ -79,7 +79,7 @@ and: {
     disjunct1: { label: { semantic_tag: "tag2"} } } }
   conjunct1: { label: { semantic_tag: "tag3"} } }
 )",
-  R"(((((mayHaveTag("$0", "tag1")); (mayHaveTag("$0", "tag2")))), (mayHaveTag("$0", "tag3"))))"},
+  R"(((((mayHaveTag("$0", _, "tag1")); (mayHaveTag("$0", _, "tag2")))), (mayHaveTag("$0", _, "tag3"))))"},
 
   // ap is tag1 or (is tag2 and is tag3)
   { R"(
@@ -88,7 +88,7 @@ or: {
   disjunct1: {  and: {
     conjunct0: { label: { semantic_tag: "tag2"} }
     conjunct1: { label: { semantic_tag: "tag3"} } } } })",
-  R"(((mayHaveTag("$0", "tag1")); (((mayHaveTag("$0", "tag2")), (mayHaveTag("$0", "tag3"))))))"},
+  R"(((mayHaveTag("$0", _, "tag1")); (((mayHaveTag("$0", _, "tag2")), (mayHaveTag("$0", _, "tag3"))))))"},
 
   // ap (is tag1 or tag2) and is tag3.
   { R"(
@@ -98,7 +98,7 @@ or: {
     conjunct1: { label: { semantic_tag: "tag2"} } } }
   disjunct1: { label: { semantic_tag: "tag3"} } }
 )",
-  R"(((((mayHaveTag("$0", "tag1")), (mayHaveTag("$0", "tag2")))); (mayHaveTag("$0", "tag3"))))"},
+  R"(((((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2")))); (mayHaveTag("$0", _, "tag3"))))"},
 
   // ap (is tag1 implies is tag2) implies (is tag3 implies is tag4)
   { R"(
@@ -115,7 +115,7 @@ implies: {
       consequent: { label: { semantic_tag: "tag4"} }
     }
   } })",
-     R"(!(!(mayHaveTag("$0", "tag1")); ((mayHaveTag("$0", "tag1")), (mayHaveTag("$0", "tag2")))); ((!(mayHaveTag("$0", "tag1")); ((mayHaveTag("$0", "tag1")), (mayHaveTag("$0", "tag2")))), (!(mayHaveTag("$0", "tag3")); ((mayHaveTag("$0", "tag3")), (mayHaveTag("$0", "tag4"))))))" }
+     R"(!(!(mayHaveTag("$0", _, "tag1")); ((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2")))); ((!(mayHaveTag("$0", _, "tag1")); ((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2")))), (!(mayHaveTag("$0", _, "tag3")); ((mayHaveTag("$0", _, "tag3")), (mayHaveTag("$0", _, "tag4"))))))" }
 };
 }  // namespace raksha::ir
 

--- a/src/ir/predicate_textproto_to_rule_body_testdata.h
+++ b/src/ir/predicate_textproto_to_rule_body_testdata.h
@@ -34,32 +34,32 @@ predicate_textproto_to_rule_body_format[] = {
 
     // ap is tag1
     { R"(label: { semantic_tag: "tag1"})",
-      R"($0, "tag1"))" },
+      R"(mayHaveTag("$0", $1, "tag1"))" },
 
     // ap is tag1 and is tag2
     { R"(
 and: {
   conjunct0: { label: { semantic_tag: "tag1"} }
   conjunct1: { label: { semantic_tag: "tag2"} } })",
-  R"((($0, "tag1")), ($0, "tag2"))))"},
+  R"(((mayHaveTag("$0", $1, "tag1")), (mayHaveTag("$0", $1, "tag2"))))"},
 
   // ap is tag1 or is tag2
   { R"(
 or: {
   disjunct0: { label: { semantic_tag: "tag1"} }
   disjunct1: { label: { semantic_tag: "tag2"} } })",
-  R"((($0, "tag1")); ($0, "tag2"))))"},
+  R"(((mayHaveTag("$0", $1, "tag1")); (mayHaveTag("$0", $1, "tag2"))))"},
 
   // ap is not tag1
   { R"(not: { predicate: { label: { semantic_tag: "tag1"} } })",
-    R"(isPrincipal(owner), !($0, "tag1")))"},
+    R"(isPrincipal(owner), !(mayHaveTag("$0", $1, "tag1")))"},
 
   // ap is tag1 implies is tag2
   { R"(
 implies: {
   antecedent: { label: { semantic_tag: "tag1"} }
   consequent: { label: { semantic_tag: "tag2"} } })",
-     R"(!($0, "tag1")); (($0, "tag1")), ($0, "tag2"))))"
+     R"(!(mayHaveTag("$0", $1, "tag1")); ((mayHaveTag("$0", $1, "tag1")), (mayHaveTag("$0", $1, "tag2"))))"
   },
 
   // ap is tag1 and (is tag2 or is tag3)
@@ -69,7 +69,7 @@ and: {
   conjunct1: {  or: {
     disjunct0: { label: { semantic_tag: "tag2"} }
     disjunct1: { label: { semantic_tag: "tag3"} } } } })",
-  R"((($0, "tag1")), ((($0, "tag2")); ($0, "tag3"))))))"},
+  R"(((mayHaveTag("$0", $1, "tag1")), (((mayHaveTag("$0", $1, "tag2")); (mayHaveTag("$0", $1, "tag3"))))))"},
 
   // ap (is tag1 or tag2) and is tag3
   { R"(
@@ -79,7 +79,7 @@ and: {
     disjunct1: { label: { semantic_tag: "tag2"} } } }
   conjunct1: { label: { semantic_tag: "tag3"} } }
 )",
-  R"((((($0, "tag1")); ($0, "tag2")))), ($0, "tag3"))))"},
+  R"(((((mayHaveTag("$0", $1, "tag1")); (mayHaveTag("$0", $1, "tag2")))), (mayHaveTag("$0", $1, "tag3"))))"},
 
   // ap is tag1 or (is tag2 and is tag3)
   { R"(
@@ -88,7 +88,7 @@ or: {
   disjunct1: {  and: {
     conjunct0: { label: { semantic_tag: "tag2"} }
     conjunct1: { label: { semantic_tag: "tag3"} } } } })",
-  R"((($0, "tag1")); ((($0, "tag2")), ($0, "tag3"))))))"},
+  R"(((mayHaveTag("$0", $1, "tag1")); (((mayHaveTag("$0", $1, "tag2")), (mayHaveTag("$0", $1, "tag3"))))))"},
 
   // ap (is tag1 or tag2) and is tag3.
   { R"(
@@ -98,7 +98,7 @@ or: {
     conjunct1: { label: { semantic_tag: "tag2"} } } }
   disjunct1: { label: { semantic_tag: "tag3"} } }
 )",
-  R"((((($0, "tag1")), ($0, "tag2")))); ($0, "tag3"))))"},
+  R"(((((mayHaveTag("$0", $1, "tag1")), (mayHaveTag("$0", $1, "tag2")))); (mayHaveTag("$0", $1, "tag3"))))"},
 
   // ap (is tag1 implies is tag2) implies (is tag3 implies is tag4)
   { R"(
@@ -115,7 +115,7 @@ implies: {
       consequent: { label: { semantic_tag: "tag4"} }
     }
   } })",
-     R"(!(!($0, "tag1")); (($0, "tag1")), ($0, "tag2")))); ((!($0, "tag1")); (($0, "tag1")), ($0, "tag2")))), (!($0, "tag3")); (($0, "tag3")), ($0, "tag4"))))))" }
+     R"(!(!(mayHaveTag("$0", $1, "tag1")); ((mayHaveTag("$0", $1, "tag1")), (mayHaveTag("$0", $1, "tag2")))); ((!(mayHaveTag("$0", $1, "tag1")); ((mayHaveTag("$0", $1, "tag1")), (mayHaveTag("$0", $1, "tag2")))), (!(mayHaveTag("$0", $1, "tag3")); ((mayHaveTag("$0", $1, "tag3")), (mayHaveTag("$0", $1, "tag4"))))))" }
 };
 }  // namespace raksha::ir
 

--- a/src/ir/predicate_textproto_to_rule_body_testdata.h
+++ b/src/ir/predicate_textproto_to_rule_body_testdata.h
@@ -34,32 +34,32 @@ predicate_textproto_to_rule_body_format[] = {
 
     // ap is tag1
     { R"(label: { semantic_tag: "tag1"})",
-      R"(mayHaveTag("$0", _, "tag1"))" },
+      R"($0, "tag1"))" },
 
     // ap is tag1 and is tag2
     { R"(
 and: {
   conjunct0: { label: { semantic_tag: "tag1"} }
   conjunct1: { label: { semantic_tag: "tag2"} } })",
-  R"(((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2"))))"},
+  R"((($0, "tag1")), ($0, "tag2"))))"},
 
   // ap is tag1 or is tag2
   { R"(
 or: {
   disjunct0: { label: { semantic_tag: "tag1"} }
   disjunct1: { label: { semantic_tag: "tag2"} } })",
-  R"(((mayHaveTag("$0", _, "tag1")); (mayHaveTag("$0", _, "tag2"))))"},
+  R"((($0, "tag1")); ($0, "tag2"))))"},
 
   // ap is not tag1
   { R"(not: { predicate: { label: { semantic_tag: "tag1"} } })",
-    R"(!(mayHaveTag("$0", _, "tag1")))"},
+    R"(isPrincipal(owner), !($0, "tag1")))"},
 
   // ap is tag1 implies is tag2
   { R"(
 implies: {
   antecedent: { label: { semantic_tag: "tag1"} }
   consequent: { label: { semantic_tag: "tag2"} } })",
-     R"(!(mayHaveTag("$0", _, "tag1")); ((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2"))))"
+     R"(!($0, "tag1")); (($0, "tag1")), ($0, "tag2"))))"
   },
 
   // ap is tag1 and (is tag2 or is tag3)
@@ -69,7 +69,7 @@ and: {
   conjunct1: {  or: {
     disjunct0: { label: { semantic_tag: "tag2"} }
     disjunct1: { label: { semantic_tag: "tag3"} } } } })",
-  R"(((mayHaveTag("$0", _, "tag1")), (((mayHaveTag("$0", _, "tag2")); (mayHaveTag("$0", _, "tag3"))))))"},
+  R"((($0, "tag1")), ((($0, "tag2")); ($0, "tag3"))))))"},
 
   // ap (is tag1 or tag2) and is tag3
   { R"(
@@ -79,7 +79,7 @@ and: {
     disjunct1: { label: { semantic_tag: "tag2"} } } }
   conjunct1: { label: { semantic_tag: "tag3"} } }
 )",
-  R"(((((mayHaveTag("$0", _, "tag1")); (mayHaveTag("$0", _, "tag2")))), (mayHaveTag("$0", _, "tag3"))))"},
+  R"((((($0, "tag1")); ($0, "tag2")))), ($0, "tag3"))))"},
 
   // ap is tag1 or (is tag2 and is tag3)
   { R"(
@@ -88,7 +88,7 @@ or: {
   disjunct1: {  and: {
     conjunct0: { label: { semantic_tag: "tag2"} }
     conjunct1: { label: { semantic_tag: "tag3"} } } } })",
-  R"(((mayHaveTag("$0", _, "tag1")); (((mayHaveTag("$0", _, "tag2")), (mayHaveTag("$0", _, "tag3"))))))"},
+  R"((($0, "tag1")); ((($0, "tag2")), ($0, "tag3"))))))"},
 
   // ap (is tag1 or tag2) and is tag3.
   { R"(
@@ -98,7 +98,7 @@ or: {
     conjunct1: { label: { semantic_tag: "tag2"} } } }
   disjunct1: { label: { semantic_tag: "tag3"} } }
 )",
-  R"(((((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2")))); (mayHaveTag("$0", _, "tag3"))))"},
+  R"((((($0, "tag1")), ($0, "tag2")))); ($0, "tag3"))))"},
 
   // ap (is tag1 implies is tag2) implies (is tag3 implies is tag4)
   { R"(
@@ -115,7 +115,7 @@ implies: {
       consequent: { label: { semantic_tag: "tag4"} }
     }
   } })",
-     R"(!(!(mayHaveTag("$0", _, "tag1")); ((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2")))); ((!(mayHaveTag("$0", _, "tag1")); ((mayHaveTag("$0", _, "tag1")), (mayHaveTag("$0", _, "tag2")))), (!(mayHaveTag("$0", _, "tag3")); ((mayHaveTag("$0", _, "tag3")), (mayHaveTag("$0", _, "tag4"))))))" }
+     R"(!(!($0, "tag1")); (($0, "tag1")), ($0, "tag2")))); ((!($0, "tag1")); (($0, "tag1")), ($0, "tag2")))), (!($0, "tag3")); (($0, "tag3")), ($0, "tag4"))))))" }
 };
 }  // namespace raksha::ir
 

--- a/src/ir/tag_check.h
+++ b/src/ir/tag_check.h
@@ -53,9 +53,13 @@ class TagCheck {
   // passed. If it is not, at least one check failed.
   std::string ToDatalog(DatalogPrintContext &ctxt) const {
     constexpr absl::string_view kCheckHasTagFormat =
-        R"(isCheck("%s"). check("%s") :- %s.)";
+        R"(isCheck("%s", "%s"). check("%s", owner, "%s") :-
+  ownsAccessPath(owner, "%s"), %s.)";
     std::string check_label = ctxt.GetUniqueCheckLabel();
-    return absl::StrFormat(kCheckHasTagFormat, check_label, check_label,
+    return absl::StrFormat(kCheckHasTagFormat,
+                           check_label, access_path_.ToString(),
+                           check_label, access_path_.ToString(),
+                           access_path_.ToString(),
                            predicate_->ToDatalogRuleBody(access_path_));
   }
 

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -68,19 +68,19 @@ static std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
       selectors: { field: "field1" } },
       predicate: { label: { semantic_tag: "tag"} })",
       absl::ParsedFormat<'s', 's'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "%s.field1"); mayHaveTag("%s.field1", owner, "tag").)") },
+          R"(isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "%s.field1"), mayHaveTag("%s.field1", owner, "tag").)") },
     { R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" } },
       predicate: { label: { semantic_tag: "tag2"} })",
       absl::ParsedFormat<'s', 's'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "%s"); mayHaveTag("%s", owner, "tag2").)")
+          R"(isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "%s"), mayHaveTag("%s", owner, "tag2").)")
     },
     { R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" },
       selectors: [{ field: "x" }, { field: "y" }] },
       predicate: { label: { semantic_tag: "user_selection"} })",
       absl::ParsedFormat<'s', 's'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "%s.x.y"); mayHaveTag("%s.x.y", owner, "user_selection").)") }
+          R"(isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "%s.x.y"), mayHaveTag("%s.x.y", owner, "user_selection").)") }
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -14,20 +14,20 @@ namespace raksha::ir {
 class TagCheckToDatalogWithRootTest :
     public testing::TestWithParam<
       std::tuple<
-        std::tuple<std::string, absl::ParsedFormat<'s'>>, AccessPathRoot>>
+        std::tuple<std::string, absl::ParsedFormat<'s', 's'>>, AccessPathRoot>>
       {};
 
 TEST_P(TagCheckToDatalogWithRootTest, TagCheckToDatalogWithRootTest) {
-  const std::tuple<std::string, absl::ParsedFormat<'s'>>
+  const std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
       &textproto_format_string_pair = std::get<0>(GetParam());
   const std::string &check_textproto =
       std::get<0>(textproto_format_string_pair);
-  const absl::ParsedFormat<'s'> expected_todatalog_format_string =
+  const absl::ParsedFormat<'s', 's'> expected_todatalog_format_string =
     std::get<1>(textproto_format_string_pair);
   const AccessPathRoot &root = std::get<1>(GetParam());
   std::string root_string = root.ToString();
   const std::string &expected_todatalog = absl::StrFormat(
-      expected_todatalog_format_string, root_string);
+      expected_todatalog_format_string, root_string, root_string);
   arcs::CheckProto check_proto;
   google::protobuf::TextFormat::ParseFromString(check_textproto, &check_proto);
   PredicateArena predicate_arena;
@@ -61,26 +61,26 @@ static AccessPathRoot instantiated_roots[] = {
 // expected ToDatalog output when the root string is substituted for the %s.
 // This allows us to test the result of combining each of the
 // TagChecks derived from the textprotos with each of the root strings.
-static std::tuple<std::string, absl::ParsedFormat<'s'>>
+static std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
     textproto_to_expected_format_string[] = {
     { R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" }
       selectors: { field: "field1" } },
       predicate: { label: { semantic_tag: "tag"} })",
-      absl::ParsedFormat<'s'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s.field1", _, "tag").)") },
+      absl::ParsedFormat<'s', 's'>(
+          R"(isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "%s.field1"); mayHaveTag("%s.field1", owner, "tag").)") },
     { R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" } },
       predicate: { label: { semantic_tag: "tag2"} })",
-      absl::ParsedFormat<'s'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s", _, "tag2").)")
+      absl::ParsedFormat<'s', 's'>(
+          R"(isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "%s"); mayHaveTag("%s", owner, "tag2").)")
     },
     { R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" },
       selectors: [{ field: "x" }, { field: "y" }] },
       predicate: { label: { semantic_tag: "user_selection"} })",
-      absl::ParsedFormat<'s'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s.x.y", _, "user_selection").)") }
+      absl::ParsedFormat<'s', 's'>(
+          R"(isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "%s.x.y"); mayHaveTag("%s.x.y", owner, "user_selection").)") }
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -68,19 +68,19 @@ static std::tuple<std::string, absl::ParsedFormat<'s'>>
       selectors: { field: "field1" } },
       predicate: { label: { semantic_tag: "tag"} })",
       absl::ParsedFormat<'s'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s.field1", "tag").)") },
+          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s.field1", _, "tag").)") },
     { R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" } },
       predicate: { label: { semantic_tag: "tag2"} })",
       absl::ParsedFormat<'s'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s", "tag2").)")
+          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s", _, "tag2").)")
     },
     { R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" },
       selectors: [{ field: "x" }, { field: "y" }] },
       predicate: { label: { semantic_tag: "user_selection"} })",
       absl::ParsedFormat<'s'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s.x.y", "user_selection").)") }
+          R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("%s.x.y", _, "user_selection").)") }
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -4,6 +4,7 @@
 #include <google/protobuf/text_format.h>
 
 #include "absl/strings/str_format.h"
+#include "absl/strings/substitute.h"
 #include "src/common/testing/gtest.h"
 #include "src/ir/access_path_selectors.h"
 #include "src/ir/proto/predicate.h"
@@ -14,20 +15,20 @@ namespace raksha::ir {
 class TagCheckToDatalogWithRootTest :
     public testing::TestWithParam<
       std::tuple<
-        std::tuple<std::string, absl::ParsedFormat<'s', 's'>>, AccessPathRoot>>
+          std::tuple<std::string, std::string>, AccessPathRoot>>
       {};
 
 TEST_P(TagCheckToDatalogWithRootTest, TagCheckToDatalogWithRootTest) {
-  const std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
+  const std::tuple<std::string, std::string>
       &textproto_format_string_pair = std::get<0>(GetParam());
   const std::string &check_textproto =
       std::get<0>(textproto_format_string_pair);
-  const absl::ParsedFormat<'s', 's'> expected_todatalog_format_string =
+  const absl::string_view expected_todatalog_format_string =
     std::get<1>(textproto_format_string_pair);
   const AccessPathRoot &root = std::get<1>(GetParam());
   std::string root_string = root.ToString();
-  const std::string &expected_todatalog = absl::StrFormat(
-      expected_todatalog_format_string, root_string, root_string);
+  const std::string &expected_todatalog = absl::Substitute(
+      expected_todatalog_format_string, "check_num_0", root_string);
   arcs::CheckProto check_proto;
   google::protobuf::TextFormat::ParseFromString(check_textproto, &check_proto);
   PredicateArena predicate_arena;
@@ -61,27 +62,25 @@ static AccessPathRoot instantiated_roots[] = {
 // expected ToDatalog output when the root string is substituted for the %s.
 // This allows us to test the result of combining each of the
 // TagChecks derived from the textprotos with each of the root strings.
-static std::tuple<std::string, absl::ParsedFormat<'s', 's'>>
+static std::tuple<std::string, std::string>
     textproto_to_expected_format_string[] = {
-    { R"(access_path: {
+        {R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" }
       selectors: { field: "field1" } },
       predicate: { label: { semantic_tag: "tag"} })",
-      absl::ParsedFormat<'s', 's'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "%s.field1"), mayHaveTag("%s.field1", owner, "tag").)") },
-    { R"(access_path: {
+         R"(isCheck("$0", "$1.field1"). check("$0", owner, "$1.field1") :-
+  ownsAccessPath(owner, "$1.field1"), mayHaveTag("$1.field1", owner, "tag").)"},
+        {R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" } },
       predicate: { label: { semantic_tag: "tag2"} })",
-      absl::ParsedFormat<'s', 's'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "%s"), mayHaveTag("%s", owner, "tag2").)")
-    },
-    { R"(access_path: {
+         R"(isCheck("$0", "$1"). check("$0", owner, "$1") :-
+  ownsAccessPath(owner, "$1"), mayHaveTag("$1", owner, "tag2").)"},
+        {R"(access_path: {
       handle: { particle_spec: "ps", handle_connection: "hc" },
       selectors: [{ field: "x" }, { field: "y" }] },
       predicate: { label: { semantic_tag: "user_selection"} })",
-      absl::ParsedFormat<'s', 's'>(
-          R"(isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "%s.x.y"), mayHaveTag("%s.x.y", owner, "user_selection").)") }
-};
+         R"(isCheck("$0", "$1.x.y"). check("$0", owner, "$1.x.y") :-
+  ownsAccessPath(owner, "$1.x.y"), mayHaveTag("$1.x.y", owner, "user_selection").)"}};
 
 INSTANTIATE_TEST_SUITE_P(
     TagCheckToDatalogWithRootTest, TagCheckToDatalogWithRootTest,

--- a/src/ir/tag_claim.h
+++ b/src/ir/tag_claim.h
@@ -65,12 +65,12 @@ class TagClaim {
   // Produce a string containing a datalog fact for this TagClaim.
   std::string ToDatalog(DatalogPrintContext &) const {
     constexpr absl::string_view kClaimTagFormat =
-        R"(%s("%s", "%s", "%s").)";
+        R"(%s("%s", "%s", owner, "%s") :- ownsAccessPath(owner, "%s").)";
     absl::string_view relation_name =
         (claim_tag_is_present_) ? "says_hasTag" : "says_removeTag";
     return absl::StrFormat(
         kClaimTagFormat, relation_name, claiming_particle_name_,
-        access_path_.ToString(), tag_);
+        access_path_.ToString(), tag_, access_path_.ToString());
   }
 
   bool operator==(const TagClaim &other) const {

--- a/src/ir/tag_claim_test.cc
+++ b/src/ir/tag_claim_test.cc
@@ -30,17 +30,17 @@ class TagClaimToDatalogWithRootTest :
     public testing::TestWithParam<
       std::tuple<
         std::string,
-        std::tuple<std::string, std::vector<absl::ParsedFormat<'s', 's'>>>,
+        std::tuple<std::string, std::vector<absl::ParsedFormat<'s', 's', 's'>>>,
         AccessPathRoot>>
       {};
 
 TEST_P(TagClaimToDatalogWithRootTest, TagClaimToDatalogWithRootTest) {
   const std::string particle_spec_name = std::get<0>(GetParam());
-  const std::tuple<std::string, std::vector<absl::ParsedFormat<'s', 's'>>>
+  const std::tuple<std::string, std::vector<absl::ParsedFormat<'s', 's', 's'>>>
       &textproto_format_string_pair = std::get<1>(GetParam());
   const std::string &assume_textproto =
       std::get<0>(textproto_format_string_pair);
-  const std::vector<absl::ParsedFormat<'s', 's'>>
+  const std::vector<absl::ParsedFormat<'s', 's', 's'>>
       expected_todatalog_format_string_vec =
           std::get<1>(textproto_format_string_pair);
   const AccessPathRoot &root = std::get<2>(GetParam());
@@ -48,7 +48,8 @@ TEST_P(TagClaimToDatalogWithRootTest, TagClaimToDatalogWithRootTest) {
   std::vector<std::string> expected_todatalog_vec;
   for (auto &format_str : expected_todatalog_format_string_vec) {
     expected_todatalog_vec.push_back(
-        absl::StrFormat(format_str, particle_spec_name, root.ToString()));
+        absl::StrFormat(format_str, particle_spec_name,
+                        root.ToString(), root.ToString()));
   }
   arcs::ClaimProto_Assume assume_proto;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
@@ -97,35 +98,35 @@ static AccessPathRoot instantiated_roots[] = {
 // expected ToDatalog output when the root string is substituted for the %s.
 // This allows us to test the result of combining each of the
 // TagClaims derived from the textprotos with each of the root strings.
-static std::tuple<std::string, std::vector<absl::ParsedFormat<'s', 's'>>>
+static std::tuple<std::string, std::vector<absl::ParsedFormat<'s', 's', 's'>>>
     textproto_to_expected_format_string[] = {
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
   selectors: { field: "field1" } },
 predicate: { label: { semantic_tag: "tag"} })",
-      { absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.field1", "tag").)") } },
+      { absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.field1", owner, "tag") :- ownsAccessPath(owner, "%s.field1").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" } },
 predicate: { label: { semantic_tag: "tag2"} })",
-      { absl::ParsedFormat<'s', 's'>(R"(says_hasTag("%s", "%s", "tag2").)") } },
+      { absl::ParsedFormat<'s', 's', 's'>(R"(says_hasTag("%s", "%s", owner, "tag2") :- ownsAccessPath(owner, "%s").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" },
   selectors: [{ field: "x" }, { field: "y" }] },
 predicate: { label: { semantic_tag: "user_selection"} })",
-      { absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.x.y", "user_selection").)") } },
+      { absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.x.y", owner, "user_selection") :- ownsAccessPath(owner, "%s.x.y").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" },
   selectors: [{ field: "x" }, { field: "y" }] },
 predicate: {
 not: { predicate: { label: { semantic_tag: "user_selection"} } } })",
-      { absl::ParsedFormat<'s', 's'>(
-          R"(says_removeTag("%s", "%s.x.y", "user_selection").)") } },
+      { absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_removeTag("%s", "%s.x.y", owner, "user_selection") :- ownsAccessPath(owner, "%s.x.y").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -133,10 +134,10 @@ access_path: {
 predicate: { and: {
   conjunct0: { label: { semantic_tag: "tag"} }
   conjunct1: { label: { semantic_tag: "tag2"} } } })",
-      { absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.field1", "tag").)"),
-        absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.field1", "tag2").)") } },
+      { absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.field1", owner, "tag") :- ownsAccessPath(owner, "%s.field1").)"),
+        absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.field1", owner, "tag2") :- ownsAccessPath(owner, "%s.field1").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -144,20 +145,20 @@ access_path: {
 predicate: { and: {
   conjunct0: { not: { predicate: { label: { semantic_tag: "tag"} } } }
   conjunct1: { label: { semantic_tag: "tag2"} } } })",
-      { absl::ParsedFormat<'s', 's'>(
-          R"(says_removeTag("%s", "%s.field1", "tag").)"),
-        absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.field1", "tag2").)") } },
+      { absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_removeTag("%s", "%s.field1", owner, "tag") :- ownsAccessPath(owner, "%s.field1").)"),
+        absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.field1", owner, "tag2") :- ownsAccessPath(owner, "%s.field1").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" } },
 predicate: { and: {
   conjunct0: { label: { semantic_tag: "tag"} }
   conjunct1: { not: { predicate: { label: { semantic_tag: "tag2"} } } } } })",
-      { absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s", "tag").)"),
-        absl::ParsedFormat<'s', 's'>(
-          R"(says_removeTag("%s", "%s", "tag2").)") } },
+      { absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s", owner, "tag") :- ownsAccessPath(owner, "%s").)"),
+        absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_removeTag("%s", "%s", owner, "tag2") :- ownsAccessPath(owner, "%s").)") } },
      { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -167,12 +168,12 @@ predicate: { and: {
     conjunct0: { label: { semantic_tag: "tag"} }
     conjunct1: { not: { predicate: { label: { semantic_tag: "tag2"} } } } } }
   conjunct1: { label: { semantic_tag: "tag3"} } } })",
-      { absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.field1", "tag").)"),
-        absl::ParsedFormat<'s', 's'>(
-          R"(says_removeTag("%s", "%s.field1", "tag2").)"),
-        absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.field1", "tag3").)") } },
+      { absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.field1", owner, "tag") :- ownsAccessPath(owner, "%s.field1").)"),
+        absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_removeTag("%s", "%s.field1", owner, "tag2") :- ownsAccessPath(owner, "%s.field1").)"),
+        absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.field1", owner, "tag3") :- ownsAccessPath(owner, "%s.field1").)") } },
      { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -184,14 +185,14 @@ predicate: { and: {
   conjunct1: { and: {
     conjunct0: { not: { predicate: { label: { semantic_tag: "tag3"} } } }
     conjunct1: { label: { semantic_tag: "tag4" } } } } } })",
-      { absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.field1", "tag").)"),
-        absl::ParsedFormat<'s', 's'>(
-          R"(says_removeTag("%s", "%s.field1", "tag2").)"),
-        absl::ParsedFormat<'s', 's'>(
-          R"(says_removeTag("%s", "%s.field1", "tag3").)"),
-        absl::ParsedFormat<'s', 's'>(
-          R"(says_hasTag("%s", "%s.field1", "tag4").)")
+      { absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.field1", owner, "tag") :- ownsAccessPath(owner, "%s.field1").)"),
+        absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_removeTag("%s", "%s.field1", owner, "tag2") :- ownsAccessPath(owner, "%s.field1").)"),
+        absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_removeTag("%s", "%s.field1", owner, "tag3") :- ownsAccessPath(owner, "%s.field1").)"),
+        absl::ParsedFormat<'s', 's', 's'>(
+          R"(says_hasTag("%s", "%s.field1", owner, "tag4") :- ownsAccessPath(owner, "%s.field1").)")
           } },
 };
 

--- a/src/xform_to_datalog/authorization_logic_datalog_facts.cc
+++ b/src/xform_to_datalog/authorization_logic_datalog_facts.cc
@@ -40,6 +40,7 @@ AuthorizationLogicDatalogFacts::create(
   // prevent typos changing the interpretation of the list.
   constexpr absl::string_view kRelationsToNotDeclare[] = {
       "says_ownsTag",
+      "says_ownsAccessPath",
       "says_hasTag",
       "says_canSay_hasTag",
       "says_removeTag",

--- a/src/xform_to_datalog/datalog_facts.h
+++ b/src/xform_to_datalog/datalog_facts.h
@@ -69,14 +69,15 @@ class DatalogFacts {
 
 .output disallowedUsage(IO=stdout)
 
-.decl isCheck(check_index: symbol)
-.decl check(check_index: symbol)
+.decl isCheck(check_index: symbol, path: AccessPath)
+.decl check(check_index: symbol, owner: Principal, path: AccessPath)
 
-allTests(check_index) :- isCheck(check_index).
-testFails(check_index) :-
-  isCheck(check_index), !check(check_index).
+allTests(check_index) :- isCheck(check_index, _).
+testFails(cat(check_index, "-", owner, "-", path)) :-
+  isCheck(check_index, path), ownsAccessPath(owner, path),
+  !check(check_index, owner, path).
 
-testFails("may_will") :- disallowedUsage(_, _, _). 
+testFails("may_will") :- disallowedUsage(_, _, _).
 
 .decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
 .decl says_will(speaker: Principal, usage: Usage, path: AccessPath)

--- a/src/xform_to_datalog/datalog_facts.h
+++ b/src/xform_to_datalog/datalog_facts.h
@@ -66,7 +66,6 @@ class DatalogFacts {
 .output allTests(IO=stdout)
 .decl duplicateTestCaseNames(testAspectName: symbol)
 .output duplicateTestCaseNames(IO=stdout)
-
 .output disallowedUsage(IO=stdout)
 
 .decl isCheck(check_index: symbol, path: AccessPath)
@@ -77,7 +76,7 @@ testFails(cat(check_index, "-", owner, "-", path)) :-
   isCheck(check_index, path), ownsAccessPath(owner, path),
   !check(check_index, owner, path).
 
-testFails("may_will") :- disallowedUsage(_, _, _).
+testFails("may_will") :- disallowedUsage(_, _, _, _).
 
 .decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
 .decl says_will(speaker: Principal, usage: Usage, path: AccessPath)

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -133,7 +133,7 @@ saysWill(w, x, y) :- says_will(w, x, y).
 // Manifest
 
 // Claims:
-says_hasTag("particle", "recipe.particle.out", "tag").
+says_hasTag("particle", "recipe.particle.out", owner, "tag") :- ownsAccessPath(owner, "recipe.particle.out").
 
 // Checks:
 

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -58,14 +58,16 @@ INSTANTIATE_TEST_SUITE_P(
 
 .output disallowedUsage(IO=stdout)
 
-.decl isCheck(check_index: symbol)
-.decl check(check_index: symbol)
+.decl isCheck(check_index: symbol, path: AccessPath)
+.decl check(check_index: symbol, owner: Principal, path: AccessPath)
 
-allTests(check_index) :- isCheck(check_index).
-testFails(check_index) :-
-  isCheck(check_index), !check(check_index).
 
-testFails("may_will") :- disallowedUsage(_, _, _). 
+allTests(check_index) :- isCheck(check_index, _).
+testFails(cat(check_index, "-", owner, "-", path)) :-
+  isCheck(check_index, path), ownsAccessPath(owner, path),
+  !check(check_index, owner, path).
+
+testFails("may_will") :- disallowedUsage(_, _, _).
 
 .decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
 .decl says_will(speaker: Principal, usage: Usage, path: AccessPath)
@@ -116,14 +118,15 @@ grounded_dummy("dummy_var").
 
 .output disallowedUsage(IO=stdout)
 
-.decl isCheck(check_index: symbol)
-.decl check(check_index: symbol)
+.decl isCheck(check_index: symbol, path: AccessPath)
+.decl check(check_index: symbol, owner: Principal, path: AccessPath)
 
-allTests(check_index) :- isCheck(check_index).
-testFails(check_index) :-
-  isCheck(check_index), !check(check_index).
+allTests(check_index) :- isCheck(check_index, _).
+testFails(cat(check_index, "-", owner, "-", path)) :-
+  isCheck(check_index, path), ownsAccessPath(owner, path),
+  !check(check_index, owner, path).
 
-testFails("may_will") :- disallowedUsage(_, _, _). 
+testFails("may_will") :- disallowedUsage(_, _, _).
 
 .decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
 .decl says_will(speaker: Principal, usage: Usage, path: AccessPath)

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -55,19 +55,17 @@ INSTANTIATE_TEST_SUITE_P(
 .output allTests(IO=stdout)
 .decl duplicateTestCaseNames(testAspectName: symbol)
 .output duplicateTestCaseNames(IO=stdout)
-
 .output disallowedUsage(IO=stdout)
 
 .decl isCheck(check_index: symbol, path: AccessPath)
 .decl check(check_index: symbol, owner: Principal, path: AccessPath)
-
 
 allTests(check_index) :- isCheck(check_index, _).
 testFails(cat(check_index, "-", owner, "-", path)) :-
   isCheck(check_index, path), ownsAccessPath(owner, path),
   !check(check_index, owner, path).
 
-testFails("may_will") :- disallowedUsage(_, _, _).
+testFails("may_will") :- disallowedUsage(_, _, _, _).
 
 .decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
 .decl says_will(speaker: Principal, usage: Usage, path: AccessPath)
@@ -115,7 +113,6 @@ grounded_dummy("dummy_var").
 .output allTests(IO=stdout)
 .decl duplicateTestCaseNames(testAspectName: symbol)
 .output duplicateTestCaseNames(IO=stdout)
-
 .output disallowedUsage(IO=stdout)
 
 .decl isCheck(check_index: symbol, path: AccessPath)
@@ -126,7 +123,7 @@ testFails(cat(check_index, "-", owner, "-", path)) :-
   isCheck(check_index, path), ownsAccessPath(owner, path),
   !check(check_index, owner, path).
 
-testFails("may_will") :- disallowedUsage(_, _, _).
+testFails("may_will") :- disallowedUsage(_, _, _, _).
 
 .decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
 .decl says_will(speaker: Principal, usage: Usage, path: AccessPath)

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -82,10 +82,10 @@ static std::tuple<ManifestDatalogFacts, std::string>
            ir::Edge(kHandleConnectionOutAccessPath, kHandleH2AccessPath)}),
       R"(
 // Claims:
-says_hasTag("particle", "recipe.particle.out", "tag").
+says_hasTag("particle", "recipe.particle.out", owner, "tag") :- ownsAccessPath(owner, "recipe.particle.out").
 
 // Checks:
-isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("recipe.particle.in", "tag2").
+isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("recipe.particle.in", _, "tag2").
 
 // Edges:
 edge("recipe.h1", "recipe.particle.in").
@@ -281,12 +281,12 @@ class ParseBigManifestTest : public testing::Test {
 };
 
 static const std::string kExpectedClaimStrings[] = {
-    R"(says_hasTag("PS1", "NamedR.PS1#0.out_handle.field1", "tag1").)",
-    R"(says_hasTag("PS1", "NamedR.PS1#1.out_handle.field1", "tag1").)",
-    R"(says_hasTag("PS2", "NamedR.PS2#2.out_handle.field1", "tag3").)",
-    R"(says_hasTag("PS1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "tag1").)",
-    R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "tag3").)",
-    R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "tag3").)",
+    R"(says_hasTag("PS1", "NamedR.PS1#0.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "NamedR.PS1#0.out_handle.field1").)",
+    R"(says_hasTag("PS1", "NamedR.PS1#1.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "NamedR.PS1#1.out_handle.field1").)",
+    R"(says_hasTag("PS2", "NamedR.PS2#2.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "NamedR.PS2#2.out_handle.field1").)",
+    R"(says_hasTag("PS1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1").)",
+    R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1").)",
+    R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
@@ -302,12 +302,12 @@ TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
 }
 
 static std::string kExpectedCheckStrings[] = {
-    R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("NamedR.PS1#0.in_handle.field1", "tag2").)",
-    R"(isCheck("check_num_1"). check("check_num_1") :- mayHaveTag("NamedR.PS1#1.in_handle.field1", "tag2").)",
-    R"(isCheck("check_num_2"). check("check_num_2") :- mayHaveTag("NamedR.PS2#2.in_handle.field1", "tag4").)",
-    R"(isCheck("check_num_3"). check("check_num_3") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "tag2").)",
-    R"(isCheck("check_num_4"). check("check_num_4") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "tag4").)",
-    R"(isCheck("check_num_5"). check("check_num_5") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "tag4").)",
+    R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("NamedR.PS1#0.in_handle.field1", _, "tag2").)",
+    R"(isCheck("check_num_1"). check("check_num_1") :- mayHaveTag("NamedR.PS1#1.in_handle.field1", _, "tag2").)",
+    R"(isCheck("check_num_2"). check("check_num_2") :- mayHaveTag("NamedR.PS2#2.in_handle.field1", _, "tag4").)",
+    R"(isCheck("check_num_3"). check("check_num_3") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", _, "tag2").)",
+    R"(isCheck("check_num_4"). check("check_num_4") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", _, "tag4").)",
+    R"(isCheck("check_num_5"). check("check_num_5") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", _, "tag4").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -85,7 +85,7 @@ static std::tuple<ManifestDatalogFacts, std::string>
 says_hasTag("particle", "recipe.particle.out", owner, "tag") :- ownsAccessPath(owner, "recipe.particle.out").
 
 // Checks:
-isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "recipe.particle.in"); mayHaveTag("recipe.particle.in", owner, "tag2").
+isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "recipe.particle.in"), mayHaveTag("recipe.particle.in", owner, "tag2").
 
 // Edges:
 edge("recipe.h1", "recipe.particle.in").
@@ -302,12 +302,12 @@ TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
 }
 
 static std::string kExpectedCheckStrings[] = {
-    R"(isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "NamedR.PS1#0.in_handle.field1"); mayHaveTag("NamedR.PS1#0.in_handle.field1", owner, "tag2").)",
-    R"(isCheck("check_num_1"). check("check_num_1") :- isPrincipal(owner), !ownsAccessPath(owner, "NamedR.PS1#1.in_handle.field1"); mayHaveTag("NamedR.PS1#1.in_handle.field1", owner, "tag2").)",
-    R"(isCheck("check_num_2"). check("check_num_2") :- isPrincipal(owner), !ownsAccessPath(owner, "NamedR.PS2#2.in_handle.field1"); mayHaveTag("NamedR.PS2#2.in_handle.field1", owner, "tag4").)",
-    R"(isCheck("check_num_3"). check("check_num_3") :- isPrincipal(owner), !ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1"); mayHaveTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", owner, "tag2").)",
-    R"(isCheck("check_num_4"). check("check_num_4") :- isPrincipal(owner), !ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1"); mayHaveTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", owner, "tag4").)",
-    R"(isCheck("check_num_5"). check("check_num_5") :- isPrincipal(owner), !ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1"); mayHaveTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", owner, "tag4").)",
+    R"(isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "NamedR.PS1#0.in_handle.field1"), mayHaveTag("NamedR.PS1#0.in_handle.field1", owner, "tag2").)",
+    R"(isCheck("check_num_1"). check("check_num_1") :- ownsAccessPath(owner, "NamedR.PS1#1.in_handle.field1"), mayHaveTag("NamedR.PS1#1.in_handle.field1", owner, "tag2").)",
+    R"(isCheck("check_num_2"). check("check_num_2") :- ownsAccessPath(owner, "NamedR.PS2#2.in_handle.field1"), mayHaveTag("NamedR.PS2#2.in_handle.field1", owner, "tag4").)",
+    R"(isCheck("check_num_3"). check("check_num_3") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1"), mayHaveTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", owner, "tag2").)",
+    R"(isCheck("check_num_4"). check("check_num_4") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1"), mayHaveTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", owner, "tag4").)",
+    R"(isCheck("check_num_5"). check("check_num_5") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1"), mayHaveTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", owner, "tag4").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -85,7 +85,7 @@ static std::tuple<ManifestDatalogFacts, std::string>
 says_hasTag("particle", "recipe.particle.out", owner, "tag") :- ownsAccessPath(owner, "recipe.particle.out").
 
 // Checks:
-isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("recipe.particle.in", _, "tag2").
+isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "recipe.particle.in"); mayHaveTag("recipe.particle.in", owner, "tag2").
 
 // Edges:
 edge("recipe.h1", "recipe.particle.in").
@@ -302,12 +302,12 @@ TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
 }
 
 static std::string kExpectedCheckStrings[] = {
-    R"(isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("NamedR.PS1#0.in_handle.field1", _, "tag2").)",
-    R"(isCheck("check_num_1"). check("check_num_1") :- mayHaveTag("NamedR.PS1#1.in_handle.field1", _, "tag2").)",
-    R"(isCheck("check_num_2"). check("check_num_2") :- mayHaveTag("NamedR.PS2#2.in_handle.field1", _, "tag4").)",
-    R"(isCheck("check_num_3"). check("check_num_3") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", _, "tag2").)",
-    R"(isCheck("check_num_4"). check("check_num_4") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", _, "tag4").)",
-    R"(isCheck("check_num_5"). check("check_num_5") :- mayHaveTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", _, "tag4").)",
+    R"(isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "NamedR.PS1#0.in_handle.field1"); mayHaveTag("NamedR.PS1#0.in_handle.field1", owner, "tag2").)",
+    R"(isCheck("check_num_1"). check("check_num_1") :- isPrincipal(owner), !ownsAccessPath(owner, "NamedR.PS1#1.in_handle.field1"); mayHaveTag("NamedR.PS1#1.in_handle.field1", owner, "tag2").)",
+    R"(isCheck("check_num_2"). check("check_num_2") :- isPrincipal(owner), !ownsAccessPath(owner, "NamedR.PS2#2.in_handle.field1"); mayHaveTag("NamedR.PS2#2.in_handle.field1", owner, "tag4").)",
+    R"(isCheck("check_num_3"). check("check_num_3") :- isPrincipal(owner), !ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1"); mayHaveTag("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", owner, "tag2").)",
+    R"(isCheck("check_num_4"). check("check_num_4") :- isPrincipal(owner), !ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1"); mayHaveTag("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", owner, "tag4").)",
+    R"(isCheck("check_num_5"). check("check_num_5") :- isPrincipal(owner), !ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1"); mayHaveTag("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", owner, "tag4").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -30,10 +30,10 @@ saysWill(w, x, y) :- says_will(w, x, y).
 // Manifest
 
 // Claims:
-says_hasTag("P1", "R.P1#0.foo", "userSelection").
+says_hasTag("P1", "R.P1#0.foo", owner, "userSelection") :- ownsAccessPath(owner, "R.P1#0.foo").
 
 // Checks:
-isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("R.P3#2.bar", "userSelection").
+isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("R.P3#2.bar", _, "userSelection").
 
 // Edges:
 edge("R.P1#0.foo", "R.handle0").

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -33,7 +33,7 @@ saysWill(w, x, y) :- says_will(w, x, y).
 says_hasTag("P1", "R.P1#0.foo", owner, "userSelection") :- ownsAccessPath(owner, "R.P1#0.foo").
 
 // Checks:
-isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("R.P3#2.bar", _, "userSelection").
+isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "R.P3#2.bar"); mayHaveTag("R.P3#2.bar", owner, "userSelection").
 
 // Edges:
 edge("R.P1#0.foo", "R.handle0").

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -13,12 +13,13 @@
 
 .output disallowedUsage(IO=stdout)
 
-.decl isCheck(check_index: symbol)
-.decl check(check_index: symbol)
+.decl isCheck(check_index: symbol, path: AccessPath)
+.decl check(check_index: symbol, owner: Principal, path: AccessPath)
 
-allTests(check_index) :- isCheck(check_index).
-testFails(check_index) :-
-  isCheck(check_index), !check(check_index).
+allTests(check_index) :- isCheck(check_index, _).
+testFails(cat(check_index, "-", owner, "-", path)) :-
+  isCheck(check_index, path), ownsAccessPath(owner, path),
+  !check(check_index, owner, path).
 
 testFails("may_will") :- disallowedUsage(_, _, _). 
 
@@ -33,7 +34,8 @@ saysWill(w, x, y) :- says_will(w, x, y).
 says_hasTag("P1", "R.P1#0.foo", owner, "userSelection") :- ownsAccessPath(owner, "R.P1#0.foo").
 
 // Checks:
-isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "R.P3#2.bar"), mayHaveTag("R.P3#2.bar", owner, "userSelection").
+isCheck("check_num_0", "R.P3#2.bar"). check("check_num_0", owner, "R.P3#2.bar") :-
+  ownsAccessPath(owner, "R.P3#2.bar"), mayHaveTag("R.P3#2.bar", owner, "userSelection").
 
 // Edges:
 edge("R.P1#0.foo", "R.handle0").

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -33,7 +33,7 @@ saysWill(w, x, y) :- says_will(w, x, y).
 says_hasTag("P1", "R.P1#0.foo", owner, "userSelection") :- ownsAccessPath(owner, "R.P1#0.foo").
 
 // Checks:
-isCheck("check_num_0"). check("check_num_0") :- isPrincipal(owner), !ownsAccessPath(owner, "R.P3#2.bar"); mayHaveTag("R.P3#2.bar", owner, "userSelection").
+isCheck("check_num_0"). check("check_num_0") :- ownsAccessPath(owner, "R.P3#2.bar"), mayHaveTag("R.P3#2.bar", owner, "userSelection").
 
 // Edges:
 edge("R.P1#0.foo", "R.handle0").

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -10,7 +10,6 @@
 .output allTests(IO=stdout)
 .decl duplicateTestCaseNames(testAspectName: symbol)
 .output duplicateTestCaseNames(IO=stdout)
-
 .output disallowedUsage(IO=stdout)
 
 .decl isCheck(check_index: symbol, path: AccessPath)
@@ -21,7 +20,7 @@ testFails(cat(check_index, "-", owner, "-", path)) :-
   isCheck(check_index, path), ownsAccessPath(owner, path),
   !check(check_index, owner, path).
 
-testFails("may_will") :- disallowedUsage(_, _, _). 
+testFails("may_will") :- disallowedUsage(_, _, _, _).
 
 .decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
 .decl says_will(speaker: Principal, usage: Usage, path: AccessPath)


### PR DESCRIPTION
Various discussions among @bgogul, @aferr and @markww led to the realization that `ownsTag` does not capture enough contextual information for making authoritative decisions at sensitive operations (like `removeTag` and `claimNotEdge`).  This PR distills the various ideas that were discussed into a working prototype. Specifically, this introduces three key concepts:
  - Attach principal to tags instead of claiming it thorough `ownsTag`. 
  - Resolved edge has a principal. 
  - Add the concept of ownership for access paths.

Note: Introducing these concepts has eliminated the need for `edgeToMidpointAccessPath` and explicit rules for `saysCanSayHasTag` in the authorization_logic.dl. Here are the key files of this PR to focus on:

- [taint.dl](https://github.com/google-research/raksha/pull/215/files#diff-c9867611ec9983acdad10ad10d9544af6c55b10b57bdaecdca62ace1e24db56b)
- [authorization_logic.dl](https://github.com/google-research/raksha/pull/215/files#diff-c9668b16b74dbe509b66025a403836b9bce0c6677e2195093b69bedfb00bd0b6)
- [ok_claim_propagates_downgrades_granted.authlogic](https://github.com/google-research/raksha/pull/215/files#diff-a0d4a360467ff8afcc8855d32a309a47a68abb0a326ab2149a6a99ca565d3ef5) for an example use case.

Note that all tests don't pass yet.

 ### Tags have principals.

Instead of having tag to be just a string like `userSelection`, we also associate a principal with the tag and propagate it through the analysis. That is, instead of  `hasTag("a.b.c", "tag")` we will have `hasTag("a.b.c",  "principal", "tag")`. The `"principal"` is propagated throughout the analysis.  (The tag could be implemented as an ADT also if needed.)

This allows us to make authoritative decisions based on the principal for  sensitive operations. e.g.,
```
mayHaveTag(tgt, owner, tag) :-
    resolvedEdge(src, tgt), mayHaveTag(src, owner, tag), !removeTag(tgt, owner, tag).
```

This also allows us to delegate at a much more granular level while not going all the way to something like `speaksFor`. e.g., 

```
// user trusting EFF to handle the tags of "EndUser".
"EndUser" says "EFF" canSay removeTag(path, "EndUser", tag) :- isAccessPath(path), isTag(tag).
// EFF auditing "P1" and making a statement that "P1" removing the "userSelection" tag is valid. 
"EFF" says "P1" canSay removeTag(path, user, "userSelection") :- isAccessPath(path), isPrincipal(user).
```

### Resolved edge has a principal.
Instead of `resolvedEdge(src, tgt)`, we have `resolvedEdge(principal, src, tgt)`, which is read as `src -> tgt` is resolved for principal: 
```
resolvedEdge(principal, src, tgt) :-
   isPrincipal(principal),
   edge(src, tgt),
   !claimNotEdge(principal, src, tgt).
```

### Attaching ownership to access paths. 
This PR also introduces an `ownsAccessPath(principal: Principal, path: AccessPath)` to capture who owns a particular piece of data and is allowed to make decisions operations allowed on the access path. Ideally, we will not be making these claims at the level of access paths within particles. Rather, we will make claims at the point of ingestion of data into the system, which usually corresponds to the handles/stores of a recipe. This ownership of access path is also propagated along the edges unless the edge was removed authoritatively for a principal.
```
ownsAccessPath(principal, tgt) :-
  resolvedEdge(principal, src, tgt), ownsAccessPath(principal, src).
```
