### PR TITLE
Introduce a type alias for the instantiation map type.

### DIFF
--- a/src/ir/access_path_root.h
+++ b/src/ir/access_path_root.h
@@ -17,8 +17,8 @@
 #ifndef SRC_IR_ACCESS_PATH_ROOT_H_
 #define SRC_IR_ACCESS_PATH_ROOT_H_
 
-#include "absl/types/variant.h"
 #include "absl/strings/str_join.h"
+#include "absl/types/variant.h"
 #include "src/common/logging/logging.h"
 
 // The classes in this file describe the root of an AccessPath. At the moment,

--- a/src/ir/datalog_print_context.h
+++ b/src/ir/datalog_print_context.h
@@ -28,6 +28,9 @@ namespace raksha::ir {
 // unique labels.
 class DatalogPrintContext {
  public:
+  using AccessPathInstantiationMap =
+      absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>;
+
   DatalogPrintContext() : check_counter_(0), instantiation_map_(nullptr) {}
 
   // DatalogPrintContext is not copyable, as we need a single copy to be the
@@ -41,20 +44,17 @@ class DatalogPrintContext {
   }
 
   void set_instantiation_map(
-      const absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
-          *instantiation_map) {
+      const AccessPathInstantiationMap *instantiation_map) {
     instantiation_map_ = instantiation_map;
   }
 
-  const absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
-      *instantiation_map() const {
+  const AccessPathInstantiationMap *instantiation_map() const {
     return instantiation_map_;
   }
 
  private:
   uint64_t check_counter_;
-  const absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
-      *instantiation_map_;
+  const AccessPathInstantiationMap *instantiation_map_;
 };
 
 }  // namespace raksha::ir

--- a/src/xform_to_datalog/manifest_datalog_facts.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts.cc
@@ -86,8 +86,7 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
       // populated by iterating over all HandleConnectionProtos and, for each
       // HandleConnectionSpec and HandleConnection pair indicated, adding
       // that pair to the instantiation_map.
-      absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
-          instantiation_map;
+      ir::DatalogPrintContext::AccessPathInstantiationMap instantiation_map;
       std::vector<ir::Edge> particle_edges;
       for (const arcs::HandleConnectionProto &connection_proto :
         particle_proto.connections()) {

--- a/src/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/xform_to_datalog/manifest_datalog_facts.h
@@ -40,23 +40,22 @@ class ManifestDatalogFacts {
   // where the instance of a particle will be clear from the visit context.
   class Particle {
    public:
-    Particle(const raksha::ir::ParticleSpec *spec,
-             absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
+    Particle(const ir::ParticleSpec *spec,
+             ir::DatalogPrintContext::AccessPathInstantiationMap
                  &&instantiation_map,
              std::vector<ir::Edge> &&edges)
-        : spec_(spec),
-          instantiation_map_(instantiation_map),
-          edges_(edges) {}
+        : spec_(spec), instantiation_map_(instantiation_map), edges_(edges) {}
 
-    const raksha::ir::ParticleSpec *spec() const { return spec_; }
-    const absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>&
-        instantiation_map() const { return instantiation_map_; }
+    const ir::ParticleSpec *spec() const { return spec_; }
+    const ir::DatalogPrintContext::AccessPathInstantiationMap &
+    instantiation_map() const {
+      return instantiation_map_;
+    }
     const std::vector<ir::Edge> &edges() const { return edges_; }
 
    private:
-    const raksha::ir::ParticleSpec *spec_;
-    absl::flat_hash_map<ir::AccessPathRoot, ir::AccessPathRoot>
-        instantiation_map_;
+    const ir::ParticleSpec *spec_;
+    ir::DatalogPrintContext::AccessPathInstantiationMap instantiation_map_;
     std::vector<ir::Edge> edges_;
   };
 


### PR DESCRIPTION
This will make it easier to be consistent across all uses.