### PR TITLE
Fix rust build errors and add build command to CI presubmit script.

### DIFF
--- a/gcb/presubmit.sh
+++ b/gcb/presubmit.sh
@@ -66,7 +66,8 @@ bazel_run build \
   //third_party/arcs/examples:consume \
   //third_party/arcs/proto:manifest_cc_proto \
   //src/analysis/souffle/tests/arcs_manifest_tests_todo/... \
-  //src/analysis/souffle/examples/...
+  //src/analysis/souffle/examples/... \
+  //rust/tools/authorization-logic:authorization_logic
 
 # Run all the bazel tests (not cargo).
 bazel_run test //src/...

--- a/rust/tools/authorization-logic/BUILD
+++ b/rust/tools/authorization-logic/BUILD
@@ -87,6 +87,8 @@ filegroup(
         "src/test/test_decl_skip.rs",
         "src/test/test_dots_and_quotes.rs",
         "src/test/test_export_signatures.rs",
+        "src/test/test_multimic_no_overrides.rs",
+        "src/test/test_multimic_overrides.rs",
         "src/test/test_negation.rs",
         "src/test/test_queries.rs",
         "src/test/test_signing.rs",


### PR DESCRIPTION
This fixes the error related to not finding modules `test_multimic_no_overrides`  and `test_multimic_overrides`.