### PR TITLE
Remove IsInstantiated methods from AccessPathRoot.

### DIFF
--- a/src/ir/access_path_root.h
+++ b/src/ir/access_path_root.h
@@ -51,11 +51,6 @@ class HandleConnectionSpecAccessPathRoot {
     return "";
   }
 
-  // A HandleConnectionSpecAccessPathRoot has not been fully instantiated.
-  bool IsInstantiated() const {
-    return false;
-  }
-
   const std::string &particle_spec_name() const {
     return particle_spec_name_;
   }
@@ -101,11 +96,6 @@ class HandleConnectionAccessPathRoot {
       recipe_name_, particle_name_, handle_connection_name_ }, ".");
   }
 
-  // A HandleConnectionAccessPathRoot is instantiated.
-  bool IsInstantiated() const {
-    return true;
-  }
-
   bool operator==(const HandleConnectionAccessPathRoot &other) const {
     return (recipe_name_ == other.recipe_name_) &&
       (particle_name_ == other.particle_name_) &&
@@ -139,11 +129,6 @@ class HandleAccessPathRoot {
   // recipe_name_.handle_name_
   std::string ToString() const {
     return absl::StrJoin({recipe_name_, handle_name_}, ".");
-  }
-
-  // A HandleAccessPathRoot is instantiated.
-  bool IsInstantiated() const {
-    return true;
   }
 
   bool operator==(const HandleAccessPathRoot &other) const {
@@ -185,13 +170,6 @@ class AccessPathRoot {
   }
 
   std::string ToDatalog(const DatalogPrintContext &ctxt) const;
-
-  // Dispatch IsInstantiated to the specific kind of AccessPathRoot.
-  bool IsInstantiated() const {
-     return std::visit(
-        [](const auto &variant){ return variant.IsInstantiated(); },
-        specific_root_);
-  }
 
   bool operator==(const AccessPathRoot &other) const {
     return specific_root_ == other.specific_root_;

--- a/src/ir/access_path_root_test.cc
+++ b/src/ir/access_path_root_test.cc
@@ -10,7 +10,6 @@ TEST(HandleConnectionSpecAccessPathRootBehaviorTest,
   HandleConnectionSpecAccessPathRoot spec_access_path_root
     ("particle_spec_name", "handle_access_path_spec_name");
   AccessPathRoot test_access_path_root(spec_access_path_root);
-  EXPECT_FALSE(test_access_path_root.IsInstantiated());
   EXPECT_DEATH(test_access_path_root.ToString(),
                "Attempted to print out an AccessPath before connecting it "
                   "to a fully-instantiated root!");
@@ -20,14 +19,12 @@ TEST(HandleConnectionAccessPathRootTest, HandleConnectionAccessPathRootTest) {
   HandleConnectionAccessPathRoot handle_connection_access_path_root(
       "recipe", "particle", "handle");
   AccessPathRoot test_access_path_root(handle_connection_access_path_root);
-  EXPECT_TRUE(test_access_path_root.IsInstantiated());
   EXPECT_EQ(test_access_path_root.ToString(), "recipe.particle.handle");
 }
 
 TEST(HandleAccessPathRootTest, HandleAccessPathRootTest) {
   HandleAccessPathRoot handle_connection_access_path_root("recipe", "handle");
   AccessPathRoot test_access_path_root(handle_connection_access_path_root);
-  EXPECT_TRUE(test_access_path_root.IsInstantiated());
   EXPECT_EQ(test_access_path_root.ToString(), "recipe.handle");
 }
 


### PR DESCRIPTION
This is part of the series of PRs to remove the concept of instantiated access path.