### PR TITLE
Print datalog without instantiation of access paths. 

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -22,6 +22,7 @@ load("//build_defs:test_helpers.bzl", "extracted_datalog_string_test")
 cc_library(
     name = "ir",
     srcs = [
+        "access_path_root.cc",
         "particle_spec.cc",
         "predicate.cc",
     ],
@@ -31,9 +32,9 @@ cc_library(
         "edge.h",
         "handle_connection_spec.h",
         "particle_spec.h",
-        "system_spec.h",
         "predicate.h",
         "predicate_arena.h",
+        "system_spec.h",
         "tag_check.h",
         "tag_claim.h",
     ],
@@ -153,7 +154,7 @@ cc_test(
     deps = [
         ":ir",
         "//src/common/testing:gtest",
-    ]
+    ],
 )
 
 cc_test(

--- a/src/ir/access_path.h
+++ b/src/ir/access_path.h
@@ -24,6 +24,13 @@ class AccessPath {
     return absl::StrCat(root_.ToString(), access_path_selectors_.ToString());
   }
 
+  // Express the AccessPath as a string. This is accomplished by
+  // concatenating the root string and the selectors string.
+  std::string ToDatalog(const DatalogPrintContext &ctxt) const {
+    return absl::StrCat(root_.ToDatalog(ctxt),
+                        access_path_selectors_.ToString());
+  }
+
   // Return a new AccessPath, identical to *this, except with the AccessPath
   // root replaced with the indicated instantiated root. Note that this expects
   // the current access path to not already be instantiated.

--- a/src/ir/access_path.h
+++ b/src/ir/access_path.h
@@ -24,7 +24,7 @@ class AccessPath {
     return absl::StrCat(root_.ToString(), access_path_selectors_.ToString());
   }
 
-  // Express the AccessPath as a string. This is accomplished by
+  // Express the AccessPath as a datalog string. This is accomplished by
   // concatenating the root string and the selectors string.
   std::string ToDatalog(const DatalogPrintContext &ctxt) const {
     return absl::StrCat(root_.ToDatalog(ctxt),

--- a/src/ir/access_path_root.cc
+++ b/src/ir/access_path_root.cc
@@ -1,0 +1,34 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+#include "src/ir/access_path_root.h"
+
+#include "src/ir/datalog_print_context.h"
+
+// The classes in this file describe the root of an AccessPath. At the moment,
+// we have only two types of roots: a HandleConnectionSpecAccessPathRoot and
+// a HandleConnectionAccessPathRoot, describing a HandleConnectionSpec in a
+// ParticleSpec and a Handle in a Particle, respectively.
+namespace raksha::ir {
+
+std::string AccessPathRoot::ToDatalog(const DatalogPrintContext &ctxt) const {
+  const auto *instantiation_map = ctxt.instantiation_map();
+  if (instantiation_map == nullptr) return this->ToString();
+  auto find_res = instantiation_map->find(*this);
+  return (find_res != instantiation_map->end()) ? find_res->second.ToString()
+                                                : this->ToString();
+}
+
+}  // namespace raksha::ir

--- a/src/ir/access_path_root.h
+++ b/src/ir/access_path_root.h
@@ -27,6 +27,8 @@
 // ParticleSpec and a Handle in a Particle, respectively.
 namespace raksha::ir {
 
+class DatalogPrintContext;
+
 // A HandleConnectionSpecAccessPathRoot describes the root as a
 // HandleConnectionSpec in a ParticleSpec. We consider this uninstantiated as
 // ParticleSpecs are abstract Particles which may be instantiated in multiple
@@ -181,6 +183,8 @@ class AccessPathRoot {
     return std::visit(
         [](const auto &variant){ return variant.ToString(); }, specific_root_);
   }
+
+  std::string ToDatalog(const DatalogPrintContext &ctxt) const;
 
   // Dispatch IsInstantiated to the specific kind of AccessPathRoot.
   bool IsInstantiated() const {

--- a/src/ir/datalog_print_context.h
+++ b/src/ir/datalog_print_context.h
@@ -17,7 +17,9 @@
 #ifndef SRC_IR_DATALOG_PRINT_CONTEXT_H_
 #define SRC_IR_DATALOG_PRINT_CONTEXT_H_
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_cat.h"
+#include "src/ir/access_path_root.h"
 
 namespace raksha::ir {
 
@@ -26,7 +28,7 @@ namespace raksha::ir {
 // unique labels.
 class DatalogPrintContext {
  public:
-  DatalogPrintContext() : check_counter_(0) {}
+  DatalogPrintContext() : check_counter_(0), instantiation_map_(nullptr) {}
 
   // DatalogPrintContext is not copyable, as we need a single copy to be the
   // source of truth on creating unique labels. It is, however, movable.
@@ -37,8 +39,22 @@ class DatalogPrintContext {
   std::string GetUniqueCheckLabel() {
     return absl::StrCat("check_num_", check_counter_++);
   }
+
+  void set_instantiation_map(
+      const absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
+          *instantiation_map) {
+    instantiation_map_ = instantiation_map;
+  }
+
+  const absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
+      *instantiation_map() const {
+    return instantiation_map_;
+  }
+
  private:
   uint64_t check_counter_;
+  const absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
+      *instantiation_map_;
 };
 
 }  // namespace raksha::ir

--- a/src/ir/edge.h
+++ b/src/ir/edge.h
@@ -32,9 +32,10 @@ class Edge {
     : from_(std::move(from)), to_(std::move(to)) {}
 
   // Print the edge as a string containing a Datalog fact.
-  std::string ToDatalog(DatalogPrintContext &) const {
+  std::string ToDatalog(DatalogPrintContext &ctxt) const {
     constexpr absl::string_view kEdgeFormat = R"(edge("%s", "%s").)";
-    return absl::StrFormat(kEdgeFormat, from_.ToString(), to_.ToString());
+    return absl::StrFormat(kEdgeFormat, from_.ToDatalog(ctxt),
+                           to_.ToDatalog(ctxt));
   }
 
   bool operator==(const Edge &other) const {

--- a/src/ir/predicate_test.cc
+++ b/src/ir/predicate_test.cc
@@ -20,9 +20,10 @@
 #include "absl/strings/substitute.h"
 #include "google/protobuf/text_format.h"
 #include "src/common/testing/gtest.h"
-#include "src/ir/single-use-arena-and-predicate.h"
+#include "src/ir/datalog_print_context.h"
 #include "src/ir/predicate_textproto_to_rule_body_testdata.h"
 #include "src/ir/proto/predicate.h"
+#include "src/ir/single-use-arena-and-predicate.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
@@ -52,12 +53,13 @@ class ToDatalogRuleBodyTest :
 };
 
 TEST_P(ToDatalogRuleBodyTest, ToDatalogRuleBodyTest) {
+  DatalogPrintContext ctxt;
   arcs::InformationFlowLabelProto_Predicate predicate_proto;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       textproto_, &predicate_proto));
   const Predicate &predicate = *predicate_decoder_.Decode(predicate_proto);
   EXPECT_EQ(
-      predicate.ToDatalogRuleBody(access_path_), expected_rule_body_);
+      predicate.ToDatalogRuleBody(access_path_, ctxt), expected_rule_body_);
 }
 
 // Helper for making AccessPaths.

--- a/src/ir/tag_check.h
+++ b/src/ir/tag_check.h
@@ -58,8 +58,8 @@ class TagCheck {
   ownsAccessPath(owner, "$1"), $2.)";
     std::string check_label = ctxt.GetUniqueCheckLabel();
     return absl::Substitute(kCheckHasTagFormat, check_label,
-                            access_path_.ToString(),
-                            predicate_->ToDatalogRuleBody(access_path_));
+                            access_path_.ToDatalog(ctxt),
+                            predicate_->ToDatalogRuleBody(access_path_, ctxt));
   }
 
   bool operator==(const TagCheck &other) const {

--- a/src/ir/tag_claim.h
+++ b/src/ir/tag_claim.h
@@ -63,14 +63,14 @@ class TagClaim {
   }
 
   // Produce a string containing a datalog fact for this TagClaim.
-  std::string ToDatalog(DatalogPrintContext &) const {
+  std::string ToDatalog(DatalogPrintContext &ctxt) const {
     constexpr absl::string_view kClaimTagFormat =
         R"(%s("%s", "%s", owner, "%s") :- ownsAccessPath(owner, "%s").)";
     absl::string_view relation_name =
         (claim_tag_is_present_) ? "says_hasTag" : "says_removeTag";
     return absl::StrFormat(
         kClaimTagFormat, relation_name, claiming_particle_name_,
-        access_path_.ToString(), tag_, access_path_.ToString());
+        access_path_.ToDatalog(ctxt), tag_, access_path_.ToDatalog(ctxt));
   }
 
   bool operator==(const TagClaim &other) const {

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -36,10 +36,24 @@ TEST_P(DatalogFactsTest, IncludesManifestFactsWithCorrectPrefixAndSuffix) {
   EXPECT_EQ(datalog_facts.ToDatalog(ctxt), expected_string);
 }
 
+static std::unique_ptr<ir::ParticleSpec> particle_spec(ir::ParticleSpec::Create(
+    "particle",
+    /*checks=*/{},
+    /*tag_claims=*/
+    {ir::TagClaim(
+        "particle",
+        ir::AccessPath(ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
+                           "recipe", "particle", "out")),
+                       ir::AccessPathSelectors()),
+        true, "tag")},
+    /*derives_from_claims=*/{},
+    /*edges=*/{},
+    /*predicate_arena=*/nullptr));
+
 INSTANTIATE_TEST_SUITE_P(
     DatalogFactsTest, DatalogFactsTest,
     testing::Values(
-        std::make_tuple(ManifestDatalogFacts({}, {}, {}),
+        std::make_tuple(ManifestDatalogFacts({}, {}, {}, {}),
                         *(AuthorizationLogicDatalogFacts::create(
                             AuthorizationLogicTest::GetTestDataDir(),
                             "empty_auth_logic")),
@@ -73,12 +87,9 @@ saysMay(w, x, y, z) :- says_may(w, x, y, z).
 saysWill(w, x, y) :- says_will(w, x, y).
 
 // Manifest
-
 // Claims:
 
-
 // Checks:
-
 
 // Edges:
 
@@ -90,6 +101,7 @@ grounded_dummy("dummy_var").
 )"),
         std::make_tuple(
             ManifestDatalogFacts(
+                {ManifestDatalogFacts::Particle(particle_spec.get(), {}, {})},
                 {ir::TagClaim(
                     "particle",
                     ir::AccessPath(
@@ -99,8 +111,7 @@ grounded_dummy("dummy_var").
                     true, "tag")},
                 {}, {}),
             *(AuthorizationLogicDatalogFacts::create(
-                AuthorizationLogicTest::GetTestDataDir(),
-                "simple_auth_logic")),
+                AuthorizationLogicTest::GetTestDataDir(), "simple_auth_logic")),
             R"(// GENERATED FILE, DO NOT EDIT!
 
 #include "taint.dl"
@@ -131,12 +142,10 @@ saysMay(w, x, y, z) :- says_may(w, x, y, z).
 saysWill(w, x, y) :- says_will(w, x, y).
 
 // Manifest
-
 // Claims:
 says_hasTag("particle", "recipe.particle.out", owner, "tag") :- ownsAccessPath(owner, "recipe.particle.out").
 
 // Checks:
-
 
 // Edges:
 

--- a/src/xform_to_datalog/datalog_facts_test.cc
+++ b/src/xform_to_datalog/datalog_facts_test.cc
@@ -53,7 +53,7 @@ static std::unique_ptr<ir::ParticleSpec> particle_spec(ir::ParticleSpec::Create(
 INSTANTIATE_TEST_SUITE_P(
     DatalogFactsTest, DatalogFactsTest,
     testing::Values(
-        std::make_tuple(ManifestDatalogFacts({}, {}, {}, {}),
+        std::make_tuple(ManifestDatalogFacts(),
                         *(AuthorizationLogicDatalogFacts::create(
                             AuthorizationLogicTest::GetTestDataDir(),
                             "empty_auth_logic")),
@@ -99,20 +99,12 @@ saysWill(w, x, y) :- says_will(w, x, y).
 grounded_dummy("dummy_var").
 
 )"),
-        std::make_tuple(
-            ManifestDatalogFacts(
-                {ManifestDatalogFacts::Particle(particle_spec.get(), {}, {})},
-                {ir::TagClaim(
-                    "particle",
-                    ir::AccessPath(
-                        ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
-                            "recipe", "particle", "out")),
-                        ir::AccessPathSelectors()),
-                    true, "tag")},
-                {}, {}),
-            *(AuthorizationLogicDatalogFacts::create(
-                AuthorizationLogicTest::GetTestDataDir(), "simple_auth_logic")),
-            R"(// GENERATED FILE, DO NOT EDIT!
+        std::make_tuple(ManifestDatalogFacts({ManifestDatalogFacts::Particle(
+                            particle_spec.get(), {}, {})}),
+                        *(AuthorizationLogicDatalogFacts::create(
+                            AuthorizationLogicTest::GetTestDataDir(),
+                            "simple_auth_logic")),
+                        R"(// GENERATED FILE, DO NOT EDIT!
 
 #include "taint.dl"
 #include "may_will.dl"

--- a/src/xform_to_datalog/manifest_datalog_facts.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts.cc
@@ -37,9 +37,6 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
     const arcs::ManifestProto &manifest_proto) {
   // These collections will be used as inputs to the constructor that we
   // return from this function.
-  std::vector<ir::TagClaim> result_claims;
-  std::vector<ir::TagCheck> result_checks;
-  std::vector<ir::Edge> result_edges;
   std::vector<Particle> particle_instances;
 
   // This loop looks at each recipe in the manifest proto and instantiates
@@ -154,31 +151,13 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
         }
       }
 
-
       particle_instances.push_back(Particle(&particle_spec,
                                             std::move(instantiation_map),
                                             std::move(particle_edges)));
-
-      // ir::InstantiatedParticleSpecFacts particle_spec_facts =
-      //     particle_spec.BulkInstantiate(instantiation_map);
-      // result_claims.insert(
-      //     result_claims.end(),
-      //     std::move_iterator(particle_spec_facts.tag_claims.begin()),
-      //     std::move_iterator(particle_spec_facts.tag_claims.end()));
-      // result_checks.insert(
-      //   result_checks.end(),
-      //   std::move_iterator(particle_spec_facts.checks.begin()),
-      //   std::move_iterator(particle_spec_facts.checks.end()));
-      // result_edges.insert(
-      //   result_edges.end(),
-      //   std::move_iterator(particle_spec_facts.edges.begin()),
-      //   std::move_iterator(particle_spec_facts.edges.end()));
     }
   }
 
-  return ManifestDatalogFacts(
-      std::move(particle_instances), std::move(result_claims),
-      std::move(result_checks), std::move(result_edges));
+  return ManifestDatalogFacts(std::move(particle_instances));
 }
 
 }  // namespace raksha::xform_to_datalog

--- a/src/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/xform_to_datalog/manifest_datalog_facts.h
@@ -69,14 +69,8 @@ class ManifestDatalogFacts {
   // ManifestDatalogFacts are embedded.
   ManifestDatalogFacts() {}
 
-  ManifestDatalogFacts(std::vector<Particle> particle_instances,
-                       std::vector<raksha::ir::TagClaim> claims,
-                       std::vector<raksha::ir::TagCheck> checks,
-                       std::vector<raksha::ir::Edge> edges)
-      : particle_instances_(std::move(particle_instances)),
-        claims_(std::move(claims)),
-        checks_(std::move(checks)),
-        edges_(std::move(edges)) {}
+  ManifestDatalogFacts(std::vector<Particle> particle_instances)
+      : particle_instances_(std::move(particle_instances)) {}
 
   // Print out all contained facts as a single datalog string. Note: this
   // does not contain the header files that would be necessary to run this
@@ -115,12 +109,6 @@ class ManifestDatalogFacts {
     return result;
   }
 
-  const std::vector<raksha::ir::TagClaim> &claims() const { return claims_; }
-
-  const std::vector<raksha::ir::TagCheck> &checks() const { return checks_; }
-
-  const std::vector<raksha::ir::Edge> &edges() const { return edges_; }
-
  private:
   // Appends the list of elements as newline separated strings to target.
   template <typename T, typename U>
@@ -134,9 +122,6 @@ class ManifestDatalogFacts {
   }
 
   std::vector<Particle> particle_instances_;
-  std::vector<raksha::ir::TagClaim> claims_;
-  std::vector<raksha::ir::TagCheck> checks_;
-  std::vector<raksha::ir::Edge> edges_;
 };
 
 }  // namespace raksha::xform_to_datalog

--- a/src/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/xform_to_datalog/manifest_datalog_facts.h
@@ -20,17 +20,46 @@
 #include <vector>
 
 #include "absl/strings/str_format.h"
+#include "src/ir/datalog_print_context.h"
 #include "src/ir/edge.h"
+#include "src/ir/particle_spec.h"
+#include "src/ir/system_spec.h"
 #include "src/ir/tag_check.h"
 #include "src/ir/tag_claim.h"
-#include "src/ir/datalog_print_context.h"
-#include "src/ir/system_spec.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::xform_to_datalog {
 
 class ManifestDatalogFacts {
  public:
+  // A hacky class with just enough information about a particle instances for
+  // the purpose of datalog generation. Specifically, instantiation_map is
+  // passed to the `ToDatalog` methods. When the data structures are all fleshed
+  // out, this class will no longer be needed and therefore, can be
+  // removed. Further, datalog generation would be implemented as a visitor
+  // where the instance of a particle will be clear from the visit context.
+  class Particle {
+   public:
+    Particle(const raksha::ir::ParticleSpec *spec,
+             absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
+                 &&instantiation_map,
+             std::vector<ir::Edge> &&edges)
+        : spec_(spec),
+          instantiation_map_(instantiation_map),
+          edges_(edges) {}
+
+    const raksha::ir::ParticleSpec *spec() const { return spec_; }
+    const absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>&
+        instantiation_map() const { return instantiation_map_; }
+    const std::vector<ir::Edge> &edges() const { return edges_; }
+
+   private:
+    const raksha::ir::ParticleSpec *spec_;
+    absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
+        instantiation_map_;
+    std::vector<ir::Edge> edges_;
+  };
+
   static ManifestDatalogFacts CreateFromManifestProto(
       const ir::SystemSpec& system_spec,
       const arcs::ManifestProto &manifest_proto);
@@ -40,24 +69,50 @@ class ManifestDatalogFacts {
   // ManifestDatalogFacts are embedded.
   ManifestDatalogFacts() {}
 
-  ManifestDatalogFacts(
-      std::vector<raksha::ir::TagClaim> claims,
-      std::vector<raksha::ir::TagCheck> checks,
-      std::vector<raksha::ir::Edge> edges)
-      : claims_(std::move(claims)), checks_(std::move(checks)),
+  ManifestDatalogFacts(std::vector<Particle> particle_instances,
+                       std::vector<raksha::ir::TagClaim> claims,
+                       std::vector<raksha::ir::TagCheck> checks,
+                       std::vector<raksha::ir::Edge> edges)
+      : particle_instances_(std::move(particle_instances)),
+        claims_(std::move(claims)),
+        checks_(std::move(checks)),
         edges_(std::move(edges)) {}
 
   // Print out all contained facts as a single datalog string. Note: this
   // does not contain the header files that would be necessary to run this
   // against the datalog scripts; it contains only facts and comments.
-  std::string ToDatalog(raksha::ir::DatalogPrintContext &ctxt) const {
+  std::string ToDatalog(raksha::ir::DatalogPrintContext &ctxt,
+                        std::string separator = "\n") const {
     auto todatalog_formatter = [&](std::string *out, const auto &arg) {
-      out->append(arg.ToDatalog(ctxt)); };
-    return absl::StrFormat(
-        kFactOutputFormat,
-        absl::StrJoin(claims_, "\n", todatalog_formatter),
-        absl::StrJoin(checks_, "\n", todatalog_formatter),
-        absl::StrJoin(edges_, "\n", todatalog_formatter));
+      out->append(arg.ToDatalog(ctxt));
+    };
+    std::string claims_string;
+    std::string checks_string;
+    std::string edges_string;
+    for (const auto &particle : particle_instances_) {
+      ctxt.set_instantiation_map(&particle.instantiation_map());
+      AppendElements(&claims_string, particle.spec()->tag_claims(), separator,
+                     todatalog_formatter);
+      AppendElements(&checks_string, particle.spec()->checks(), separator,
+                     todatalog_formatter);
+      AppendElements(&edges_string, particle.edges(), separator,
+                     todatalog_formatter);
+      AppendElements(&edges_string, particle.spec()->edges(), separator,
+                     todatalog_formatter);
+    }
+
+    // Assemble the output and return the result.
+    std::string result;
+    absl::StrAppend(&result, absl::StrFormat("// Claims:%s", separator));
+    absl::StrAppend(&result, claims_string);
+    absl::StrAppend(&result, separator);
+    absl::StrAppend(&result, absl::StrFormat("// Checks:%s", separator));
+    absl::StrAppend(&result, checks_string);
+    absl::StrAppend(&result, separator);
+    absl::StrAppend(&result, absl::StrFormat("// Edges:%s", separator));
+    absl::StrAppend(&result, edges_string);
+    absl::StrAppend(&result, separator);
+    return result;
   }
 
   const std::vector<raksha::ir::TagClaim> &claims() const { return claims_; }
@@ -67,17 +122,18 @@ class ManifestDatalogFacts {
   const std::vector<raksha::ir::Edge> &edges() const { return edges_; }
 
  private:
-  static constexpr absl::string_view kFactOutputFormat = R"(
-// Claims:
-%s
+  // Appends the list of elements as newline separated strings to target.
+  template <typename T, typename U>
+  static void AppendElements(std::string *target, const T &elements,
+                             const std::string& separator,
+                             const U &formatter) {
+    absl::StrAppend(target, absl::StrJoin(elements, separator, formatter));
+    if (!elements.empty()) {
+      absl::StrAppend(target, separator);
+    }
+  }
 
-// Checks:
-%s
-
-// Edges:
-%s
-)";
-
+  std::vector<Particle> particle_instances_;
   std::vector<raksha::ir::TagClaim> claims_;
   std::vector<raksha::ir::TagCheck> checks_;
   std::vector<raksha::ir::Edge> edges_;

--- a/src/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/xform_to_datalog/manifest_datalog_facts.h
@@ -77,44 +77,40 @@ class ManifestDatalogFacts {
   // against the datalog scripts; it contains only facts and comments.
   std::string ToDatalog(raksha::ir::DatalogPrintContext &ctxt,
                         std::string separator = "\n") const {
-    auto todatalog_formatter = [&](std::string *out, const auto &arg) {
-      out->append(arg.ToDatalog(ctxt));
-    };
-    std::string claims_string;
-    std::string checks_string;
-    std::string edges_string;
+    std::string claims;
+    std::string checks;
+    std::string edges;
     for (const auto &particle : particle_instances_) {
       ctxt.set_instantiation_map(&particle.instantiation_map());
-      AppendElements(&claims_string, particle.spec()->tag_claims(), separator,
-                     todatalog_formatter);
-      AppendElements(&checks_string, particle.spec()->checks(), separator,
-                     todatalog_formatter);
-      AppendElements(&edges_string, particle.edges(), separator,
-                     todatalog_formatter);
-      AppendElements(&edges_string, particle.spec()->edges(), separator,
-                     todatalog_formatter);
+      AppendElements(&claims, ctxt, particle.spec()->tag_claims(), separator);
+      AppendElements(&checks, ctxt, particle.spec()->checks(), separator);
+      AppendElements(&edges, ctxt, particle.edges(), separator);
+      AppendElements(&edges, ctxt, particle.spec()->edges(), separator);
     }
 
     // Assemble the output and return the result.
     std::string result;
     absl::StrAppend(&result, absl::StrFormat("// Claims:%s", separator));
-    absl::StrAppend(&result, claims_string);
+    absl::StrAppend(&result, claims);
     absl::StrAppend(&result, separator);
     absl::StrAppend(&result, absl::StrFormat("// Checks:%s", separator));
-    absl::StrAppend(&result, checks_string);
+    absl::StrAppend(&result, checks);
     absl::StrAppend(&result, separator);
     absl::StrAppend(&result, absl::StrFormat("// Edges:%s", separator));
-    absl::StrAppend(&result, edges_string);
+    absl::StrAppend(&result, edges);
     absl::StrAppend(&result, separator);
     return result;
   }
 
  private:
   // Appends the list of elements as newline separated strings to target.
-  template <typename T, typename U>
-  static void AppendElements(std::string *target, const T &elements,
-                             const std::string& separator,
-                             const U &formatter) {
+  template <typename T>
+  static void AppendElements(std::string *target,
+                             raksha::ir::DatalogPrintContext &ctxt,
+                             const T &elements, const std::string &separator) {
+    auto formatter = [&ctxt](std::string *out, const auto &arg) {
+      out->append(arg.ToDatalog(ctxt));
+    };
     absl::StrAppend(target, absl::StrJoin(elements, separator, formatter));
     if (!elements.empty()) {
       absl::StrAppend(target, separator);

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -100,15 +100,11 @@ static std::tuple<ManifestDatalogFacts, std::string>
                  {ir::AccessPathRoot(
                       ir::HandleConnectionSpecAccessPathRoot("particle", "in")),
                   ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
-                      "recipe", "particle", "in"))
-
-                 },
+                      "recipe", "particle", "in"))},
                  {ir::AccessPathRoot(ir::HandleConnectionSpecAccessPathRoot(
                       "particle", "out")),
                   ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
-                      "recipe", "particle", "out"))
-
-                 },
+                      "recipe", "particle", "out"))},
              },
              /*edges*/
              {ir::Edge(kHandleH1AccessPath, kHandleConnectionInAccessPath),

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -21,8 +21,10 @@
 #include "absl/strings/substitute.h"
 #include "src/common/testing/gtest.h"
 #include "src/ir/datalog_print_context.h"
+#include "src/ir/particle_spec.h"
 #include "src/ir/proto/system_spec.h"
 #include "src/ir/single-use-arena-and-predicate.h"
+#include "src/ir/types/primitive_type.h"
 
 namespace raksha::xform_to_datalog {
 
@@ -60,30 +62,68 @@ static const ir::AccessPath kHandleConnectionOutAccessPath(
         "recipe", "particle", "out")),
     ir::AccessPathSelectors());
 
