### PR TITLE
Rename `says` relations in datalog to match facts from auth logic.

### DIFF
--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -28,11 +28,11 @@
 
 // Some party asserts the claim that the label of an access path should
 // remove the referenced tag from the set.
-.decl saysRemoveTag(speaker: Principal, path: AccessPath, tag: Tag)
+.decl says_removeTag(speaker: Principal, path: AccessPath, tag: Tag)
 
 // The `speaker` says that `delegatee` is allowed to indicate that a `path` does
 // not have a `tag`.
-.decl saysCanSayRemoveTag(
+.decl says_canSay_removeTag(
   speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
 
 // Indicates that a speaker is allowed to say removeTag.
@@ -44,13 +44,13 @@
 // it).
 .decl ownsTag(owner: Principal, tag: Tag)
 
-.decl saysOwnsTag(speaker: Principal, owner: Principal, tag: Tag)
+.decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
 
 // The `speaker` says that `path` definitely has `tag` taint.
-.decl saysHasTag(speaker: Principal, path: AccessPath, tag: Tag)
+.decl says_hasTag(speaker: Principal, path: AccessPath, tag: Tag)
 
 // The `speaker` says that the `delegatee` can say that `path` has `tag`.
-.decl saysCanSayHasTag(
+.decl says_canSay_hasTag(
   speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
 
 // Indicates that a speaker is allowed to say a path has a particular tag.
@@ -78,21 +78,21 @@ canSayRemoveTag(speaker, path, tag) :-
 // If the owner says a speaker can say removeTag, the speaker can say
 // removeTag.
 canSayRemoveTag(speaker, path, tag) :-
-  ownsTag(owner, tag), saysCanSayRemoveTag(owner, speaker, path, tag).
+  ownsTag(owner, tag), says_canSay_removeTag(owner, speaker, path, tag).
 
 removeTag(path, tag) :-
-    canSayRemoveTag(speaker, path, tag), saysRemoveTag(speaker, path, tag).
+    canSayRemoveTag(speaker, path, tag), says_removeTag(speaker, path, tag).
 
 // The owner can say the tag is present anywhere.
 canSayHasTag(speaker, path, tag) :- isAccessPath(path), ownsTag(speaker, tag).
 
 // The speaker can also speak about the tag if the owner said so.
 canSayHasTag(speaker, path, tag) :-
-  ownsTag(owner, tag), saysCanSayHasTag(owner, speaker, path, tag).
+  ownsTag(owner, tag), says_canSay_hasTag(owner, speaker, path, tag).
 
 // The path has a tag if an authorized speaker says it does.
 hasTag(path, tag) :-
-  saysHasTag(speaker, path, tag), canSayHasTag(speaker, path, tag).
+  says_hasTag(speaker, path, tag), canSayHasTag(speaker, path, tag).
 
 // This rule says that any principal can say that another principal owns a tag.
 // This rule is just a starting point to allow all aspects of the policy to
@@ -100,7 +100,7 @@ hasTag(path, tag) :-
 // ownsTag from something with a speaker. This rule is likely to change. It
 // does not rule out the case that two different principals claim ownership of
 // a tag.
-ownsTag(owner, tag) :- saysOwnsTag(_, owner, tag).
+ownsTag(owner, tag) :- says_ownsTag(_, owner, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -56,7 +56,7 @@
 
 // claimNotEdge(p, src, tgt) is an _attempt_ to remove an edge from the
 // analysis (by principal p)
-// saysRemoveTag(p, path, tgt) is an _attempt_ to remove just one tag
+// says_removeTag(p, path, tgt) is an _attempt_ to remove just one tag
 // from a path (by principal p).
 //
 // The rule for removeTag(p, t) in authorization_logic.dl describes when
@@ -77,7 +77,7 @@
 //      permission for edge removal indirectly by granting permission to remove
 //      tags (abstract representations of their data).
 
-saysRemoveTag(principal, midpoint, tag) :-
+says_removeTag(principal, midpoint, tag) :-
   isTag(tag), claimNotEdge(principal, src, tgt), edgeToMidpointAccessPath(src, tgt, midpoint).
 
 mayHaveTag(tgt, tag) :- hasTag(tgt, tag).
@@ -92,12 +92,12 @@ mayHaveTag(tgt, tag) :-
 // `isObject(..)`) whenever they are mentioned in other rules.
 
 // Any Principal used in a claim is in the universe of isPrincipal.
-isPrincipal(principal) :- saysHasTag(principal, _, _).
+isPrincipal(principal) :- says_hasTag(principal, _, _).
 
-isAccessPath(path) :- saysHasTag(_, path, _).
+isAccessPath(path) :- says_hasTag(_, path, _).
 
 // Symbols used in hasTag or mayHaveTag are tags
-isTag(tag) :- saysHasTag(_, _, tag).
+isTag(tag) :- says_hasTag(_, _, tag).
 
 // A pair of (base, member) is in this set if the base access path is a non-trivial subpath of the
 // member access path.

--- a/src/analysis/souffle/tests/arcs_fact_tests/claim_not_edge_two_inputs_two_outputs.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/claim_not_edge_two_inputs_two_outputs.dl
@@ -22,8 +22,8 @@ isPrincipal("ParticleX").
 ownsTag("Claimer", "tag1").
 ownsTag("Claimer", "tag2").
 
-saysHasTag("Claimer", "R.foo.hc1", "tag1").
-saysHasTag("Claimer", "R.foo.hc2", "tag2").
+says_hasTag("Claimer", "R.foo.hc1", "tag1").
+says_hasTag("Claimer", "R.foo.hc2", "tag2").
 
 // ParticleX claims that hc2 does not flow to hco1.
 // TODO(#146) In the case where we expect this claim to be upheld, how does that

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
@@ -22,8 +22,8 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-saysHasTag("P1", "R.P1.foo.a", "userSelection").
-saysHasTag("P1", "R.P1.foo.b", "screenContent").
+says_hasTag("P1", "R.P1.foo.a", "userSelection").
+says_hasTag("P1", "R.P1.foo.b", "screenContent").
 
 edge("R.P1.foo.a", "R.h.Foo.a").
 edge("R.P1.foo.b", "R.h.Foo.b").

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
@@ -21,7 +21,7 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-saysHasTag("P1", "R.P1.foo", "userSelection").
+says_hasTag("P1", "R.P1.foo", "userSelection").
 edge("R.P1.foo", "R.h.Foo").
 edge("R.h.Foo", "R.P2.bar").
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
@@ -25,7 +25,7 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-saysHasTag("P1", "R.P1.foo", "userSelection").
+says_hasTag("P1", "R.P1.foo", "userSelection").
 edge("R.P1.foo", "R.h1.Foo").
 edge("R.h1.Foo", "R.P2.bar").
 edge("R.P2.bar", "R.P2.foo").

--- a/src/ir/tag_claim.h
+++ b/src/ir/tag_claim.h
@@ -67,7 +67,7 @@ class TagClaim {
     constexpr absl::string_view kClaimTagFormat =
         R"(%s("%s", "%s", "%s").)";
     absl::string_view relation_name =
-        (claim_tag_is_present_) ? "saysHasTag" : "saysRemoveTag";
+        (claim_tag_is_present_) ? "says_hasTag" : "says_removeTag";
     return absl::StrFormat(
         kClaimTagFormat, relation_name, claiming_particle_name_,
         access_path_.ToString(), tag_);

--- a/src/ir/tag_claim_test.cc
+++ b/src/ir/tag_claim_test.cc
@@ -105,19 +105,19 @@ access_path: {
   selectors: { field: "field1" } },
 predicate: { label: { semantic_tag: "tag"} })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.field1", "tag").)") } },
+          R"(says_hasTag("%s", "%s.field1", "tag").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" } },
 predicate: { label: { semantic_tag: "tag2"} })",
