### PR TITLE
Create a header-only Souffle library, use instead of `souffle_lib`.

### DIFF
--- a/build_defs/raksha.bzl
+++ b/build_defs/raksha.bzl
@@ -108,7 +108,7 @@ def policy_check(name, dataflow_graph, auth_logic, expect_failure = False, visib
         ],
         linkopts = ["-pthread"],
         deps = [
-            "@souffle//:souffle_lib",
+            "@souffle//:souffle_include_lib",
             souffle_dl_cpp_target,
         ],
     )

--- a/build_defs/souffle.bzl
+++ b/build_defs/souffle.bzl
@@ -80,7 +80,7 @@ def souffle_cc_library(
         defines = [
             "__EMBEDDED_SOUFFLE__",
         ],
-        deps = ["@souffle//:souffle_lib"],
+        deps = ["@souffle//:souffle_include_lib"],
         alwayslink = True,
         visibility = visibility,
     )

--- a/build_defs/test_helpers.bzl
+++ b/build_defs/test_helpers.bzl
@@ -79,6 +79,6 @@ def extracted_datalog_string_test(
         linkopts = ["-pthread"],
         deps = [
             name + "_souffle_lib",
-            "@souffle//:souffle_lib",
+            "@souffle//:souffle_include_lib",
         ],
     )

--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -17,7 +17,7 @@ cc_test(
     deps = [
         ":taint_dl",
         "//src/common/testing:gtest",
-        "@souffle//:souffle_lib",
+        "@souffle//:souffle_include_lib",
     ],
 )
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/BUILD
+++ b/src/analysis/souffle/tests/arcs_fact_tests/BUILD
@@ -41,7 +41,7 @@ exports_files(["fact_test_driver.cc"])
     ],
     linkopts = ["-pthread"],
     deps = [
-        "@souffle//:souffle_lib",
+        "@souffle//:souffle_include_lib",
         dl_script.replace(".dl", "_souffle_cc_library"),
     ],
 ) for dl_script in ALL_DL_TEST_FILES]
@@ -74,7 +74,7 @@ exports_files(["fact_test_driver.cc"])
     ],
     linkopts = ["-pthread"],
     deps = [
-        "@souffle//:souffle_lib",
+        "@souffle//:souffle_include_lib",
         dl_script.replace(".dl", "_no_owners_souffle_cc_library"),
     ],
 ) for dl_script in TURN_OFF_ALL_OWNERS_OWN_ALL_TAGS_FILES]

--- a/third_party/souffle/BUILD.souffle
+++ b/third_party/souffle/BUILD.souffle
@@ -93,6 +93,21 @@ cc_library(
     ],
 )
 
+cc_library(
+  name = "souffle_include_lib",
+  hdrs = glob(["src/**/*.h"]) + [":parser_gen"],
+  copts = [
+      "-std=c++17",
+      # We don't want warnings in 3rd party packages to obscure issues in our
+      # own code that we are more likely to need to fix.
+      "-w",
+  ],
+  includes = [
+      "src",
+      "src/include",
+  ],
+)
+
 cc_binary(
     name = "souffle",
     srcs = ["src/main.cpp"],

--- a/third_party/souffle/BUILD.souffle
+++ b/third_party/souffle/BUILD.souffle
@@ -95,7 +95,7 @@ cc_library(
 
 cc_library(
   name = "souffle_include_lib",
-  hdrs = glob(["src/**/*.h"]) + [":parser_gen"],
+  hdrs = glob(["src/**/*.h"]),
   copts = [
       "-std=c++17",
       # We don't want warnings in 3rd party packages to obscure issues in our


### PR DESCRIPTION
On chat, we had a discussion as to whether Souffle needs to be linked
into the C++ programs generated from compiled Souffle or whether they
are standalone programs. This commit is an experiment to clarify that:
in all cases possible, this replaces `souffle_lib` with
`souffle_include_lib`, a library consisting only of Souffle header
files. It appears that this can replace `souffle_lib` in all cases in
Raksha where we are compiling Datalog, meaning that Souffle-generated
C++ programs do not need to link with Souffle.

Note that we would need to link with a native binary if we were to use
Souffle user-defined functors. However, we have not needed to resort to
that yet.