### PR TITLE
Create a SystemSpec class in the place of ParticleSpecRegistry.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "edge.h",
         "handle_connection_spec.h",
         "particle_spec.h",
+        "system_spec.h",
         "predicate.h",
         "predicate_arena.h",
         "tag_check.h",
@@ -144,6 +145,15 @@ cc_test(
         ":ir",
         "//src/common/testing:gtest",
     ],
+)
+
+cc_test(
+    name = "system_spec_test",
+    srcs = ["system_spec_test.cc"],
+    deps = [
+        ":ir",
+        "//src/common/testing:gtest",
+    ]
 )
 
 cc_test(

--- a/src/ir/particle_spec.cc
+++ b/src/ir/particle_spec.cc
@@ -18,17 +18,16 @@
 
 namespace raksha::ir {
 
-const ParticleSpec *ParticleSpec::Create(
-      ParticleSpecRegistry &registry, std::string name,
-      std::vector<TagCheck> checks, std::vector<TagClaim> tag_claims,
-      std::vector<DerivesFromClaim> derives_from_claims,
-      std::vector<HandleConnectionSpec> handle_connection_specs,
-      std::unique_ptr<PredicateArena> predicate_arena) {
-  return registry.CaptureParticleSpec(std::unique_ptr<ParticleSpec>(
-      new ParticleSpec(
-          std::move(name), std::move(checks), std::move(tag_claims),
-          std::move(derives_from_claims), std::move(handle_connection_specs),
-          std::move(predicate_arena))));
+std::unique_ptr<ParticleSpec> ParticleSpec::Create(
+    std::string name, std::vector<TagCheck> checks,
+    std::vector<TagClaim> tag_claims,
+    std::vector<DerivesFromClaim> derives_from_claims,
+    std::vector<HandleConnectionSpec> handle_connection_specs,
+    std::unique_ptr<PredicateArena> predicate_arena) {
+  return std::unique_ptr<ParticleSpec>(new ParticleSpec(
+      std::move(name), std::move(checks), std::move(tag_claims),
+      std::move(derives_from_claims), std::move(handle_connection_specs),
+      std::move(predicate_arena)));
 }
 
 void ParticleSpec::GenerateEdges() {

--- a/src/ir/proto/BUILD
+++ b/src/ir/proto/BUILD
@@ -117,6 +117,19 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "system_spec",
+    srcs = ["system_spec.cc"],
+    hdrs = ["system_spec.h"],
+    deps = [
+        ":particle_spec",
+        "//src/ir",
+        "//src/ir:access_path",
+        "//src/ir/proto:types",
+        "//third_party/arcs/proto:manifest_cc_proto",
+    ],
+)
+
 cc_test(
     name = "access_path_test",
     srcs = ["access_path_test.cc"],

--- a/src/ir/proto/particle_spec.cc
+++ b/src/ir/proto/particle_spec.cc
@@ -25,8 +25,7 @@
 
 namespace raksha::ir::proto {
 
-const ParticleSpec *Decode(
-    ParticleSpecRegistry &particle_spec_registry,
+std::unique_ptr<ParticleSpec> Decode(
     std::unique_ptr<PredicateArena> arena,
     const arcs::ParticleSpecProto &particle_spec_proto) {
   std::string name = particle_spec_proto.name();
@@ -71,9 +70,9 @@ const ParticleSpec *Decode(
   }
 
   return ParticleSpec::Create(
-      particle_spec_registry, std::move(name), std::move(checks),
-      std::move(tag_claims), std::move(derives_from_claims),
-      std::move(handle_connection_specs), std::move(arena));
+      std::move(name), std::move(checks), std::move(tag_claims),
+      std::move(derives_from_claims), std::move(handle_connection_specs),
+      std::move(arena));
 }
 
 }  // namespace raksha::ir::proto

--- a/src/ir/proto/system_spec.cc
+++ b/src/ir/proto/system_spec.cc
@@ -13,21 +13,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-----------------------------------------------------------------------------
+#ifndef SRC_IR_PROTO_SYSTEM_SPEC_H_
+#define SRC_IR_PROTO_SYSTEM_SPEC_H_
 
-#ifndef SRC_IR_PROTO_PARTICLE_SPEC_H_
-#define SRC_IR_PROTO_PARTICLE_SPEC_H_
+#include "src/ir/proto/system_spec.h"
 
 #include <memory>
 
-#include "src/ir/particle_spec.h"
-#include "src/ir/predicate_arena.h"
-#include "third_party/arcs/proto/manifest.pb.h"
+#include "src/ir/proto/particle_spec.h"
+#include "src/ir/system_spec.h"
 
 namespace raksha::ir::proto {
 
-std::unique_ptr<ParticleSpec> Decode(std::unique_ptr<PredicateArena> arena,
-                                     const arcs::ParticleSpecProto &proto);
+std::unique_ptr<SystemSpec> Decode(const arcs::ManifestProto &manifest_proto) {
+  // Turn each ParticleSpecProto indicated in the manifest_proto into a
+  // ParticleSpec object, which we can use directly.
+  auto system_spec = std::make_unique<SystemSpec>();
+  for (const arcs::ParticleSpecProto &particle_spec_proto :
+       manifest_proto.particle_specs()) {
+    std::unique_ptr<ir::PredicateArena> arena =
+        std::make_unique<ir::PredicateArena>();
+    system_spec->AddParticleSpec(
+        ir::proto::Decode(std::move(arena), particle_spec_proto));
+  }
+  return system_spec;
+}
 
 }  // namespace raksha::ir::proto
 
-#endif  // SRC_IR_PROTO_PARTICLE_SPEC_H_
+#endif  // SRC_IR_PROTO_SYSTEM_SPEC_H_

--- a/src/ir/proto/system_spec.h
+++ b/src/ir/proto/system_spec.h
@@ -13,21 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-----------------------------------------------------------------------------
+#ifndef SRC_IR_PROTO_SYSTEM_SPEC_H_
+#define SRC_IR_PROTO_SYSTEM_SPEC_H_
 
-#ifndef SRC_IR_PROTO_PARTICLE_SPEC_H_
-#define SRC_IR_PROTO_PARTICLE_SPEC_H_
-
-#include <memory>
-
-#include "src/ir/particle_spec.h"
-#include "src/ir/predicate_arena.h"
+#include "src/ir/system_spec.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::proto {
 
-std::unique_ptr<ParticleSpec> Decode(std::unique_ptr<PredicateArena> arena,
-                                     const arcs::ParticleSpecProto &proto);
+std::unique_ptr<SystemSpec> Decode(const arcs::ManifestProto &manifest_proto);
 
 }  // namespace raksha::ir::proto
 
-#endif  // SRC_IR_PROTO_PARTICLE_SPEC_H_
+#endif  // SRC_IR_PROTO_SYSTEM_SPEC_H_

--- a/src/ir/system_spec.h
+++ b/src/ir/system_spec.h
@@ -32,14 +32,13 @@ class SystemSpec {
     return ins_res.first->second.get();
   }
 
-  // Get a ParticleSpec with a particular name. Errors if there is no
-  // particle spec with that name.
-  const ParticleSpec &GetParticleSpec(
+  // Returns a ParticleSpec with a particular name. If there is no
+  // particle spec with that name, returns nullptr.
+  const ParticleSpec *GetParticleSpec(
       absl::string_view particle_spec_name) const {
     auto find_res = particle_specs_.find(particle_spec_name);
-    CHECK(find_res != particle_specs_.end())
-        << "No particle spec with name " << particle_spec_name;
-    return *find_res->second;
+    return (find_res != particle_specs_.end()) ? find_res->second.get()
+                                               : nullptr;
   }
 
  private:

--- a/src/ir/system_spec.h
+++ b/src/ir/system_spec.h
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#ifndef SRC_IR_SYSTEM_SPEC_H_
+#define SRC_IR_SYSTEM_SPEC_H_
+
+#include "src/ir/particle_spec.h"
+
+namespace raksha::ir {
+
+// The specification of the entire system that is being modeled in the IR.
+class SystemSpec {
+ public:
+  const ParticleSpec *AddParticleSpec(
+      std::unique_ptr<ParticleSpec> particle_spec) {
+    auto ins_res = particle_specs_.insert(
+        {particle_spec->name(), std::move(particle_spec)});
+    CHECK(ins_res.second) << "Tried to insert second particle spec with name "
+                          << ins_res.first->first;
+    return ins_res.first->second.get();
+  }
+
+  // Get a ParticleSpec with a particular name. Errors if there is no
+  // particle spec with that name.
+  const ParticleSpec &GetParticleSpec(
+      absl::string_view particle_spec_name) const {
+    auto find_res = particle_specs_.find(particle_spec_name);
+    CHECK(find_res != particle_specs_.end())
+        << "No particle spec with name " << particle_spec_name;
+    return *find_res->second;
+  }
+
+ private:
+  // The particles in the system spec.
+  absl::flat_hash_map<std::string, std::unique_ptr<ParticleSpec>>
+      particle_specs_;
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_SYSTEM_SPEC_H_

--- a/src/ir/system_spec_test.cc
+++ b/src/ir/system_spec_test.cc
@@ -1,0 +1,64 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#include "src/ir/system_spec.h"
+
+#include "src/common/logging/logging.h"
+#include "src/common/testing/gtest.h"
+#include "src/ir/particle_spec.h"
+
+
+namespace raksha::ir {
+
+TEST(AddParticleSpec, StoresAndReturnsParticleSpec) {
+  SystemSpec spec;
+  std::unique_ptr<ParticleSpec> particle_spec =
+      ParticleSpec::Create("MyParticle", {}, {}, {}, {}, nullptr);
+  const ParticleSpec* created_spec = particle_spec.get();
+  const ParticleSpec* stored_spec =
+      spec.AddParticleSpec(std::move(particle_spec));
+  EXPECT_EQ(created_spec, stored_spec);
+  EXPECT_EQ(stored_spec->name(), "MyParticle");
+}
+
+TEST(AddParticleSpec, FailsWhenDuplicateSpecsAreStored) {
+  SystemSpec spec;
+  const ParticleSpec* particle_spec = spec.AddParticleSpec(
+      ParticleSpec::Create("MyParticle", {}, {}, {}, {}, nullptr));
+  EXPECT_EQ(particle_spec->name(), "MyParticle");
+  EXPECT_DEATH( spec.AddParticleSpec(
+      ParticleSpec::Create("MyParticle", {}, {}, {}, {}, nullptr)),
+                "Tried to insert second particle spec with name MyParticle");
+}
+
+TEST(GetParticleSpec, ReturnsStoredParticleSpec) {
+  SystemSpec spec;
+  spec.AddParticleSpec(
+      ParticleSpec::Create("MyParticle", {}, {}, {}, {}, nullptr));
+  const ParticleSpec& stored_spec = spec.GetParticleSpec("MyParticle");
+  EXPECT_EQ(stored_spec.name(), "MyParticle");
+}
+
+TEST(GetParticleSpec, FailsIfParticleSpecNotFound) {
+  SystemSpec spec;
+  spec.AddParticleSpec(
+      ParticleSpec::Create("MyParticle", {}, {}, {}, {}, nullptr));
+  EXPECT_DEATH(spec.GetParticleSpec("MyPart"),
+               "No particle spec with name MyPart");
+}
+
+
+
+}  // namespace raksha::ir

--- a/src/ir/system_spec_test.cc
+++ b/src/ir/system_spec_test.cc
@@ -47,18 +47,16 @@ TEST(GetParticleSpec, ReturnsStoredParticleSpec) {
   SystemSpec spec;
   spec.AddParticleSpec(
       ParticleSpec::Create("MyParticle", {}, {}, {}, {}, nullptr));
-  const ParticleSpec& stored_spec = spec.GetParticleSpec("MyParticle");
-  EXPECT_EQ(stored_spec.name(), "MyParticle");
+  const ParticleSpec* stored_spec = spec.GetParticleSpec("MyParticle");
+  EXPECT_EQ(stored_spec->name(), "MyParticle");
 }
 
 TEST(GetParticleSpec, FailsIfParticleSpecNotFound) {
   SystemSpec spec;
   spec.AddParticleSpec(
       ParticleSpec::Create("MyParticle", {}, {}, {}, {}, nullptr));
-  EXPECT_DEATH(spec.GetParticleSpec("MyPart"),
-               "No particle spec with name MyPart");
+  const ParticleSpec* stored_spec = spec.GetParticleSpec("MyPart");
+  EXPECT_EQ(stored_spec, nullptr);
 }
-
-
 
 }  // namespace raksha::ir

--- a/src/xform_to_datalog/BUILD
+++ b/src/xform_to_datalog/BUILD
@@ -100,6 +100,7 @@ cc_library(
     deps = [
         "//src/ir",
         "//src/ir/proto:particle_spec",
+        "//src/ir/proto:system_spec",
         "//src/ir/proto:types",
         "//third_party/arcs/proto:manifest_cc_proto",
     ],
@@ -120,6 +121,7 @@ cc_binary(
     srcs = ["generate_datalog_program.cc"],
     deps = [
         ":datalog_facts",
+        "//src/ir/proto:system_spec",
         "//src/common/logging",
         "@absl//absl/flags:flag",
         "@absl//absl/flags:parse",

--- a/src/xform_to_datalog/generate_datalog_program.cc
+++ b/src/xform_to_datalog/generate_datalog_program.cc
@@ -25,7 +25,8 @@
 #include "absl/flags/usage.h"
 #include "src/common/logging/logging.h"
 #include "src/ir/datalog_print_context.h"
-#include "src/ir/particle_spec.h"
+#include "src/ir/proto/system_spec.h"
+#include "src/ir/system_spec.h"
 #include "src/xform_to_datalog/authorization_logic_datalog_facts.h"
 #include "src/xform_to_datalog/datalog_facts.h"
 #include "src/xform_to_datalog/manifest_datalog_facts.h"
@@ -86,9 +87,12 @@ int main(int argc, char *argv[]) {
     LOG(ERROR) << "Error parsing the manifest proto " << manifest_filepath;
   }
 
-  raksha::ir::ParticleSpecRegistry particle_spec_registry;
+  // Turn each ParticleSpecProto indicated in the manifest_proto into a
+  // ParticleSpec object, which we can use directly.
+  std::unique_ptr<raksha::ir::SystemSpec> system_spec =
+      raksha::ir::proto::Decode(manifest_proto);
   auto manifest_datalog_facts = ManifestDatalogFacts::CreateFromManifestProto(
-      manifest_proto, particle_spec_registry);
+      system_spec.get(), manifest_proto);
 
   std::filesystem::path auth_logic_filename = auth_logic_filepath.filename();
   auth_logic_filepath.remove_filename();

--- a/src/xform_to_datalog/generate_datalog_program.cc
+++ b/src/xform_to_datalog/generate_datalog_program.cc
@@ -91,8 +91,9 @@ int main(int argc, char *argv[]) {
   // ParticleSpec object, which we can use directly.
   std::unique_ptr<raksha::ir::SystemSpec> system_spec =
       raksha::ir::proto::Decode(manifest_proto);
+  CHECK(system_spec != nullptr);
   auto manifest_datalog_facts = ManifestDatalogFacts::CreateFromManifestProto(
-      system_spec.get(), manifest_proto);
+      *system_spec, manifest_proto);
 
   std::filesystem::path auth_logic_filename = auth_logic_filepath.filename();
   auth_logic_filepath.remove_filename();

--- a/src/xform_to_datalog/manifest_datalog_facts.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts.cc
@@ -19,7 +19,7 @@
 #include "src/ir/handle_connection_spec.h"
 #include "src/ir/particle_spec.h"
 #include "src/ir/proto/type.h"
-#include "src/ir/proto/particle_spec.h"
+#include "src/ir/proto/system_spec.h"
 
 namespace raksha::xform_to_datalog {
 
@@ -33,23 +33,13 @@ namespace types = raksha::ir::types;
 //  traversal. This works, but it is hard to read and hard to test. We should
 //  break this up.
 ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
-    const arcs::ManifestProto &manifest_proto,
-    ir::ParticleSpecRegistry &particle_spec_registry) {
+    const ir::SystemSpec* system_spec,
+    const arcs::ManifestProto &manifest_proto) {
   // These collections will be used as inputs to the constructor that we
   // return from this function.
   std::vector<ir::TagClaim> result_claims;
   std::vector<ir::TagCheck> result_checks;
   std::vector<ir::Edge> result_edges;
-
-  // Turn each ParticleSpecProto indicated in the manifest_proto into a
-  // ParticleSpec object, which we can use directly.
-  for (const arcs::ParticleSpecProto &particle_spec_proto :
-    manifest_proto.particle_specs()) {
-    std::unique_ptr<ir::PredicateArena> arena =
-        std::make_unique<ir::PredicateArena>();
-    ir::proto::Decode(
-        particle_spec_registry, std::move(arena), particle_spec_proto);
-  }
 
   // This loop looks at each recipe in the manifest proto and instantiates
   // the ParticleSpecs indicated by the ParticleProtos in that recipe. It
@@ -86,7 +76,7 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
       // contained in the spec will be needed for all facts produced within a
       // Particle.
       const ir::ParticleSpec &particle_spec =
-          particle_spec_registry.GetParticleSpec(particle_spec_name);
+          system_spec->GetParticleSpec(particle_spec_name);
 
       // Each ParticleSpec already contains lists of TagClaims, TagChecks,
       // and Edges that shall be generated for each Particle implementing that

--- a/src/xform_to_datalog/manifest_datalog_facts.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts.cc
@@ -75,8 +75,8 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
       // Find the ParticleSpec referenced by this Particle. The information
       // contained in the spec will be needed for all facts produced within a
       // Particle.
-      const ir::ParticleSpec &particle_spec =
-          system_spec->GetParticleSpec(particle_spec_name);
+      const ir::ParticleSpec *particle_spec =
+          CHECK_NOTNULL(system_spec->GetParticleSpec(particle_spec_name));
 
       // Each ParticleSpec already contains lists of TagClaims, TagChecks,
       // and Edges that shall be generated for each Particle implementing that
@@ -124,7 +124,7 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
         // Look up the HandleConnectionSpec to see if the handle connection
         // will read and/or write.
         const ir::HandleConnectionSpec &handle_connection_spec =
-            particle_spec.getHandleConnectionSpec(handle_spec_name);
+            particle_spec->getHandleConnectionSpec(handle_spec_name);
         const bool handle_connection_reads = handle_connection_spec.reads();
         const bool handle_connection_writes = handle_connection_spec.writes();
 
@@ -153,7 +153,7 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
       }
 
       ir::InstantiatedParticleSpecFacts particle_spec_facts =
-          particle_spec.BulkInstantiate(instantiation_map);
+          particle_spec->BulkInstantiate(instantiation_map);
       result_claims.insert(
           result_claims.end(),
           std::move_iterator(particle_spec_facts.tag_claims.begin()),

--- a/src/xform_to_datalog/manifest_datalog_facts.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts.cc
@@ -33,7 +33,7 @@ namespace types = raksha::ir::types;
 //  traversal. This works, but it is hard to read and hard to test. We should
 //  break this up.
 ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
-    const ir::SystemSpec* system_spec,
+    const ir::SystemSpec& system_spec,
     const arcs::ManifestProto &manifest_proto) {
   // These collections will be used as inputs to the constructor that we
   // return from this function.
@@ -75,8 +75,8 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
       // Find the ParticleSpec referenced by this Particle. The information
       // contained in the spec will be needed for all facts produced within a
       // Particle.
-      const ir::ParticleSpec *particle_spec =
-          CHECK_NOTNULL(system_spec->GetParticleSpec(particle_spec_name));
+      const ir::ParticleSpec &particle_spec =
+          *CHECK_NOTNULL(system_spec.GetParticleSpec(particle_spec_name));
 
       // Each ParticleSpec already contains lists of TagClaims, TagChecks,
       // and Edges that shall be generated for each Particle implementing that
@@ -124,7 +124,7 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
         // Look up the HandleConnectionSpec to see if the handle connection
         // will read and/or write.
         const ir::HandleConnectionSpec &handle_connection_spec =
-            particle_spec->getHandleConnectionSpec(handle_spec_name);
+            particle_spec.getHandleConnectionSpec(handle_spec_name);
         const bool handle_connection_reads = handle_connection_spec.reads();
         const bool handle_connection_writes = handle_connection_spec.writes();
 
@@ -153,7 +153,7 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
       }
 
       ir::InstantiatedParticleSpecFacts particle_spec_facts =
-          particle_spec->BulkInstantiate(instantiation_map);
+          particle_spec.BulkInstantiate(instantiation_map);
       result_claims.insert(
           result_claims.end(),
           std::move_iterator(particle_spec_facts.tag_claims.begin()),

--- a/src/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/xform_to_datalog/manifest_datalog_facts.h
@@ -32,7 +32,7 @@ namespace raksha::xform_to_datalog {
 class ManifestDatalogFacts {
  public:
   static ManifestDatalogFacts CreateFromManifestProto(
-      const ir::SystemSpec* system_spec,
+      const ir::SystemSpec& system_spec,
       const arcs::ManifestProto &manifest_proto);
 
   // A default constructor creates a sensible, legal state (no facts) and

--- a/src/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/xform_to_datalog/manifest_datalog_facts.h
@@ -24,7 +24,7 @@
 #include "src/ir/tag_check.h"
 #include "src/ir/tag_claim.h"
 #include "src/ir/datalog_print_context.h"
-#include "src/ir/particle_spec.h"
+#include "src/ir/system_spec.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::xform_to_datalog {
@@ -32,8 +32,8 @@ namespace raksha::xform_to_datalog {
 class ManifestDatalogFacts {
  public:
   static ManifestDatalogFacts CreateFromManifestProto(
-      const arcs::ManifestProto &manifest_proto,
-      ir::ParticleSpecRegistry &particle_spec_registry);
+      const ir::SystemSpec* system_spec,
+      const arcs::ManifestProto &manifest_proto);
 
   // A default constructor creates a sensible, legal state (no facts) and
   // allows a bit more flexibility in constructing objects within which

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -274,8 +274,9 @@ class ParseBigManifestTest : public testing::Test {
     google::protobuf::TextFormat::ParseFromString(
         kManifestTextproto, &manifest_proto);
     system_spec_ = ir::proto::Decode(manifest_proto);
+    CHECK(system_spec_ != nullptr);
     datalog_facts_ = ManifestDatalogFacts::CreateFromManifestProto(
-        system_spec_.get(), manifest_proto);
+        *system_spec_, manifest_proto);
   }
 
  protected:

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -21,6 +21,7 @@
 #include "absl/strings/substitute.h"
 #include "src/common/testing/gtest.h"
 #include "src/ir/datalog_print_context.h"
+#include "src/ir/proto/system_spec.h"
 #include "src/ir/single-use-arena-and-predicate.h"
 
 namespace raksha::xform_to_datalog {
@@ -272,12 +273,13 @@ class ParseBigManifestTest : public testing::Test {
     arcs::ManifestProto manifest_proto;
     google::protobuf::TextFormat::ParseFromString(
         kManifestTextproto, &manifest_proto);
+    system_spec_ = ir::proto::Decode(manifest_proto);
     datalog_facts_ = ManifestDatalogFacts::CreateFromManifestProto(
-        manifest_proto, registry_);
+        system_spec_.get(), manifest_proto);
   }
 
  protected:
-  ir::ParticleSpecRegistry registry_;
+  std::unique_ptr<ir::SystemSpec> system_spec_;
   ir::DatalogPrintContext ctxt_;
   ManifestDatalogFacts datalog_facts_;
 };


### PR DESCRIPTION
This is the place where all information about the system being modeled will be kept.This is class that frontends should build into.Further, all the information in the manifest.proto should be decoded to this class.