### PR TITLE
Typing interface

### DIFF
--- a/build_defs/raksha.bzl
+++ b/build_defs/raksha.bzl
@@ -92,7 +92,8 @@ def policy_check(name, dataflow_graph, auth_logic, expect_failure = False, visib
             "//src/analysis/souffle:dataflow_graph.dl",
             "//src/analysis/souffle:taint.dl",
             "//src/analysis/souffle:tags.dl",
-            "//src/analysis/souffle:may_will.dl"
+            "//src/analysis/souffle:may_will.dl",
+            "//src/analysis/souffle:auth_logic_type_interface.dl"
         ]
     )
     native.cc_test(

--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -26,6 +26,7 @@ souffle_cc_library(
     src = "taint.dl",
     included_dl_scripts = [
         "authorization_logic.dl",
+        "auth_logic_type_interface.dl",
         "dataflow_graph.dl",
         "tags.dl",
     ],
@@ -33,6 +34,7 @@ souffle_cc_library(
 
 exports_files([
     "authorization_logic.dl",
+    "auth_logic_type_interface.dl",
     "dataflow_graph.dl",
     "fact_test_helper.dl",
     "tags.dl",

--- a/src/analysis/souffle/auth_logic_type_interface.dl
+++ b/src/analysis/souffle/auth_logic_type_interface.dl
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+// This file provides an interface that applies types to the untyped relations 
+// from authorization logic.
+
+
+#ifndef SRC_ANALYSIS_SOUFFLE_AUTHORIZATION_LOGIC_TYPE_INTERFACE_DL_
+#define SRC_ANALYSIS_SOUFFLE_AUTHORIZATION_LOGIC_TYPE_INTERFACE_DL_
+
+#include "dataflow_graph.dl"
+#include "authorization_logic.dl"
+#include "tags.dl"
+
+.decl says_removeTag(speaker: symbol, path: symbol, tag: symbol)
+.decl says_ownsTag(speaker: symbol, path: symbol, tag: symbol)
+.decl says_hasTag(speaker: symbol, path: symbol, tag: symbol)
+.decl says_may(speaker: symbol, actor: symbol, usage: symbol, tag: symbol)
+.decl says_will(speaker: symbol, usage: symbol, path: symbol)
+
+saysRemoveTag(as(speaker, Principal), as(path, AccessPath), as(tag, Tag)) :-
+    says_removeTag(speaker, path, tag).
+
+saysOwnsTag(as(speaker, Principal), as(owner, Principal), as(tag, Tag)) :-
+    says_ownsTag(speaker, owner, tag).
+
+saysHasTag(as(speaker, Principal), as(path, AccessPath), as(tag, Tag)) :-
+    says_hasTag(speaker, path, tag).
+
+saysMay(as(speaker, Principal), as(actor, Principal), as(usage, Usage),
+    as(tag, Tag)) :- says_may(speaker, actor, usage, tag).
+
+saysWill(as(speaker, Principal), as(usage, Usage), as(path, AccessPath)) :-
+    says_will(speaker, usage, path).
+
+#endif //SRC_ANALYSIS_SOUFFLE_AUTHORIZATION_LOGIC_TYPE_INTERFACE_DL_

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -28,34 +28,17 @@
 
 // Some party asserts the claim that the label of an access path should
 // remove the referenced tag from the set.
-.decl says_removeTag(speaker: Principal, path: AccessPath, tag: Tag)
-
-// The `speaker` says that `delegatee` is allowed to indicate that a `path` does
-// not have a `tag`.
-.decl says_canSay_removeTag(
-  speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
-
-// Indicates that a speaker is allowed to say removeTag.
-.decl canSayRemoveTag(speaker: Principal, path: AccessPath, tag: Tag)
+.decl saysRemoveTag(speaker: Principal, path: AccessPath, tag: Tag)
 
 .decl isPrincipal(principal: Principal)
 
 // This party is the owner of a taint Tag (they have the privilege to remove
 // it).
 .decl ownsTag(owner: Principal, tag: Tag)
-
-.decl says_ownsTag(speaker: Principal, owner: Principal, tag: Tag)
+.decl saysOwnsTag(speaker: Principal, owner: Principal, tag: Tag)
 
 // The `speaker` says that `path` definitely has `tag` taint.
-.decl says_hasTag(speaker: Principal, path: AccessPath, tag: Tag)
-
-// The `speaker` says that the `delegatee` can say that `path` has `tag`.
-.decl says_canSay_hasTag(
-  speaker: Principal, delegatee: Principal, path: AccessPath, tag: Tag)
-
-// Indicates that a speaker is allowed to say a path has a particular tag.
-.decl canSayHasTag(speaker: Principal, path: AccessPath, tag: Tag)
-
+.decl saysHasTag(speaker: Principal, path: AccessPath, tag: Tag)
 // Indicates that a `tag` is definitely present upon a `path` because a speaker
 // delegated to by the owner said so.
 .decl hasTag(path: AccessPath, tag: Tag)
@@ -66,41 +49,23 @@
 // by the subset or equals relation), removing a tag from the set corresponds to
 // a downgrade by making set of tags on the access path "lower" in the order.
 .decl removeTag(path: AccessPath, tag: Tag)
+removeTag(path, tag) :- ownsTag(speaker, tag),
+    saysRemoveTag(speaker, path, tag).
 
 //-----------------------------------------------------------------------------
 // Rules
 //-----------------------------------------------------------------------------
 
-// The owner can always say removeTag.
-canSayRemoveTag(speaker, path, tag) :-
-    isAccessPath(path), ownsTag(speaker, tag).
-
-// If the owner says a speaker can say removeTag, the speaker can say
-// removeTag.
-canSayRemoveTag(speaker, path, tag) :-
-  ownsTag(owner, tag), says_canSay_removeTag(owner, speaker, path, tag).
-
-removeTag(path, tag) :-
-    canSayRemoveTag(speaker, path, tag), says_removeTag(speaker, path, tag).
-
-// The owner can say the tag is present anywhere.
-canSayHasTag(speaker, path, tag) :- isAccessPath(path), ownsTag(speaker, tag).
-
-// The speaker can also speak about the tag if the owner said so.
-canSayHasTag(speaker, path, tag) :-
-  ownsTag(owner, tag), says_canSay_hasTag(owner, speaker, path, tag).
-
 // The path has a tag if an authorized speaker says it does.
 hasTag(path, tag) :-
-  says_hasTag(speaker, path, tag), canSayHasTag(speaker, path, tag).
-
+  saysHasTag(speaker, path, tag), ownsTag(speaker, tag).
 // This rule says that any principal can say that another principal owns a tag.
 // This rule is just a starting point to allow all aspects of the policy to
 // come from authorization logic -- it is just a simple way to generate
 // ownsTag from something with a speaker. This rule is likely to change. It
 // does not rule out the case that two different principals claim ownership of
 // a tag.
-ownsTag(owner, tag) :- says_ownsTag(_, owner, tag).
+ownsTag(owner, tag) :- saysOwnsTag(_, owner, tag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -77,7 +77,7 @@
 //      permission for edge removal indirectly by granting permission to remove
 //      tags (abstract representations of their data).
 
-says_removeTag(principal, midpoint, tag) :-
+saysRemoveTag(principal, midpoint, tag) :-
   isTag(tag), claimNotEdge(principal, src, tgt), edgeToMidpointAccessPath(src, tgt, midpoint).
 
 mayHaveTag(tgt, tag) :- hasTag(tgt, tag).
@@ -92,12 +92,12 @@ mayHaveTag(tgt, tag) :-
 // `isObject(..)`) whenever they are mentioned in other rules.
 
 // Any Principal used in a claim is in the universe of isPrincipal.
-isPrincipal(principal) :- says_hasTag(principal, _, _).
+isPrincipal(principal) :- saysHasTag(principal, _, _).
 
-isAccessPath(path) :- says_hasTag(_, path, _).
+isAccessPath(path) :- saysHasTag(_, path, _).
 
 // Symbols used in hasTag or mayHaveTag are tags
-isTag(tag) :- says_hasTag(_, _, tag).
+isTag(tag) :- saysHasTag(_, _, tag).
 
 // A pair of (base, member) is in this set if the base access path is a non-trivial subpath of the
 // member access path.

--- a/src/analysis/souffle/tests/arcs_fact_tests/claim_not_edge_two_inputs_two_outputs.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/claim_not_edge_two_inputs_two_outputs.dl
@@ -22,8 +22,8 @@ isPrincipal("ParticleX").
 ownsTag("Claimer", "tag1").
 ownsTag("Claimer", "tag2").
 
-says_hasTag("Claimer", "R.foo.hc1", "tag1").
-says_hasTag("Claimer", "R.foo.hc2", "tag2").
+saysHasTag("Claimer", "R.foo.hc1", "tag1").
+saysHasTag("Claimer", "R.foo.hc2", "tag2").
 
 // ParticleX claims that hc2 does not flow to hco1.
 // TODO(#146) In the case where we expect this claim to be upheld, how does that

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_check_on_subpaths.dl
@@ -22,8 +22,8 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-says_hasTag("P1", "R.P1.foo.a", "userSelection").
-says_hasTag("P1", "R.P1.foo.b", "screenContent").
+saysHasTag("P1", "R.P1.foo.a", "userSelection").
+saysHasTag("P1", "R.P1.foo.b", "screenContent").
 
 edge("R.P1.foo.a", "R.h.Foo.a").
 edge("R.P1.foo.b", "R.h.Foo.b").

--- a/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fail_different_tag.dl
@@ -21,7 +21,7 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-says_hasTag("P1", "R.P1.foo", "userSelection").
+saysHasTag("P1", "R.P1.foo", "userSelection").
 edge("R.P1.foo", "R.h.Foo").
 edge("R.h.Foo", "R.P2.bar").
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates.dl
@@ -25,7 +25,7 @@
 #include "taint.dl"
 #include "fact_test_helper.dl"
 
-says_hasTag("P1", "R.P1.foo", "userSelection").
+saysHasTag("P1", "R.P1.foo", "userSelection").
 edge("R.P1.foo", "R.h1.Foo").
 edge("R.h1.Foo", "R.P2.bar").
 edge("R.P2.bar", "R.P2.foo").

--- a/src/xform_to_datalog/authorization_logic_datalog_facts.cc
+++ b/src/xform_to_datalog/authorization_logic_datalog_facts.cc
@@ -41,9 +41,7 @@ AuthorizationLogicDatalogFacts::create(
   constexpr absl::string_view kRelationsToNotDeclare[] = {
       "says_ownsTag",
       "says_hasTag",
-      "says_canSay_hasTag",
       "says_removeTag",
-      "says_canSay_removeTag",
       "says_may",
       "says_will",
       "isAccessPath",

--- a/src/xform_to_datalog/datalog_facts.h
+++ b/src/xform_to_datalog/datalog_facts.h
@@ -58,6 +58,7 @@ class DatalogFacts {
 
 #include "taint.dl"
 #include "may_will.dl"
+#include "auth_logic_type_interface.dl"
 
 // Rules for detecting policy failures.
 .decl testFails(check_index: symbol)
@@ -77,11 +78,6 @@ testFails(check_index) :-
   isCheck(check_index), !check(check_index).
 
 testFails("may_will") :- disallowedUsage(_, _, _). 
-
-.decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
-.decl says_will(speaker: Principal, usage: Usage, path: AccessPath)
-saysMay(w, x, y, z) :- says_may(w, x, y, z).
-saysWill(w, x, y) :- says_will(w, x, y).
 
 // Manifest
 %s

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -47,6 +47,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 #include "taint.dl"
 #include "may_will.dl"
+#include "auth_logic_type_interface.dl"
 
 // Rules for detecting policy failures.
 .decl testFails(check_index: symbol)
@@ -66,11 +67,6 @@ testFails(check_index) :-
   isCheck(check_index), !check(check_index).
 
 testFails("may_will") :- disallowedUsage(_, _, _). 
-
-.decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
-.decl says_will(speaker: Principal, usage: Usage, path: AccessPath)
-saysMay(w, x, y, z) :- says_may(w, x, y, z).
-saysWill(w, x, y) :- says_will(w, x, y).
 
 // Manifest
 
@@ -105,6 +101,7 @@ grounded_dummy("dummy_var").
 
 #include "taint.dl"
 #include "may_will.dl"
+#include "auth_logic_type_interface.dl"
 
 // Rules for detecting policy failures.
 .decl testFails(check_index: symbol)
@@ -124,11 +121,6 @@ testFails(check_index) :-
   isCheck(check_index), !check(check_index).
 
 testFails("may_will") :- disallowedUsage(_, _, _). 
-
-.decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
-.decl says_will(speaker: Principal, usage: Usage, path: AccessPath)
-saysMay(w, x, y, z) :- says_may(w, x, y, z).
-saysWill(w, x, y) :- says_will(w, x, y).
 
 // Manifest
 

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -2,6 +2,7 @@
 
 #include "taint.dl"
 #include "may_will.dl"
+#include "auth_logic_type_interface.dl"
 
 // Rules for detecting policy failures.
 .decl testFails(check_index: symbol)
@@ -21,11 +22,6 @@ testFails(check_index) :-
   isCheck(check_index), !check(check_index).
 
 testFails("may_will") :- disallowedUsage(_, _, _). 
-
-.decl says_may(speaker: Principal, actor: Principal, usage: Usage, tag: Tag)
-.decl says_will(speaker: Principal, usage: Usage, path: AccessPath)
-saysMay(w, x, y, z) :- says_may(w, x, y, z).
-saysWill(w, x, y) :- says_will(w, x, y).
 
 // Manifest
 


### PR DESCRIPTION
This fixes the typing interface between authorization logic and the
raksha taint analysis and IR. 

This will conflict with
[#215](https://github.com/google-research/raksha/pull/215), so I will
likely need to redo this later. Even after 215, I think this fix is
still needed in order to handle cases like the following, where in the
authorization logic there is a user-defined relation on the RHS that is used to
prove one of the facts beginning with "says" in Raksha:

```
"P1" saysHasTag("some.path", "someTag") :-
    someUserDefinedRelation("some.path", "someTag").
```

which produce the declaration:

```
.decl speaker_someUserDefinedRelation(x1: symbol, x2: symbol,
    x3: symbol)
```

which will cause a type error without an interface fix like this one.