### PR TITLE
Use predecessor ordering to propagate IntegrityTags without negation.

### DIFF
--- a/src/analysis/souffle/dataflow_graph.dl
+++ b/src/analysis/souffle/dataflow_graph.dl
@@ -52,7 +52,7 @@
 // to the tgt. That allows us to effectively eliminate edges that are the
 // subject of a claimNotEdge from the dataflow graph by eliminating all tags
 // from the midway point. Paths are defined in terms of resolvedEdges.
-.decl resolvedEdge(for: Principal, src: AccessPath, tgt: AccessPath)
+.decl resolvedEdge(owner: Principal, src: AccessPath, tgt: AccessPath)
 
 // A direct or transitive data flow path.
 .decl path(src: AccessPath, tgt: AccessPath)
@@ -69,8 +69,8 @@
 // predecessor have the IntegrityTag and all predecessors up to N-1 have the
 // IntegrityTag". We can then ask if all predecessors up to numPredecessors
 // - 1 have the integrity tag to accomplish forall.
-.decl orderedPredecessors(ap: AccessPath, for: Principal, src: AccessPath, orderNum: number)
-.decl numPredecessors(ap: AccessPath, for: Principal, num: number)
+.decl orderedPredecessors(ap: AccessPath, owner: Principal, src: AccessPath, orderNum: number)
+.decl numPredecessors(ap: AccessPath, owner: Principal, num: number)
 
 //-----------------------------------------------------------------------------
 // Rules
@@ -91,19 +91,19 @@ isAccessPath(y) :- resolvedEdge(_, _, y).
 
 // The 0th predecessor shall be the predecessor with the smallest src ordinal
 // number.
-orderedPredecessors(ap, for, src, 0) :-
-  resolvedEdge(for, src, ap),
-  ord(src) = min ord(candidate) : { resolvedEdge(for, candidate, ap) }.
+orderedPredecessors(ap, owner, src, 0) :-
+  resolvedEdge(owner, src, ap),
+  ord(src) = min ord(candidate) : { resolvedEdge(owner, candidate, ap) }.
 
 // The Nth precessor shall be the precessor with the smallest src ordinal
 // number larger than the N-1th ordinal number.
-orderedPredecessors(ap, for, src, prevOrd + 1) :-
-  orderedPredecessors(ap, for, prevSrc, prevOrd),
-  resolvedEdge(for, src, ap),
-  ord(src) = min ord(candidate) : { resolvedEdge(for, candidate, ap), ord(candidate) > ord(prevSrc) }.
+orderedPredecessors(ap, owner, src, prevOrd + 1) :-
+  orderedPredecessors(ap, owner, prevSrc, prevOrd),
+  resolvedEdge(owner, src, ap),
+  ord(src) = min ord(candidate) : { resolvedEdge(owner, candidate, ap), ord(candidate) > ord(prevSrc) }.
 
-numPredecessors(ap, for, maxOrd + 1) :-
-  orderedPredecessors(ap, for, _, maxOrd),
-  maxOrd = max ordNum : { orderedPredecessors(ap, for, _, ordNum) }.
+numPredecessors(ap, owner, maxOrd + 1) :-
+  orderedPredecessors(ap, owner, _, maxOrd),
+  maxOrd = max ordNum : { orderedPredecessors(ap, owner, _, ordNum) }.
 
 #endif // SRC_ANALYSIS_SOUFFLE_DATAFLOW_GRAPH_DL_

--- a/src/analysis/souffle/dataflow_graph.dl
+++ b/src/analysis/souffle/dataflow_graph.dl
@@ -57,9 +57,25 @@
 // A direct or transitive data flow path.
 .decl path(src: AccessPath, tgt: AccessPath)
 