-      { absl::ParsedFormat<'s', 's'>(R"(saysHasTag("%s", "%s", "tag2").)") } },
+      { absl::ParsedFormat<'s', 's'>(R"(says_hasTag("%s", "%s", "tag2").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" },
   selectors: [{ field: "x" }, { field: "y" }] },
 predicate: { label: { semantic_tag: "user_selection"} })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.x.y", "user_selection").)") } },
+          R"(says_hasTag("%s", "%s.x.y", "user_selection").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" },
@@ -125,7 +125,7 @@ access_path: {
 predicate: {
 not: { predicate: { label: { semantic_tag: "user_selection"} } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(saysRemoveTag("%s", "%s.x.y", "user_selection").)") } },
+          R"(says_removeTag("%s", "%s.x.y", "user_selection").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -134,9 +134,9 @@ predicate: { and: {
   conjunct0: { label: { semantic_tag: "tag"} }
   conjunct1: { label: { semantic_tag: "tag2"} } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.field1", "tag").)"),
+          R"(says_hasTag("%s", "%s.field1", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.field1", "tag2").)") } },
+          R"(says_hasTag("%s", "%s.field1", "tag2").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -145,9 +145,9 @@ predicate: { and: {
   conjunct0: { not: { predicate: { label: { semantic_tag: "tag"} } } }
   conjunct1: { label: { semantic_tag: "tag2"} } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(saysRemoveTag("%s", "%s.field1", "tag").)"),
