### PR TITLE
Swap expected and actual values in EXPECT_THAT macro.

### DIFF
--- a/src/ir/particle_spec_test.cc
+++ b/src/ir/particle_spec_test.cc
@@ -57,14 +57,14 @@ TEST_P(ParticleSpecFromProtoTest, ParticleSpecFromProtoTest) {
 
   EXPECT_EQ(particle_spec_->name(), param.expected_name);
   EXPECT_THAT(
-      param.expected_claims,
-      testing::UnorderedElementsAreArray(particle_spec_->tag_claims()));
+      particle_spec_->tag_claims(),
+      testing::UnorderedElementsAreArray(param.expected_claims));
   EXPECT_THAT(
-      param.expected_checks,
-      testing::UnorderedElementsAreArray(particle_spec_->checks()));
+      particle_spec_->checks(),
+      testing::UnorderedElementsAreArray(param.expected_checks));
   EXPECT_THAT(
-      param.expected_edges,
-      testing::UnorderedElementsAreArray(particle_spec_->edges()));
+      particle_spec_->edges(),
+      testing::UnorderedElementsAreArray(param.expected_edges));
 }
 
 // Constant to reduce wordiness of test expected output.


### PR DESCRIPTION
This is the right way to invoke this macro. Using it the other way can cause problems is if the actual value is non-copyable. In the code changed in the PR, `UnorderedElementsAreArray` may try to make a copy.