### PR TITLE
Rename Type to TypeBase and introduce a new Type wrapper class.

### DIFF
--- a/src/ir/handle_connection_spec.h
+++ b/src/ir/handle_connection_spec.h
@@ -29,24 +29,24 @@ namespace raksha::ir {
 // equivalent ArcsManifestProtos.
 class HandleConnectionSpec {
  public:
-  explicit HandleConnectionSpec(
-    std::string name, bool reads, bool writes,
-    std::unique_ptr<types::Type> type)
-    : name_(std::move(name)), reads_(reads), writes_(writes),
-      type_(std::move(type)) {}
+  explicit HandleConnectionSpec(std::string name, bool reads, bool writes,
+                                types::Type type)
+      : name_(std::move(name)),
+        reads_(reads),
+        writes_(writes),
+        type_(std::move(type)) {}
 
   const std::string &name() const { return name_; }
   bool reads() const { return reads_; }
   bool writes() const { return writes_; }
-  const types::Type &type() const { return *type_; }
+  const types::Type &type() const { return type_; }
 
   // Get all of the AccessPaths rooted at the associated ParticleSpec
   // (indicated through the provided name) through leaf fields of type_.
   std::vector<AccessPath> GetAccessPaths(
       std::string particle_spec_name) const {
     std::vector<AccessPath> result_paths;
-    AccessPathSelectorsSet selectors_set =
-        type_->GetAccessPathSelectorsSet();
+    AccessPathSelectorsSet selectors_set = type_.GetAccessPathSelectorsSet();
     AccessPathRoot root(
         HandleConnectionSpecAccessPathRoot(
             std::move(particle_spec_name), name_));
@@ -67,7 +67,7 @@ class HandleConnectionSpec {
   // HandleConnectionSpec.
   bool writes_;
   // The type of this HandleConnectionSpec.
-  std::unique_ptr<types::Type> type_;
+  types::Type type_;
 };
 
 }  // namespace raksha::ir

--- a/src/ir/proto/entity_type_test.cc
+++ b/src/ir/proto/entity_type_test.cc
@@ -32,7 +32,7 @@ TEST_P(EntityTypeTest, RoundTripPreservesAllInformation) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(GetParam(),
                                                             &orig_type_proto))
       << "Failed to parse type proto.";
-  arcs::TypeProto result_type_proto = Encode(*Decode(orig_type_proto));
+  arcs::TypeProto result_type_proto = Encode(Decode(orig_type_proto));
   ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
       orig_type_proto, result_type_proto));
 }

--- a/src/ir/proto/handle_connection_spec.cc
+++ b/src/ir/proto/handle_connection_spec.cc
@@ -45,7 +45,7 @@ HandleConnectionSpec Decode(const arcs::HandleConnectionSpecProto &proto) {
   }
   CHECK(proto.has_type())
     << "Found connection spec " << name << " without required type.";
-  std::unique_ptr<types::Type> type = types::proto::Decode(proto.type());
+  types::Type type = types::proto::Decode(proto.type());
   return HandleConnectionSpec(std::move(name), reads, writes, std::move(type));
 }
 

--- a/src/ir/proto/schema.cc
+++ b/src/ir/proto/schema.cc
@@ -31,7 +31,7 @@ Schema decode(const arcs::SchemaProto& schema_proto) {
     name = schema_names.at(0);
   }
 
