### PR TITLE
Draft PR showing issues with the "may have integrity tag" approach.

### DIFF
--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -122,7 +122,7 @@ mayHaveIntegrityTag(ap, owner, integTag) :- hasAppliedIntegrityTag(ap, owner, in
 
 // Any AccessPath that has an incoming resolvedEdge where the source of that
 // edge may have an IntegrityTag may also have that IntegrityTag.
-mayHaveIntegrityTag(src, owner, integTag) :-
+mayHaveIntegrityTag(dst, owner, integTag) :-
   resolvedEdge(owner, src, dst), mayHaveIntegrityTag(src, owner, integTag),
   !removeIntegrityTag(dst, owner, integTag).
 

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -64,9 +64,12 @@
 // Removes an integrity tag from some path.
 .decl removeIntegrityTag(accessPath: AccessPath, owner: Principal, integTag: IntegrityTag)
 
-// Indicates that a particular tag may lack an integrity tag, which
+// Indicates that a particular AccessPath may lack an integrity tag, which
 // indicates that it should not have an integrity tag.
 .decl lacksIntegrityTag(accessPath: AccessPath, owner: Principal, integTag: IntegrityTag)
+
+// Indicates that a particular AccessPath may have an integrity tag.
+.decl mayHaveIntegrityTag(accessPath: AccessPath, owner: Principal, integTag: IntegrityTag)
 
 // Used to test whether a particular path has a particular integrity tag.
 // Should be used as close to top-level checks as possible, and not for
@@ -113,10 +116,21 @@ lacksIntegrityTag(dst, owner, integTag) :-
   edge(src, dst), lacksIntegrityTag(src, owner, integTag),
   !hasAppliedIntegrityTag(dst, owner, integTag).
 
-// An access path must have an integrity tag if it does not lack the integrity tag.
+// Any AccessPath that has an IntegrityTag directly applied to it may (really,
+// stronger than may, must) have that IntegrityTag.
+mayHaveIntegrityTag(ap, owner, integTag) :- hasAppliedIntegrityTag(ap, owner, integTag).
+
+// Any AccessPath that has an incoming resolvedEdge where the source of that
+// edge may have an IntegrityTag may also have that IntegrityTag.
+mayHaveIntegrityTag(src, owner, integTag) :-
+  resolvedEdge(owner, src, dst), mayHaveIntegrityTag(src, owner, integTag),
+  !removeIntegrityTag(dst, owner, integTag).
+
+// An access path must have an integrity tag if it may have the IntegrityTag
+// and does not lack the IntegrityTag
 mustHaveIntegrityTag(ap, owner, integTag) :-
   isAccessPath(ap), isIntegrityTag(integTag), isPrincipal(owner),
-  !lacksIntegrityTag(ap, owner, integTag).
+  mayHaveIntegrityTag(ap, owner, integTag), !lacksIntegrityTag(ap, owner, integTag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/tests/arcs_fact_tests/dynamic_rule_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/dynamic_rule_test.dl
@@ -1,0 +1,71 @@
+#include "taint.dl"
+#include "fact_test_helper.dl"
+#include "integrity_tag_prop_helper.dl"
+
+// This file explores a simple policy that attempts to add integrity tags based
+// upon the presence of other integrity tags. It has the following rules:
+//
+// 1. When a value tagged with TimestampMillis is divided by a value tagged as
+//    being the constant 1000, the result is TimestampSeconds
+//
+// 2. When a value tagged with TimestampSeconds is multiplied by a value tagged
+//    as being the constant 1000, the result is TimestampMillisRedacted.
+//
+// While we might use something like operators in the future, we are currently
+// doing something a bit more ad-hoc for this test by indicating that certain
+// access paths are the result of operation expressions with the isOperatorExpr
+// relation.
+
+.decl mult_op(result: AccessPath, operand1: AccessPath, operand2: AccessPath)
+.decl div_op(result: AccessPath, dividend: AccessPath, divisor: AccessPath)
+
+edge(op1, result), edge(op2, result) :- mult_op(result, op1, op2).
+edge(dividend, result), edge(divisor, result) :- div_op(result, dividend, divisor).
+
+isAccessPath("a").
+isAccessPath("b").
+isAccessPath("c").
+isAccessPath("d").
+isAccessPath("e").
+
+mult_op("c", "a", "b").
+div_op("e", "c", "d").
+
+hasAppliedIntegrityTag("a", "defaultOwner", "TimestampMillis").
+hasAppliedIntegrityTag("b", "defaultOwner", "Constant_1000").
+hasAppliedIntegrityTag("d", "defaultOwner", "Constant_1000").
+
+// This is the first policy rule.
+mayHaveIntegrityTag(ap, owner, "TimestampSeconds") :-
+  div_op(ap, operand1, operand2),
+  mayHaveIntegrityTag(operand1, owner, "TimestampMillis"),
+  mayHaveIntegrityTag(operand2, owner, "Constant_1000").
+
+// These rules propagating lacks of integrity tags across rules can only remove
+// integrity tags. Remove them for now to illustrate issue.
+// lacksIntegrityTag(ap, owner, "TimestampSeconds") :-
+//  div_op(ap, operand1, operand2),
+//  (lacksIntegrityTag(operand1, owner, "TimestampMillis");
+//   lacksIntegrityTag(operand2, owner, "Constant_1000")).
+
+// This is the second policy rule.
+mayHaveIntegrityTag(ap, owner, "TimestampMillisRedacted") :-
+  mult_op(ap, operand1, operand2),
+  mayHaveIntegrityTag(operand1, owner, "TimestampSeconds"),
+  mayHaveIntegrityTag(operand1, owner, "Constant_1000").
+
+// lacksIntegrityTag(ap, owner, "TimestampMillisRedacted") :-
+//  mult_op(ap, operand1, operand2),
+//  (lacksIntegrityTag(operand1, owner, "TimestampSeconds");
+//   lacksIntegrityTag(operand2, owner, "Constant_1000")).
+
+expectHasIntegrityTag("a", "defaultOwner", "TimestampMillis").
+expectHasIntegrityTag("b", "defaultOwner", "Constant_1000").
+expectHasIntegrityTag("d", "defaultOwner", "Constant_1000").
+
+// We expect these to be present, but they are not. They are not present
+// because the lack of TimestampSeconds propagates in from "a" and "b" onto "c"
+// and the lack of "TimestampMillisRedacted" propagates in from "a", "b", and
+// "d" onto "e".
+expectHasIntegrityTag("c", "defaultOwner", "TimestampSeconds").
+expectHasIntegrityTag("e", "defaultOwner", "TimestampMillisRedacted").

--- a/src/analysis/souffle/tests/arcs_fact_tests/dynamic_rule_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/dynamic_rule_test.dl
@@ -36,6 +36,7 @@ hasAppliedIntegrityTag("b", "defaultOwner", "Constant_1000").
 hasAppliedIntegrityTag("d", "defaultOwner", "Constant_1000").
 
 // This is the first policy rule.
+isIntegrityTag("TimestampSeconds").
 mayHaveIntegrityTag(ap, owner, "TimestampSeconds") :-
   div_op(ap, operand1, operand2),
   mayHaveIntegrityTag(operand1, owner, "TimestampMillis"),
@@ -49,6 +50,7 @@ mayHaveIntegrityTag(ap, owner, "TimestampSeconds") :-
 //   lacksIntegrityTag(operand2, owner, "Constant_1000")).
 
 // This is the second policy rule.
+isIntegrityTag("TimestampMillisRedacted").
 mayHaveIntegrityTag(ap, owner, "TimestampMillisRedacted") :-
   mult_op(ap, operand1, operand2),
   mayHaveIntegrityTag(operand1, owner, "TimestampSeconds"),

--- a/src/analysis/souffle/tests/arcs_fact_tests/dynamic_rule_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/dynamic_rule_test.dl
@@ -28,8 +28,8 @@ isAccessPath("c").
 isAccessPath("d").
 isAccessPath("e").
 
-mult_op("c", "a", "b").
-div_op("e", "c", "d").
+div_op("c", "a", "b").
+mult_op("e", "c", "d").
 
 hasAppliedIntegrityTag("a", "defaultOwner", "TimestampMillis").
 hasAppliedIntegrityTag("b", "defaultOwner", "Constant_1000").
@@ -52,7 +52,7 @@ mayHaveIntegrityTag(ap, owner, "TimestampSeconds") :-
 mayHaveIntegrityTag(ap, owner, "TimestampMillisRedacted") :-
   mult_op(ap, operand1, operand2),
   mayHaveIntegrityTag(operand1, owner, "TimestampSeconds"),
-  mayHaveIntegrityTag(operand1, owner, "Constant_1000").
+  mayHaveIntegrityTag(operand2, owner, "Constant_1000").
 
 // lacksIntegrityTag(ap, owner, "TimestampMillisRedacted") :-
 //  mult_op(ap, operand1, operand2),

--- a/src/analysis/souffle/tests/arcs_fact_tests/fact_test_driver.cc
+++ b/src/analysis/souffle/tests/arcs_fact_tests/fact_test_driver.cc
@@ -40,6 +40,8 @@ int run_test(std::string const &test_name) {
     prog->getRelation("duplicateTestCaseNames");
 
   assert(test_failures != nullptr);
+  assert(all_tests != nullptr);
+  assert(duplicate_test_case_names != nullptr);
 
   bool const test_is_trivial = all_tests->size() == 0;
   bool const test_has_failures = test_failures->size() > 0;


### PR DESCRIPTION
This draft PR shows the issues with the proposed integrity tag
propagation approach using `mayHaveIntegrityTag`, in which an
`AccessPath` must have an `IntegrityTag` if it `mayHaveIntegrityTag`
(where `mayHaveIntegrityTag` facts propagate like confidentiality tags)
and does not have a `lacksIntegrityTag` fact. Policy rules propagate
a `may` fact. In attempting to write a simple rule of this form, `lacks`
facts propagate over the newly-introduced `may` facts, making them
ineffective.