+// A common way to do "forall" in Datalog is to use !exists. Unfortunately,
+// this imposes a stratification requirement. To allow IntegrityTags to
+// propagate when all predecessors have a particular IntegrityTag, instead give
+// each predecessor an arbitrary predecessor number between 0 and N, where N is
+// the number of predecessors a particular AccessPath has. Track the number of
+// predecessors an AccessPath has in numPredecssors. This allows us to
+// calculate whether all predecessors up to a particular order number have an
+// integrity tag, with the base case of 0 being just "does that particular
+// AccessPath have the IntegrityTag" and the inductive case being "does the nth
+// predecessor have the IntegrityTag and all predecessors up to N-1 have the
+// IntegrityTag". We can then ask if all predecessors up to numPredecessors
+// - 1 have the integrity tag to accomplish forall.
+.decl orderedPredecessors(ap: AccessPath, for: Principal, src: AccessPath, orderNum: number)
+.decl numPredecessors(ap: AccessPath, for: Principal, num: number)
+
 //-----------------------------------------------------------------------------
 // Rules
 //-----------------------------------------------------------------------------
+
 resolvedEdge(principal, src, tgt) :-
    isPrincipal(principal),
    edge(src, tgt),
@@ -72,5 +88,22 @@ path(from, to) :- resolvedEdge(_, from, intermediate), path(intermediate, to).
 // Symbols used in resolvedEdges are access paths
 isAccessPath(x) :- resolvedEdge(_, x, _).
 isAccessPath(y) :- resolvedEdge(_, _, y).
+
+// The 0th predecessor shall be the predecessor with the smallest src ordinal
+// number.
+orderedPredecessors(ap, for, src, 0) :-
+  resolvedEdge(for, src, ap),
+  ord(src) = min ord(candidate) : { resolvedEdge(for, candidate, ap) }.
+
+// The Nth precessor shall be the precessor with the smallest src ordinal
+// number larger than the N-1th ordinal number.
+orderedPredecessors(ap, for, src, prevOrd + 1) :-
+  orderedPredecessors(ap, for, prevSrc, prevOrd),
+  resolvedEdge(for, src, ap),
+  ord(src) = min ord(candidate) : { resolvedEdge(for, candidate, ap), ord(candidate) > ord(prevSrc) }.
+
+numPredecessors(ap, for, maxOrd + 1) :-
+  orderedPredecessors(ap, for, _, maxOrd),
+  maxOrd = max ordNum : { orderedPredecessors(ap, for, _, ordNum) }.
 
 #endif // SRC_ANALYSIS_SOUFFLE_DATAFLOW_GRAPH_DL_

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -65,14 +65,12 @@
 .decl removeIntegrityTag(accessPath: AccessPath, owner: Principal, integTag: IntegrityTag)
 
 // Given how predecessors are ordered in orderedPredecessors, indicate whether
-// a predcessor with a given order num and all predecessors with lower order
-// nums have a particular integrity tag.
+// a predecessor with a given orderNum and all predecessors with lower
+// orderNums have a particular IntegrityTag.
 .decl predecessorsUpToOrderNumHaveIntegrityTag(
   accessPath: AccessPath, owner: Principal, integTag: IntegrityTag, orderNum: number)
 
 // Used to test whether a particular path has a particular integrity tag.
-// Should be used as close to top-level checks as possible, and not for
-// propagation, to prevent stratification issues.
 .decl mustHaveIntegrityTag(accessPath: AccessPath, owner: Principal, integTag: IntegrityTag)
 
 //-----------------------------------------------------------------------------
@@ -112,8 +110,8 @@ predecessorsUpToOrderNumHaveIntegrityTag(ap, owner, integTag, ordNum + 1) :-
 mustHaveIntegrityTag(ap, owner, integTag) :- hasAppliedIntegrityTag(ap, owner, integTag).
 
 // If all predecessors up to the one with an order number one less than the
-// number of predecessors have the integrity tag and the integrity tag is not
-// removed, then this AccessPath has the IntegrityTag.
+// number of predecessors (ie, all predecessors) have the integrity tag and the
+// integrity tag is not removed, then this AccessPath has the IntegrityTag.
 mustHaveIntegrityTag(ap, owner, integTag) :-
   isAccessPath(ap), isIntegrityTag(integTag), isPrincipal(owner),
   numPredecessors(ap, owner, numPreds),

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -64,9 +64,11 @@
 // Removes an integrity tag from some path.
 .decl removeIntegrityTag(accessPath: AccessPath, owner: Principal, integTag: IntegrityTag)
 