-  absl::flat_hash_map<std::string, std::unique_ptr<Type>> field_map;
+  absl::flat_hash_map<std::string, Type> field_map;
   for (const auto &field_name_type_pair : schema_proto.fields()) {
     const std::string &field_name = field_name_type_pair.first;
     const arcs::TypeProto &type_proto = field_name_type_pair.second;
@@ -52,7 +52,7 @@ arcs::SchemaProto encode(const Schema& schema) {
   auto &fields_map = *schema_proto.mutable_fields();
   for (auto &field_name_type_pair : schema.fields()) {
     const std::string &field_name = field_name_type_pair.first;
-    const Type &field_type = *field_name_type_pair.second;
+    const Type &field_type = field_name_type_pair.second;
 
     auto insert_result = fields_map.insert(
         {field_name, Encode(field_type)});

--- a/src/ir/proto/type.cc
+++ b/src/ir/proto/type.cc
@@ -24,7 +24,7 @@
 
 namespace raksha::ir::types::proto {
 
-std::unique_ptr<Type> Decode(const arcs::TypeProto &type_proto) {
+Type Decode(const arcs::TypeProto &type_proto) {
   // Delegate to the various CreateFromProto implementations on the base types
   // depending upon which specific type is contained within the TypeProto.
   CHECK(!type_proto.optional())
@@ -35,9 +35,10 @@ std::unique_ptr<Type> Decode(const arcs::TypeProto &type_proto) {
     case arcs::TypeProto::DATA_NOT_SET:
       LOG(FATAL) << "Found a TypeProto with an unset specific type.";
     case arcs::TypeProto::kPrimitive:
-      return std::make_unique<PrimitiveType>(decode(type_proto.primitive()));
+      return Type(
+          std::make_unique<PrimitiveType>(decode(type_proto.primitive())));
     case arcs::TypeProto::kEntity:
-      return std::make_unique<EntityType>(decode(type_proto.entity()));
+      return Type(std::make_unique<EntityType>(decode(type_proto.entity())));
     default:
       LOG(FATAL) << "Found unimplemented type. Only Primitive and Entity "
                     "types are currently implemented.";
@@ -46,11 +47,12 @@ std::unique_ptr<Type> Decode(const arcs::TypeProto &type_proto) {
 }
 
 arcs::TypeProto Encode(const Type& type) {
-  switch (type.kind()) {
-    case Type::Kind::kPrimitive:
-      return encodeAsTypeProto(static_cast<const PrimitiveType&>(type));
-    case Type::Kind::kEntity:
-      return encodeAsTypeProto(static_cast<const EntityType&>(type));
+  const TypeBase& type_base = type.type_base();
+  switch (type_base.kind()) {
+    case TypeBase::Kind::kPrimitive:
+      return encodeAsTypeProto(static_cast<const PrimitiveType&>(type_base));
+    case TypeBase::Kind::kEntity:
+      return encodeAsTypeProto(static_cast<const EntityType&>(type_base));
   }
   CHECK(false) << "Found unknown Type.";
 }

--- a/src/ir/proto/type.h
+++ b/src/ir/proto/type.h
@@ -22,7 +22,7 @@
 namespace raksha::ir::types::proto {
 
 // Decodes the given `type_proto` and returns Type as a unique_ptr.
-std::unique_ptr<Type> Decode(const arcs::TypeProto &type_proto);
+Type Decode(const arcs::TypeProto &type_proto);
 
 // Encodes the given `type` in an arcs::TypeProto.
 arcs::TypeProto Encode(const Type& type);

--- a/src/ir/types/entity_type.h
+++ b/src/ir/types/entity_type.h
@@ -9,11 +9,11 @@
 
 namespace raksha::ir::types {
 
-class EntityType : public Type {
+class EntityType : public TypeBase {
  public:
   explicit EntityType(Schema schema) : schema_(std::move(schema)) {}
 
-  Type::Kind kind() const override { return Type::Kind::kEntity; }
+  TypeBase::Kind kind() const override { return TypeBase::Kind::kEntity; }
 
   raksha::ir::AccessPathSelectorsSet
   GetAccessPathSelectorsSet() const override {

--- a/src/ir/types/primitive_type.h
+++ b/src/ir/types/primitive_type.h
@@ -11,20 +11,20 @@ namespace raksha::ir::types {
 // Right now, the most important thing about primitive types is that they
 // terminate an access path. For now, we've left them empty; we should fill
 // them in in the future.
-class PrimitiveType : public Type {
+class PrimitiveType : public TypeBase {
  public:
   // For now, a primitive type has no members and a trivial constructor. This
   // will change as we add more cases to this translator in the future.
   PrimitiveType() = default;
 
-  Type::Kind kind() const override { return Type::Kind::kPrimitive; }
+  TypeBase::Kind kind() const override { return TypeBase::Kind::kPrimitive; }
 
   // A primitive type marks the end of a single access path to be built.
   // Return a set containing an empty AccessPathSelectors object.
   raksha::ir::AccessPathSelectorsSet
     GetAccessPathSelectorsSet() const override {
     return raksha::ir::AccessPathSelectorsSet(
-        { raksha::ir::AccessPathSelectors() });
+        {raksha::ir::AccessPathSelectors()});
   }
 };
 

--- a/src/ir/types/primitive_type_test.cc
+++ b/src/ir/types/primitive_type_test.cc
@@ -10,7 +10,7 @@ namespace ir = raksha::ir;
 
 TEST(PrimitiveTypeTest, KindReturnsCorrectKind) {
   PrimitiveType primitive_type;
-  EXPECT_EQ(primitive_type.kind(), Type::Kind::kPrimitive);
+  EXPECT_EQ(primitive_type.kind(), TypeBase::Kind::kPrimitive);
 }
 
 TEST(TestGetAccessPaths, TestGetAccessPaths) {

--- a/src/ir/types/schema.cc
+++ b/src/ir/types/schema.cc
@@ -26,7 +26,7 @@ ir::AccessPathSelectorsSet Schema::GetAccessPathSelectorsSet() const {
         ir::Selector(ir::FieldSelector(field_name_type_pair.first));
 
     ir::AccessPathSelectorsSet field_access_paths =
-        field_name_type_pair.second->GetAccessPathSelectorsSet();
+        field_name_type_pair.second.GetAccessPathSelectorsSet();
 
     result = ir::AccessPathSelectorsSet::Union(
         std::move(result),

--- a/src/ir/types/schema.h
+++ b/src/ir/types/schema.h
@@ -12,23 +12,21 @@ namespace raksha::ir::types {
 
 class Schema {
  public:
-  explicit Schema(
-    std::optional<std::string> name,
-    absl::flat_hash_map<std::string, std::unique_ptr<Type>> fields)
-    : name_(std::move(name)), fields_(std::move(fields)) {}
+  explicit Schema(std::optional<std::string> name,
+                  absl::flat_hash_map<std::string, Type> fields)
+      : name_(std::move(name)), fields_(std::move(fields)) {}
 
   raksha::ir::AccessPathSelectorsSet GetAccessPathSelectorsSet() const;
 
   const std::optional<std::string>& name() const { return name_; }
 
-  const absl::flat_hash_map<std::string, std::unique_ptr<Type>>& fields()
-      const {
+  const absl::flat_hash_map<std::string, Type>& fields() const {
     return fields_;
   }
 
  private:
   std::optional<std::string> name_;
-  absl::flat_hash_map<std::string, std::unique_ptr<Type>> fields_;
+  absl::flat_hash_map<std::string, Type> fields_;
 };
 
 }  // namespace raksha::ir::types

--- a/src/ir/types/type.h
+++ b/src/ir/types/type.h
@@ -6,11 +6,11 @@
 
 namespace raksha::ir::types {
 
-class Type {
+class TypeBase {
  public:
   enum class Kind { kPrimitive, kEntity };
 
-  virtual ~Type() {}
+  virtual ~TypeBase() {}
 
   virtual raksha::ir::AccessPathSelectorsSet GetAccessPathSelectorsSet()
       const = 0;
@@ -18,6 +18,24 @@ class Type {
   // Returns the kind of type.
   virtual Kind kind() const = 0;
 };
+
+
+class Type {
+ public:
+  Type(std::unique_ptr<TypeBase> type) : type_(std::move(type)) {}
+
+  raksha::ir::AccessPathSelectorsSet GetAccessPathSelectorsSet() const {
+    return type_->GetAccessPathSelectorsSet();
+  }
+
+  // TODO: This should be removed to hide the TypeBase.  method is added as a
+  // stop-gap solution to work with the rest of the code base.
+  const TypeBase& type_base() const { return *type_.get(); }
+
+ private:
+  std::unique_ptr<TypeBase> type_;
+};
+
 
 }  // namespace raksha::ir::types
 

--- a/src/xform_to_datalog/manifest_datalog_facts.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts.cc
@@ -114,10 +114,10 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
 
         CHECK(connection_proto.has_type())
           << "Handle connection with absent type not allowed.";
-        std::unique_ptr<types::Type> connection_type =
+        types::Type connection_type =
             ir::types::proto::Decode(connection_proto.type());
         ir::AccessPathSelectorsSet access_path_selectors_set =
-            connection_type->GetAccessPathSelectorsSet();
+            connection_type.GetAccessPathSelectorsSet();
 
         // Look up the HandleConnectionSpec to see if the handle connection
         // will read and/or write.

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -64,10 +64,10 @@ std::vector<ir::HandleConnectionSpec> GetHandleConnectionSpecs() {
   std::vector<ir::HandleConnectionSpec> result;
   result.push_back(ir::HandleConnectionSpec(
       "in", /*reads=*/true, /*writes=*/false,
-      /*type=*/std::make_unique<ir::types::PrimitiveType>()));
+      /*type=*/ir::types::Type(std::make_unique<ir::types::PrimitiveType>())));
   result.push_back(ir::HandleConnectionSpec(
       "out", /*reads=*/false, /*writes=*/true,
-      /*type=*/std::make_unique<ir::types::PrimitiveType>()));
+      /*type=*/ir::types::Type(std::make_unique<ir::types::PrimitiveType>())));
   return result;
 }
 


### PR DESCRIPTION
This refactoring is a staging step to make type a copyable value type. Specifically, this PR  does the following:
  - Renames `Type` to `TypeBase`
  - Introduces a wrapper `Type` class that holds onto `std::unique_ptr<TypeBase>`
  - replaces all _original_ uses of `std::unique_ptr<Type>` with `Type`.