### PR TITLE
Return error status from bazel_run functions.

### DIFF
--- a/gcb/presubmit.sh
+++ b/gcb/presubmit.sh
@@ -51,8 +51,10 @@ bazel_run() {
     ${TARGETS};
   then
     post_commit_status "${STATUS_MESSAGE}" "success" ${INVOCATION_ID}
+    return 0
   else
     post_commit_status "${STATUS_MESSAGE}" "failure" ${INVOCATION_ID}
+    return 1
   fi
 }
 


### PR DESCRIPTION
Otherwise, gcb incorrectly thinks that the tests and builds pass. 

See the new behavior with an intentional failure: https://pantheon.corp.google.com/cloud-build/builds/357b1fa2-6414-4087-b2ff-39e8fb5ccffa;step=3?project=google.com:raksha-ci