-static std::tuple<ManifestDatalogFacts, std::string>
-  datalog_facts_and_output_strings[] = {
-    { ManifestDatalogFacts({}, {}, {}),
-      R"(
-// Claims:
+std::vector<ir::HandleConnectionSpec> GetHandleConnectionSpecs() {
+  std::vector<ir::HandleConnectionSpec> result;
+  result.push_back(ir::HandleConnectionSpec(
+      "in", /*reads=*/true, /*writes=*/false,
+      /*type=*/std::make_unique<ir::types::PrimitiveType>()));
+  result.push_back(ir::HandleConnectionSpec(
+      "out", /*reads=*/false, /*writes=*/true,
+      /*type=*/std::make_unique<ir::types::PrimitiveType>()));
+  return result;
+}
 
+static std::unique_ptr<ir::ParticleSpec> particle_spec(ir::ParticleSpec::Create(
+    "particle",
+    /*checks=*/
+    {ir::TagCheck(kHandleConnectionInAccessPath, *kTag2Presence.predicate())},
+    /*tag_claims=*/
+    {ir::TagClaim("particle", kHandleConnectionOutAccessPath, true, "tag")},
+    /*derives_from_claims=*/{},
+    /*handle_connection_specs=*/GetHandleConnectionSpecs(),
+    /*predicate_arena=*/nullptr));
+
+static std::tuple<ManifestDatalogFacts, std::string>
+    datalog_facts_and_output_strings[] = {
+        {ManifestDatalogFacts({}, {}, {}, {}),
+         R"(// Claims:
 
 // Checks:
 
-
 // Edges:
 
-)" },
-    { ManifestDatalogFacts(
-        { ir::TagClaim(
-            "particle", kHandleConnectionOutAccessPath, true, "tag") },
-        { ir::TagCheck(
-            kHandleConnectionInAccessPath, *kTag2Presence.predicate()) },
-        { ir::Edge(kHandleH1AccessPath, kHandleConnectionInAccessPath),
-          ir::Edge(kHandleConnectionInAccessPath,
-                   kHandleConnectionOutAccessPath),
-           ir::Edge(kHandleConnectionOutAccessPath, kHandleH2AccessPath)}),
-      R"(
-// Claims:
+)"},
+        {ManifestDatalogFacts(
+             {ManifestDatalogFacts::Particle(
+                 particle_spec.get(),
+                 /*instantiation_map*/
+                 {
+                     {ir::AccessPathRoot(ir::HandleConnectionSpecAccessPathRoot(
+                          "particle", "in")),
+                      ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
+                          "recipe", "particle", "in"))
+
+                     },
+                     {ir::AccessPathRoot(ir::HandleConnectionSpecAccessPathRoot(
+                          "particle", "out")),
+                      ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
+                          "recipe", "particle", "out"))
+
+                     },
+                 },
+                 /*edges*/
+                 {ir::Edge(kHandleH1AccessPath, kHandleConnectionInAccessPath),
+                  ir::Edge(kHandleConnectionOutAccessPath,
+                           kHandleH2AccessPath)})},
+             {ir::TagClaim("particle", kHandleConnectionOutAccessPath, true,
+                           "tag")},
+             {ir::TagCheck(kHandleConnectionInAccessPath,
+                           *kTag2Presence.predicate())},
+             {ir::Edge(kHandleH1AccessPath, kHandleConnectionInAccessPath),
+              ir::Edge(kHandleConnectionInAccessPath,
+                       kHandleConnectionOutAccessPath),
+              ir::Edge(kHandleConnectionOutAccessPath, kHandleH2AccessPath)}),
+         R"(// Claims:
 says_hasTag("particle", "recipe.particle.out", owner, "tag") :- ownsAccessPath(owner, "recipe.particle.out").
 
 // Checks:
