### PR TITLE
Update Souffle version to 2.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -111,9 +111,9 @@ http_archive(
     patches = [
         "@//third_party/souffle:remove_config.patch",
     ],
-    sha256 = "654c1b33b2b3f20fdc1f0983dfed562c24a0baa230fd431401cc0004464c6b4d",
-    strip_prefix = "souffle-fbb4c4b967bf58cccb7aca58e3d200a799218d98",
-    urls = ["https://github.com/souffle-lang/souffle/archive/fbb4c4b967bf58cccb7aca58e3d200a799218d98.zip"],
+    sha256 = "34b5723afb9f0b57172c984c8bb87cf1b57140d192d15d4786bc4f1fdc3ecbf2",
+    strip_prefix = "souffle-2.1",
+    urls = ["https://github.com/souffle-lang/souffle/archive/refs/tags/2.1.zip"],
 )
 
 #-------------------

--- a/third_party/souffle/remove_config.patch
+++ b/third_party/souffle/remove_config.patch
@@ -1,11 +1,11 @@
 --- src/main.cpp
 +++ src/main.cpp
 @@ -60,7 +60,7 @@
- #include "ast/transform/SimplifyAggregateTargetExpression.h"
- #include "ast/transform/UniqueAggregationVariables.h"
- #include "ast2ram/AstToRamTranslator.h"
+ #include "ast2ram/seminaive/TranslationStrategy.h"
+ #include "ast2ram/seminaive/UnitTranslator.h"
+ #include "ast2ram/utility/TranslatorContext.h"
 -#include "config.h"
-+#define PACKAGE_VERSION "2.0.2-352-gfbb4c4b96"
++#define PACKAGE_VERSION "2.1"
  #include "interpreter/Engine.h"
  #include "interpreter/ProgInterface.h"
  #include "parser/ParserDriver.h"


### PR DESCRIPTION
I ran into a segfault while attempting to run a test with the integrity
tags. This change updates Souffle to the latest tagged version which no
longer segfaults on my test.