+          R"(says_removeTag("%s", "%s.field1", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.field1", "tag2").)") } },
+          R"(says_hasTag("%s", "%s.field1", "tag2").)") } },
     { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" } },
@@ -155,9 +155,9 @@ predicate: { and: {
   conjunct0: { label: { semantic_tag: "tag"} }
   conjunct1: { not: { predicate: { label: { semantic_tag: "tag2"} } } } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s", "tag").)"),
+          R"(says_hasTag("%s", "%s", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(saysRemoveTag("%s", "%s", "tag2").)") } },
+          R"(says_removeTag("%s", "%s", "tag2").)") } },
      { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -168,11 +168,11 @@ predicate: { and: {
     conjunct1: { not: { predicate: { label: { semantic_tag: "tag2"} } } } } }
   conjunct1: { label: { semantic_tag: "tag3"} } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.field1", "tag").)"),
+          R"(says_hasTag("%s", "%s.field1", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(saysRemoveTag("%s", "%s.field1", "tag2").)"),
+          R"(says_removeTag("%s", "%s.field1", "tag2").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.field1", "tag3").)") } },
+          R"(says_hasTag("%s", "%s.field1", "tag3").)") } },
      { R"(
 access_path: {
   handle: { particle_spec: "ps", handle_connection: "hc" }
@@ -185,13 +185,13 @@ predicate: { and: {
     conjunct0: { not: { predicate: { label: { semantic_tag: "tag3"} } } }
     conjunct1: { label: { semantic_tag: "tag4" } } } } } })",
       { absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.field1", "tag").)"),
+          R"(says_hasTag("%s", "%s.field1", "tag").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(saysRemoveTag("%s", "%s.field1", "tag2").)"),
+          R"(says_removeTag("%s", "%s.field1", "tag2").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(saysRemoveTag("%s", "%s.field1", "tag3").)"),
+          R"(says_removeTag("%s", "%s.field1", "tag3").)"),
         absl::ParsedFormat<'s', 's'>(
-          R"(saysHasTag("%s", "%s.field1", "tag4").)")
+          R"(says_hasTag("%s", "%s.field1", "tag4").)")
           } },
 };
 

--- a/src/xform_to_datalog/datalog_facts.h
+++ b/src/xform_to_datalog/datalog_facts.h
@@ -73,27 +73,6 @@ allTests(check_index) :- isCheck(check_index).
 testFails(check_index) :-
   isCheck(check_index), !check(check_index).
 