@@ -92,11 +132,10 @@ isCheck("check_num_0", "recipe.particle.in"). check("check_num_0", owner, "recip
 
 // Edges:
 edge("recipe.h1", "recipe.particle.in").
-edge("recipe.particle.in", "recipe.particle.out").
 edge("recipe.particle.out", "recipe.h2").
-)"
-    }
-};
+edge("recipe.particle.in", "recipe.particle.out").
+
+)"}};
 
 INSTANTIATE_TEST_SUITE_P(
     ManifestDatalogFactsToDatalogTest, ManifestDatalogFactsToDatalogTest,
@@ -277,15 +316,20 @@ class ParseBigManifestTest : public testing::Test {
     CHECK(system_spec_ != nullptr);
     datalog_facts_ = ManifestDatalogFacts::CreateFromManifestProto(
         *system_spec_, manifest_proto);
+
+    std::string datalog = datalog_facts_.ToDatalog(ctxt_, "~");
+    datalog_strings_ = absl::StrSplit(datalog, "~", absl::SkipEmpty());
   }
 
  protected:
   std::unique_ptr<ir::SystemSpec> system_spec_;
   ir::DatalogPrintContext ctxt_;
   ManifestDatalogFacts datalog_facts_;
+  std::vector<std::string> datalog_strings_;
 };
 
 static const std::string kExpectedClaimStrings[] = {
+    R"(// Claims:)",
     R"(says_hasTag("PS1", "NamedR.PS1#0.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "NamedR.PS1#0.out_handle.field1").)",
     R"(says_hasTag("PS1", "NamedR.PS1#1.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "NamedR.PS1#1.out_handle.field1").)",
     R"(says_hasTag("PS2", "NamedR.PS2#2.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "NamedR.PS2#2.out_handle.field1").)",
@@ -294,15 +338,35 @@ static const std::string kExpectedClaimStrings[] = {
     R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1").)",
 };
 
+// TODO(bgogul): Move this to a common/utils.
+template <typename I>
+class iterator_range {
+ public:
+  using const_iterator = I;
+  using value_type = typename std::iterator_traits<I>::value_type;
+
+  iterator_range() = default;
+  iterator_range(I begin, I end): begin_(begin), end_(end) {}
+
+  I begin() const { return begin_; }
+  I end() const { return end_; }
+  bool empty() const { return begin() == end(); }
+
+ private:
+  I begin_;
+  I end_;
+};
+
+template <typename I>
+inline iterator_range<I> make_range(I begin, I end) {
+  return iterator_range<I>(begin, end);
+}
+
 TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
-  // Go through all of the facts, convert them to strings, and compare them
-  // against our expected strings. Strings are much easier to read on a test
-  // failure than structured datalog facts.
-  std::vector<std::string> claim_datalog_strings;
-  for (const ir::TagClaim &claim : datalog_facts_.claims()) {
-    claim_datalog_strings.push_back(claim.ToDatalog(ctxt_));
-  }
-  EXPECT_THAT(claim_datalog_strings,
+  EXPECT_THAT(make_range(std::find(datalog_strings_.begin(),
+                                   datalog_strings_.end(), "// Claims:"),
+                         std::find(datalog_strings_.begin(),
+                                   datalog_strings_.end(), "// Checks:")),
               testing::UnorderedElementsAreArray(kExpectedClaimStrings));
 }
 
@@ -311,6 +375,7 @@ static constexpr absl::string_view kPattern =
   ownsAccessPath(owner, "$1"), mayHaveTag("$1", owner, "$2").)";
 
 static std::string kExpectedCheckStrings[] = {
+    R"(// Checks:)",
     absl::Substitute(kPattern, "check_num_0", "NamedR.PS1#0.in_handle.field1",
                      "tag2"),
     absl::Substitute(kPattern, "check_num_1", "NamedR.PS1#1.in_handle.field1",
@@ -326,25 +391,22 @@ static std::string kExpectedCheckStrings[] = {
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {
-  // Go through all of the facts, convert them to strings, and compare them
-  // against our expected strings. Strings are much easier to read on a test
-  // failure than structured datalog facts.
-  std::vector<std::string> check_datalog_strings;
-  for (const ir::TagCheck &check : datalog_facts_.checks()) {
-    check_datalog_strings.push_back(check.ToDatalog(ctxt_));
-  }
-  EXPECT_THAT(check_datalog_strings,
+  EXPECT_THAT(make_range(std::find(datalog_strings_.begin(),
+                                   datalog_strings_.end(), "// Checks:"),
+                         std::find(datalog_strings_.begin(),
+                                   datalog_strings_.end(), "// Edges:")),
               testing::UnorderedElementsAreArray(kExpectedCheckStrings));
 }
 
 static const std::string kExpectedEdgeStrings[] = {
     // Named recipe edges:
     // Edges connecting h1 to NamedR.PS1#0 for fields {field1, field2}.
+    R"(// Edges:)",
     R"(edge("NamedR.h1.field1", "NamedR.PS1#0.in_handle.field1").)",
     R"(edge("NamedR.h1.field2", "NamedR.PS1#0.in_handle.field2").)",
 
     // Edges connecting h2 to NamedR.PS1#0 for field1
-     R"(edge("NamedR.PS1#0.out_handle.field1", "NamedR.h2.field1").)",
+    R"(edge("NamedR.PS1#0.out_handle.field1", "NamedR.h2.field1").)",
 
     // Intra-particle connection
     R"(edge("NamedR.PS1#0.in_handle.field1", "NamedR.PS1#0.out_handle.field1").)",
@@ -392,18 +454,12 @@ static const std::string kExpectedEdgeStrings[] = {
     R"(edge("GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "GENERATED_RECIPE_NAME0.h4.field1").)",
 
     // Intra-particle connection
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1").)"
-};
+    R"(edge("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1").)"};
 
 TEST_F(ParseBigManifestTest, ManifestProtoEdgesTest) {
-  // Go through all of the facts, convert them to strings, and compare them
-  // against our expected strings. Strings are much easier to read on a test
-  // failure than structured datalog facts.
-  std::vector<std::string> edge_datalog_strings;
-  for (const ir::Edge &edge : datalog_facts_.edges()) {
-    edge_datalog_strings.push_back(edge.ToDatalog(ctxt_));
-  }
-  EXPECT_THAT(edge_datalog_strings,
+  EXPECT_THAT(make_range(std::find(datalog_strings_.begin(),
+                                   datalog_strings_.end(), "// Edges:"),
+                         datalog_strings_.end()),
               testing::UnorderedElementsAreArray(kExpectedEdgeStrings));
 }
 

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -85,7 +85,7 @@ static std::unique_ptr<ir::ParticleSpec> particle_spec(ir::ParticleSpec::Create(
 
 static std::tuple<ManifestDatalogFacts, std::string>
     datalog_facts_and_output_strings[] = {
-        {ManifestDatalogFacts({}, {}, {}, {}),
+        {ManifestDatalogFacts(),
          R"(// Claims:
 
 // Checks:
@@ -93,36 +93,26 @@ static std::tuple<ManifestDatalogFacts, std::string>
 // Edges:
 
 )"},
-        {ManifestDatalogFacts(
-             {ManifestDatalogFacts::Particle(
-                 particle_spec.get(),
-                 /*instantiation_map*/
-                 {
-                     {ir::AccessPathRoot(ir::HandleConnectionSpecAccessPathRoot(
-                          "particle", "in")),
-                      ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
-                          "recipe", "particle", "in"))
+        {ManifestDatalogFacts({ManifestDatalogFacts::Particle(
+             particle_spec.get(),
+             /*instantiation_map*/
+             {
+                 {ir::AccessPathRoot(
+                      ir::HandleConnectionSpecAccessPathRoot("particle", "in")),
+                  ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
+                      "recipe", "particle", "in"))
 
-                     },
-                     {ir::AccessPathRoot(ir::HandleConnectionSpecAccessPathRoot(
-                          "particle", "out")),
-                      ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
-                          "recipe", "particle", "out"))
-
-                     },
                  },
-                 /*edges*/
-                 {ir::Edge(kHandleH1AccessPath, kHandleConnectionInAccessPath),
-                  ir::Edge(kHandleConnectionOutAccessPath,
-                           kHandleH2AccessPath)})},
-             {ir::TagClaim("particle", kHandleConnectionOutAccessPath, true,
-                           "tag")},
-             {ir::TagCheck(kHandleConnectionInAccessPath,
-                           *kTag2Presence.predicate())},
+                 {ir::AccessPathRoot(ir::HandleConnectionSpecAccessPathRoot(
+                      "particle", "out")),
+                  ir::AccessPathRoot(ir::HandleConnectionAccessPathRoot(
+                      "recipe", "particle", "out"))
+
+                 },
+             },
+             /*edges*/
              {ir::Edge(kHandleH1AccessPath, kHandleConnectionInAccessPath),
-              ir::Edge(kHandleConnectionInAccessPath,
-                       kHandleConnectionOutAccessPath),
-              ir::Edge(kHandleConnectionOutAccessPath, kHandleH2AccessPath)}),
+              ir::Edge(kHandleConnectionOutAccessPath, kHandleH2AccessPath)})}),
          R"(// Claims:
 says_hasTag("particle", "recipe.particle.out", owner, "tag") :- ownsAccessPath(owner, "recipe.particle.out").
 

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -28,7 +28,6 @@ saysMay(w, x, y, z) :- says_may(w, x, y, z).
 saysWill(w, x, y) :- says_will(w, x, y).
 
 // Manifest
-
 // Claims:
 says_hasTag("P1", "R.P1#0.foo", owner, "userSelection") :- ownsAccessPath(owner, "R.P1#0.foo").
 
@@ -42,6 +41,7 @@ edge("R.handle0", "R.P2#1.bar").
 edge("R.P2#1.foo", "R.handle1").
 edge("R.P2#1.bar", "R.P2#1.foo").
 edge("R.handle1", "R.P3#2.bar").
+
 
 // Authorization Logic
 


### PR DESCRIPTION
In this PR, instead of creating instantiated versions of the various data structures, we simply fix the access path at the time of datalog generation. This required passing along the `instantiation_map` as a part of the `DatalogPrintContext`. This is a very temporary hack. When all the classes are fleshed out, we will implement `ToDatalog` as a visitor, where the necessary context can be cleanly passed along in the visitor. 