### PR TITLE
Early start at refactoring AccessPath and AccessPathSelectorSet.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -51,9 +51,11 @@ cc_library(
 
 cc_library(
     name = "access_path",
+    srcs = ["access_path_selector_tree.cc"],
     hdrs = [
         "access_path.h",
         "access_path_root.h",
+        "access_path_selector_tree.h",
         "access_path_selectors.h",
         "access_path_selectors_set.h",
         "field_selector.h",

--- a/src/ir/access_path_selector_tree.h
+++ b/src/ir/access_path_selector_tree.h
@@ -1,0 +1,62 @@
+#ifndef SRC_IR_ACCESS_PATH_SELECTOR_TREE_H_
+#define SRC_IR_ACCESS_PATH_SELECTOR_TREE_H_
+
+#include <memory>
+
+#include "src/common/logging/logging.h"
+#include "src/ir/selector.h"
+
+namespace raksha::ir {
+
+// A tree of AccessPathSelectors. Used to describe the AccessPaths that
+// derive from a particular type. This contains both links to children and
+// links to parents to support different use cases: the upwards links so that
+// the selectors list of an AccessPath can be expressed as a link to an inner
+// node, usually a leaf.
+class AccessPathSelectorTree {
+ public:
+  AccessPathSelectorTree(
+      Selector selector,
+      std::vector<std::unique_ptr<AccessPathSelectorTree>> children)
+      : selector_(std::move(selector)),
+        children_(std::move(children)) {}
+
+  void SetParent(const AccessPathSelectorTree &parent) {
+    CHECK(parent_ == nullptr)
+      << "Attempt to set a parent pointer that has already been set in "
+      << "AccessPathSelectorTree.";
+    parent_ = &parent;
+  }
+
+  // Indicates whether the access paths indicated by the parent pointers are
+  // equal for these two AccessPathSelectorTrees.
+  bool ParentPathsEqual(const AccessPathSelectorTree &other) const {
+    if (selector_ != other.selector_) return false;
+    if ((parent_ == nullptr) != (other.parent_ == nullptr)) return false;
+    if (parent_ == nullptr) {
+      CHECK(other.parent_ == nullptr)
+        << "Assumed both parent pointers would be nullptr at this point!";
+      return true;
+    }
+    return parent_->ParentPathsEqual(*other.parent_);
+  }
+
+  void PrintParentPath(std::ostream &out) const {
+    if (parent_ != nullptr) parent_->PrintParentPath(out);
+    out << selector_.ToString();
+  }
+
+  class AccessPathSelectorTreeIter {
+   private:
+    std::vector<const AccessPathSelectorTree *> path_stack_;
+  };
+
+ private:
+  Selector selector_;
+  const AccessPathSelectorTree *parent_;
+  std::vector<std::unique_ptr<AccessPathSelectorTree>> children_;
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_ACCESS_PATH_SELECTOR_TREE_H_

--- a/src/ir/access_path_selectors.h
+++ b/src/ir/access_path_selectors.h
@@ -7,6 +7,7 @@
 
 #include "absl/hash/hash.h"
 #include "absl/strings/str_join.h"
+#include "src/ir/access_path_selector_tree.h"
 
 namespace raksha::ir {
 
@@ -85,7 +86,7 @@ class AccessPathSelectors {
   // Storing it as a vector in reverse order allows us to continually push
   // the components onto the end of the vector in a single AccessPathSelectors
   // that is moved from callee towards caller.
-  std::vector<Selector> reverse_selectors_;
+  const AccessPathSelectorTree *leaf_access_path_node_;
 };
 
 }  // namespace raksha::ir

--- a/src/ir/access_path_selectors_set.h
+++ b/src/ir/access_path_selectors_set.h
@@ -4,6 +4,7 @@
 #include "access_path_selectors.h"
 
 #include "absl/container/flat_hash_set.h"
+#include "absl/container/flat_hash_map.h"
 
 namespace raksha::ir {
 
@@ -19,51 +20,34 @@ class AccessPathSelectorsSet {
 
   // Allow creating an AccessPathSelectorSet with an explicit list of items
   // that should be in that set.
-  explicit AccessPathSelectorsSet(std::vector<AccessPathSelectors> contents)
-    : inner_vec_(std::move(contents)) {}
+  explicit AccessPathSelectorsSet(
+      absl::flat_hash_map<Selector, std::unique_ptr<AccessPathSelectorTree>>
+      contents)
+    : selector_trees_(std::move(contents)) {}
 
   // Returns a set that is the union of the two passed-in sets.
   static AccessPathSelectorsSet Union(
       AccessPathSelectorsSet set1, AccessPathSelectorsSet set2) {
-    set1.inner_vec_.insert(
-        set1.inner_vec_.end(),
-        std::make_move_iterator(set2.inner_vec_.begin()),
-        std::make_move_iterator(set2.inner_vec_.end()));
+    uint64_t set1_size = set1.selector_trees_.size();
+    uint64_t set2_size = set2.selector_trees_.size();
+    set1.selector_trees_.insert(
+        std::make_move_iterator(set2.selector_trees_.begin()),
+        std::make_move_iterator(set2.selector_trees_.end()));
+    // If the size is not the sum of the sets pre-insertion, then there was a
+    // duplicate key.
+    CHECK(set1.selector_trees_.size() == (set1_size + set2_size))
+      << "Found duplicate selector when unioning two AccessPathSelectorsSets.";
     return set1;
-  }
-
-  // Returns a set that is the intersection of the two passed-in sets.
-  static AccessPathSelectorsSet Intersect(
-      AccessPathSelectorsSet set1, AccessPathSelectorsSet set2) {
-    AccessPathSelectorsSet result;
-
-    // Make the first set into a hash set for efficient lookup.
-    absl::flat_hash_set<AccessPathSelectors> hash_set1 =
-      AccessPathSelectorsSet::CreateAbslSet(std::move(set1));
-
-    // Place items from the second set into the result only if they were in
-    // the first set.
-    for (AccessPathSelectors &path : set2.inner_vec_) {
-      if (hash_set1.contains(path)) {
-        result.inner_vec_.push_back(std::move(path));
-      }
-    }
-
-    return result;
   }
 
   // Returns a set that has the same elements as child_set but with
   // parent_selector added as a parent to each of them.
   static AccessPathSelectorsSet AddParentToAll(
       Selector parent_selector, AccessPathSelectorsSet child_set) {
-    AccessPathSelectorsSet result;
-
-    for (AccessPathSelectors &path : child_set.inner_vec_) {
-      result.inner_vec_.push_back(
-          AccessPathSelectors(parent_selector, std::move(path)));
-    }
-
-    return result;
+    return AccessPathSelectorsSet(
+        { std::make_unique<AccessPathSelectorTree>(
+            std::move(parent_selector),
+            std::move(child_set.selector_trees_)) } );
   }
 
   // Move the contents of the given AccessPathSelectorsSet into a new
@@ -77,13 +61,10 @@ class AccessPathSelectorsSet {
   }
 
  private:
-  // The inner vector implementing the set. It is not guaranteed that the
-  // contents of this vector are unique (although, due to the invariants of
-  // the type tree, we suspect they may well be). It is not guaranteed (and
-  // not expected) that the contents of this vector are sorted. We can get
-  // away with this only because we do not allow access to the contents of
-  // this set until it is requested that we turn it into a flat_hash_set.
-  std::vector<AccessPathSelectors> inner_vec_;
+  // The map from selectors to subtrees. The map is used not for lookup, but
+  // to guarantee that no two subtrees start with the same selector.
+  absl::flat_hash_map<
+      Selector, std::unique_ptr<AccessPathSelectorTree>> selector_trees_;
 };
 
 }  // namespace raksha::ir

--- a/src/ir/selector.h
+++ b/src/ir/selector.h
@@ -39,6 +39,9 @@ class Selector {
   bool operator==(const Selector &other) const {
     return specific_selector_ == other.specific_selector_;
   }
+  bool operator!=(const Selector &other) const {
+    return !(*this == other);
+  }
 
   template<typename H>
   friend H AbslHashValue(H h, const Selector &selector) {


### PR DESCRIPTION
Rather than having an AccessPath be a root combined with a list of
selectors and an AccessPathSelectorSet be a straightforward set of
those AccessPaths, this PR reimagines an AccessPathSelectorSet to be
a tree of selectors with both parent->child pointers and child->parent
pointers. Now, an AccessPath can be viewed as a pointer to a particular
leaf within a tree, and can be printed out by recursing from the leaf to
the root and printing on return. This means that AccessPaths are either
a single pointer or a pair of an AccessPathRoot and a single pointer.

I didn't figure out exactly where these AccessPathSelectorSets should
live (probably somewhere long lived so that we don't have use after
frees when following the pointers in AccessPaths) nor many other
details. But I think this will make copies of AccessPaths less painful
and will make AccessPaths take up a lot less space.