-// Rules for linking generated relations with the ones in the dl program.
-.decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
-saysOwnsTag(x, y, z) :- says_ownsTag(x, y, z).
-
-.decl says_hasTag(speaker: Principal, path: AccessPath, tag: Tag)
-saysHasTag(x, y, z) :- says_hasTag(x, y, z).
-
-.decl says_canSay_hasTag(
-  speaker: Principal,
-  delegatee: Principal,
-  accessPath: AccessPath,
-  tag: Tag)
-saysCanSayHasTag(w, x, y, z) :- says_canSay_hasTag(w, x, y, z).
-
-.decl says_canSay_removeTag(
-    speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
-saysCanSayRemoveTag(w, x, y, z) :- says_canSay_removeTag(w, x, y, z).
-
-.decl says_removeTag(speaker: Principal, path: AccessPath, tag: Tag)
-saysRemoveTag(x, y, z) :- says_removeTag(x, y, z).
-
 // Manifest
 %s
 // Authorization Logic

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -62,27 +62,6 @@ allTests(check_index) :- isCheck(check_index).
 testFails(check_index) :-
   isCheck(check_index), !check(check_index).
 
-// Rules for linking generated relations with the ones in the dl program.
-.decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
-saysOwnsTag(x, y, z) :- says_ownsTag(x, y, z).
-
-.decl says_hasTag(speaker: Principal, path: AccessPath, tag: Tag)
-saysHasTag(x, y, z) :- says_hasTag(x, y, z).
-
-.decl says_canSay_hasTag(
-  speaker: Principal,
-  delegatee: Principal,
-  accessPath: AccessPath,
-  tag: Tag)
-saysCanSayHasTag(w, x, y, z) :- says_canSay_hasTag(w, x, y, z).
-
-.decl says_canSay_removeTag(
-    speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
-saysCanSayRemoveTag(w, x, y, z) :- says_canSay_removeTag(w, x, y, z).
-
-.decl says_removeTag(speaker: Principal, path: AccessPath, tag: Tag)
-saysRemoveTag(x, y, z) :- says_removeTag(x, y, z).
-
 // Manifest
 
 // Claims:
@@ -131,31 +110,10 @@ allTests(check_index) :- isCheck(check_index).
 testFails(check_index) :-
   isCheck(check_index), !check(check_index).
 
-// Rules for linking generated relations with the ones in the dl program.
-.decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
-saysOwnsTag(x, y, z) :- says_ownsTag(x, y, z).
-
-.decl says_hasTag(speaker: Principal, path: AccessPath, tag: Tag)
-saysHasTag(x, y, z) :- says_hasTag(x, y, z).
-
-.decl says_canSay_hasTag(
-  speaker: Principal,
-  delegatee: Principal,
-  accessPath: AccessPath,
-  tag: Tag)
-saysCanSayHasTag(w, x, y, z) :- says_canSay_hasTag(w, x, y, z).
-
-.decl says_canSay_removeTag(
-    speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
-saysCanSayRemoveTag(w, x, y, z) :- says_canSay_removeTag(w, x, y, z).
-
-.decl says_removeTag(speaker: Principal, path: AccessPath, tag: Tag)
-saysRemoveTag(x, y, z) :- says_removeTag(x, y, z).
-
 // Manifest
 
 // Claims:
-saysHasTag("particle", "recipe.particle.out", "tag").
+says_hasTag("particle", "recipe.particle.out", "tag").
 
 // Checks:
 

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -82,7 +82,7 @@ static std::tuple<ManifestDatalogFacts, std::string>
            ir::Edge(kHandleConnectionOutAccessPath, kHandleH2AccessPath)}),
       R"(
 // Claims:
-saysHasTag("particle", "recipe.particle.out", "tag").
+says_hasTag("particle", "recipe.particle.out", "tag").
 
 // Checks:
 isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("recipe.particle.in", "tag2").
@@ -281,12 +281,12 @@ class ParseBigManifestTest : public testing::Test {
 };
 
 static const std::string kExpectedClaimStrings[] = {
-    R"(saysHasTag("PS1", "NamedR.PS1#0.out_handle.field1", "tag1").)",
-    R"(saysHasTag("PS1", "NamedR.PS1#1.out_handle.field1", "tag1").)",
-    R"(saysHasTag("PS2", "NamedR.PS2#2.out_handle.field1", "tag3").)",
-    R"(saysHasTag("PS1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "tag1").)",
-    R"(saysHasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "tag3").)",
-    R"(saysHasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "tag3").)",
+    R"(says_hasTag("PS1", "NamedR.PS1#0.out_handle.field1", "tag1").)",
+    R"(says_hasTag("PS1", "NamedR.PS1#1.out_handle.field1", "tag1").)",
+    R"(says_hasTag("PS2", "NamedR.PS2#2.out_handle.field1", "tag3").)",
+    R"(says_hasTag("PS1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "tag1").)",
+    R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "tag3").)",
+    R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "tag3").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -17,31 +17,10 @@ allTests(check_index) :- isCheck(check_index).
 testFails(check_index) :-
   isCheck(check_index), !check(check_index).
 
-// Rules for linking generated relations with the ones in the dl program.
-.decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
-saysOwnsTag(x, y, z) :- says_ownsTag(x, y, z).
-
-.decl says_hasTag(speaker: Principal, path: AccessPath, tag: Tag)
-saysHasTag(x, y, z) :- says_hasTag(x, y, z).
-
-.decl says_canSay_hasTag(
-  speaker: Principal,
-  delegatee: Principal,
-  accessPath: AccessPath,
-  tag: Tag)
-saysCanSayHasTag(w, x, y, z) :- says_canSay_hasTag(w, x, y, z).
-
-.decl says_canSay_removeTag(
-    speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
-saysCanSayRemoveTag(w, x, y, z) :- says_canSay_removeTag(w, x, y, z).
-
-.decl says_removeTag(speaker: Principal, path: AccessPath, tag: Tag)
-saysRemoveTag(x, y, z) :- says_removeTag(x, y, z).
-
 // Manifest
 
 // Claims:
-saysHasTag("P1", "R.P1#0.foo", "userSelection").
+says_hasTag("P1", "R.P1#0.foo", "userSelection").
 
 // Checks:
 isCheck("check_num_0"). check("check_num_0") :- mayHaveTag("R.P3#2.bar", "userSelection").


### PR DESCRIPTION
Closes #102. Ultimately, we should change authorization logic to generate camel case relations, but let us defer this to the time when we rewrite the parser.