-// Indicates that a particular tag may lack an integrity tag, which
-// indicates that it should not have an integrity tag.
-.decl lacksIntegrityTag(accessPath: AccessPath, owner: Principal, integTag: IntegrityTag)
+// Given how predecessors are ordered in orderedPredecessors, indicate whether
+// a predcessor with a given order num and all predecessors with lower order
+// nums have a particular integrity tag.
+.decl predecessorsUpToOrderNumHaveIntegrityTag(
+  accessPath: AccessPath, owner: Principal, integTag: IntegrityTag, orderNum: number)
 
 // Used to test whether a particular path has a particular integrity tag.
 // Should be used as close to top-level checks as possible, and not for
@@ -96,27 +98,28 @@ mayHaveTag(tgt, owner, tag) :-
 isIntegrityTag(integTag) :- hasAppliedIntegrityTag(_, _, integTag).
 isPrincipal(principal) :- hasAppliedIntegrityTag(_, principal, _).
 
-// Any access point that has no incoming edges and is not directly given an
-// integrity tag lacks that integrity tag, as there is no way for it to
-// propagate to that AccessPath.
-lacksIntegrityTag(ap, owner, integTag) :-
-  isAccessPath(ap), isPrincipal(owner), isIntegrityTag(integTag),
-  !edge(_, ap), !hasAppliedIntegrityTag(ap, owner, integTag).
+predecessorsUpToOrderNumHaveIntegrityTag(ap, owner, integTag, 0) :-
+  orderedPredecessors(ap, owner, pred, 0),
+  mustHaveIntegrityTag(pred, owner, integTag).
 
-// Any point where an integrity tag is removed lacks an integrity tag.
-lacksIntegrityTag(ap, owner, integTag) :- removeIntegrityTag(ap, owner, integTag).
+predecessorsUpToOrderNumHaveIntegrityTag(ap, owner, integTag, ordNum + 1) :-
+  predecessorsUpToOrderNumHaveIntegrityTag(ap, owner, integTag, ordNum),
+  orderedPredecessors(ap, owner, pred, ordNum + 1),
+  mustHaveIntegrityTag(pred, owner, integTag).
 
-// Propagate lack of integrity tag along edges to any destination that did not
-// have an integrity tag directly added.
-lacksIntegrityTag(dst, owner, integTag) :-
-  isAccessPath(src), isAccessPath(dst),
-  edge(src, dst), lacksIntegrityTag(src, owner, integTag),
-  !hasAppliedIntegrityTag(dst, owner, integTag).
+// Any access path that has an IntegrityTag directly applied must have the
+// integrity tag.
+mustHaveIntegrityTag(ap, owner, integTag) :- hasAppliedIntegrityTag(ap, owner, integTag).
 
-// An access path must have an integrity tag if it does not lack the integrity tag.
+// If all predecessors up to the one with an order number one less than the
+// number of predecessors have the integrity tag and the integrity tag is not
+// removed, then this AccessPath has the IntegrityTag.
 mustHaveIntegrityTag(ap, owner, integTag) :-
   isAccessPath(ap), isIntegrityTag(integTag), isPrincipal(owner),
-  !lacksIntegrityTag(ap, owner, integTag).
+  numPredecessors(ap, owner, numPreds),
+  numPreds > 0,
+  predecessorsUpToOrderNumHaveIntegrityTag(ap, owner, integTag, numPreds - 1),
+  !removeIntegrityTag(ap, owner, integTag).
 
 //-----------------------------------------------------------------------------
 // Universe Populating Rules

--- a/src/analysis/souffle/tests/arcs_fact_tests/integrity_cycle_with_onramp.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/integrity_cycle_with_onramp.dl
@@ -1,0 +1,27 @@
+#include "taint.dl"
+#include "fact_test_helper.dl"
+#include "integrity_tag_prop_helper.dl"
+
+// Create a simple cycle with an additional AccessPath connected to it (call
+// this an "onramp") and show that the onramp affects propagation of the
+// integrity tags through the cycle.
+isAccessPath("a").
+isAccessPath("b").
+isAccessPath("c").
+isAccessPath("d").
+
+edge("a", "b").
+edge("b", "c").
+edge("d", "c").
+edge("c", "a").
+
+hasAppliedIntegrityTag("a", "defaultOwner", "integ1").
+hasAppliedIntegrityTag("d", "defaultOwner", "integ1").
+expectHasIntegrityTag("a", "defaultOwner", "integ1").
+expectHasIntegrityTag("b", "defaultOwner", "integ1").
+expectHasIntegrityTag("c", "defaultOwner", "integ1").
+expectHasIntegrityTag("d", "defaultOwner", "integ1").
+
+hasAppliedIntegrityTag("a", "defaultOwner", "integ2").
+expectHasIntegrityTag("a", "defaultOwner", "integ2").
+expectHasIntegrityTag("b", "defaultOwner", "integ2").

--- a/src/analysis/souffle/tests/arcs_fact_tests/integrity_interlocking_cycles.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/integrity_interlocking_cycles.dl
@@ -1,0 +1,40 @@
+#include "taint.dl"
+#include "fact_test_helper.dl"
+#include "integrity_tag_prop_helper.dl"
+
+// Create two simple cycles and watch integrity tags flow along them.
+isAccessPath("a").
+isAccessPath("b").
+isAccessPath("c").
+isAccessPath("d").
+isAccessPath("e").
+
+edge("a", "b").
+edge("b", "c").
+edge("c", "a").
+edge("c", "d").
+edge("d", "e").
+edge("e", "c").
+
+hasAppliedIntegrityTag("a", "defaultOwner", "integ1").
+hasAppliedIntegrityTag("d", "defaultOwner", "integ1").
+expectHasIntegrityTag("a", "defaultOwner", "integ1").
+expectHasIntegrityTag("b", "defaultOwner", "integ1").
+expectHasIntegrityTag("c", "defaultOwner", "integ1").
+expectHasIntegrityTag("d", "defaultOwner", "integ1").
+expectHasIntegrityTag("e", "defaultOwner", "integ1").
+
+hasAppliedIntegrityTag("c", "defaultOwner", "integ2").
+expectHasIntegrityTag("a", "defaultOwner", "integ2").
+expectHasIntegrityTag("b", "defaultOwner", "integ2").
+expectHasIntegrityTag("c", "defaultOwner", "integ2").
+expectHasIntegrityTag("d", "defaultOwner", "integ2").
+expectHasIntegrityTag("e", "defaultOwner", "integ2").
+
+hasAppliedIntegrityTag("a", "defaultOwner", "integ3").
+expectHasIntegrityTag("a", "defaultOwner", "integ3").
+expectHasIntegrityTag("b", "defaultOwner", "integ3").
+
+hasAppliedIntegrityTag("d", "defaultOwner", "integ4").
+expectHasIntegrityTag("d", "defaultOwner", "integ4").
+expectHasIntegrityTag("e", "defaultOwner", "integ4").

--- a/src/analysis/souffle/tests/arcs_fact_tests/integrity_simple_cycle.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/integrity_simple_cycle.dl
@@ -1,0 +1,17 @@
+#include "taint.dl"
+#include "fact_test_helper.dl"
+#include "integrity_tag_prop_helper.dl"
+
+// Create a simple cycle and watch the integrity tag flow along it.
+isAccessPath("a").
+isAccessPath("b").
+isAccessPath("c").
+
+edge("a", "b").
+edge("b", "c").
+edge("c", "a").
+
+hasAppliedIntegrityTag("a", "defaultOwner", "integ1").
+expectHasIntegrityTag("a", "defaultOwner", "integ1").
+expectHasIntegrityTag("b", "defaultOwner", "integ1").
+expectHasIntegrityTag("c", "defaultOwner", "integ1").


### PR DESCRIPTION
This commit propagates `IntegrityTag`s without altering the dataflow
graph, without restricting the tags that may be introduced
dynamically, and without using negation. It does so by using a different
formulation of `forall` for the `IntegrityTag` propagation rule. Rather
than using `!`, it assigns each predecessor `AccessPath` a predecessor
order number. Then, it calculates a relation
`predecessorsUpToOrderNumHaveIntegrityTag` inductively, using the 0th
predecessor as the base case. Then, an `AccessPath` must have an
integrity tag if `predecessorsUpToOrderNumHaveIntegrityTag` for an
`orderNum` that is one less than the number of total predecessors.