### PR TITLE
Add type factory for creating types::Type instances.

### DIFF
--- a/src/ir/handle_connection_spec_test.cc
+++ b/src/ir/handle_connection_spec_test.cc
@@ -21,6 +21,7 @@
 
 #include "src/common/testing/gtest.h"
 #include "src/ir/proto/handle_connection_spec.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir {
@@ -33,7 +34,10 @@ struct ProtoStringAndExpectations {
 };
 
 class RoundTripHandleConnectionSpecProtoTest :
-    public testing::TestWithParam<ProtoStringAndExpectations> {};
+    public testing::TestWithParam<ProtoStringAndExpectations> {
+protected:
+  types::TypeFactory type_factory_;
+};
 
 TEST_P(RoundTripHandleConnectionSpecProtoTest,
        RoundTripHandleConnectionSpecProtoTest) {
@@ -42,7 +46,8 @@ TEST_P(RoundTripHandleConnectionSpecProtoTest,
   arcs::HandleConnectionSpecProto original_proto;
   google::protobuf::TextFormat::ParseFromString(
       info.proto_str, &original_proto);
-  HandleConnectionSpec handle_connection_spec = proto::Decode(original_proto);
+  HandleConnectionSpec handle_connection_spec =
+      proto::Decode(type_factory_, original_proto);
 
   EXPECT_EQ(handle_connection_spec.name(), info.expected_name);
   EXPECT_EQ(handle_connection_spec.reads(), info.expected_reads);
@@ -86,14 +91,18 @@ struct ProtoStringAndExpectedAccessPathPieces {
 
 class GetAccessPathTest :
  public testing::TestWithParam<
-  std::tuple<ProtoStringAndExpectedAccessPathPieces, std::string>> {};
+  std::tuple<ProtoStringAndExpectedAccessPathPieces, std::string>> {
+ protected:
+  types::TypeFactory type_factory_;
+};
 
 TEST_P(GetAccessPathTest, GetAccessPathTest) {
   const ProtoStringAndExpectedAccessPathPieces &param = std::get<0>(GetParam());
   const std::string &particle_spec_name = std::get<1>(GetParam());
   arcs::HandleConnectionSpecProto hcs_proto;
   google::protobuf::TextFormat::ParseFromString(param.textproto, &hcs_proto);
-  HandleConnectionSpec handle_connection_spec = proto::Decode(hcs_proto);
+  HandleConnectionSpec handle_connection_spec =
+      proto::Decode(type_factory_, hcs_proto);
   std::vector<ir::AccessPath> access_paths =
       handle_connection_spec.GetAccessPaths(particle_spec_name);
   std::vector<std::string> found_access_path_selector_strings;

--- a/src/ir/particle_spec_test.cc
+++ b/src/ir/particle_spec_test.cc
@@ -18,9 +18,10 @@
 
 #include <google/protobuf/text_format.h>
 
-#include "src/common/testing/gtest.h"
 #include "src/common/logging/logging.h"
+#include "src/common/testing/gtest.h"
 #include "src/ir/proto/particle_spec.h"
+#include "src/ir/types/type_factory.h"
 
 namespace raksha::ir {
 
@@ -35,17 +36,20 @@ struct ParticleSpecProtoAndExpectedInfo {
 class ParticleSpecFromProtoTest :
    public testing::TestWithParam<ParticleSpecProtoAndExpectedInfo> {
  protected:
-  ParticleSpecFromProtoTest() : particle_spec_(CreateParticleSpec()) {}
+  ParticleSpecFromProtoTest()
+      : particle_spec_(CreateParticleSpec(type_factory_)) {}
 
-  static std::unique_ptr<ParticleSpec> CreateParticleSpec() {
+  static std::unique_ptr<ParticleSpec> CreateParticleSpec(
+      types::TypeFactory& type_factory) {
     arcs::ParticleSpecProto particle_spec_proto;
     std::string textproto = GetParam().textproto;
     CHECK(google::protobuf::TextFormat::ParseFromString(
         textproto, &particle_spec_proto))
         << "Particle spec textproto did not parse correctly.";
-    return proto::Decode(particle_spec_proto);
+    return proto::Decode(type_factory, particle_spec_proto);
   }
 
+  types::TypeFactory type_factory_;
   std::unique_ptr<ParticleSpec> particle_spec_;
 };
 

--- a/src/ir/proto/entity_type.cc
+++ b/src/ir/proto/entity_type.cc
@@ -19,10 +19,11 @@
 
 namespace raksha::ir::types::proto {
 
-EntityType decode(const arcs::EntityTypeProto& entity_type_proto) {
+EntityType decode(types::TypeFactory& type_factory,
+                  const arcs::EntityTypeProto& entity_type_proto) {
   CHECK(entity_type_proto.has_schema())
       << "Schema is required for Entity types.";
-  return EntityType(decode(entity_type_proto.schema()));
+  return EntityType(decode(type_factory, entity_type_proto.schema()));
 }
 
 arcs::EntityTypeProto encode(const EntityType& entity_type) {

--- a/src/ir/proto/entity_type.cc
+++ b/src/ir/proto/entity_type.cc
@@ -19,11 +19,12 @@
 
 namespace raksha::ir::types::proto {
 
-EntityType decode(types::TypeFactory& type_factory,
+Type decode(types::TypeFactory& type_factory,
                   const arcs::EntityTypeProto& entity_type_proto) {
   CHECK(entity_type_proto.has_schema())
       << "Schema is required for Entity types.";
-  return EntityType(decode(type_factory, entity_type_proto.schema()));
+  return type_factory.MakeEntityType(
+      decode(type_factory, entity_type_proto.schema()));
 }
 
 arcs::EntityTypeProto encode(const EntityType& entity_type) {

--- a/src/ir/proto/entity_type.h
+++ b/src/ir/proto/entity_type.h
@@ -23,8 +23,8 @@
 namespace raksha::ir::types::proto {
 
 // Decodes the given `entity_type_proto` as an EntityType.
-EntityType decode(types::TypeFactory& type_factory,
-                  const arcs::EntityTypeProto& entity_type_proto);
+Type decode(types::TypeFactory& type_factory,
+            const arcs::EntityTypeProto& entity_type_proto);
 
 // Encodes the given `entity_type` as an EntityTypeProto.
 arcs::EntityTypeProto encode(const EntityType& entity_type);

--- a/src/ir/proto/entity_type.h
+++ b/src/ir/proto/entity_type.h
@@ -17,12 +17,14 @@
 #define SRC_IR_PROTO_ENTITY_TYPE_H_
 
 #include "src/ir/types/entity_type.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::types::proto {
 
 // Decodes the given `entity_type_proto` as an EntityType.
-EntityType decode(const arcs::EntityTypeProto& entity_type_proto);
+EntityType decode(types::TypeFactory& type_factory,
+                  const arcs::EntityTypeProto& entity_type_proto);
 
 // Encodes the given `entity_type` as an EntityTypeProto.
 arcs::EntityTypeProto encode(const EntityType& entity_type);

--- a/src/ir/proto/entity_type_test.cc
+++ b/src/ir/proto/entity_type_test.cc
@@ -21,18 +21,23 @@
 #include "google/protobuf/util/message_differencer.h"
 #include "src/common/testing/gtest.h"
 #include "src/ir/proto/type.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::types::proto {
 
-class EntityTypeTest : public testing::TestWithParam<std::string> {};
+class EntityTypeTest : public testing::TestWithParam<std::string> {
+ protected:
+  types::TypeFactory type_factory_;
+};
 
 TEST_P(EntityTypeTest, RoundTripPreservesAllInformation) {
   arcs::TypeProto orig_type_proto;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(GetParam(),
                                                             &orig_type_proto))
       << "Failed to parse type proto.";
-  arcs::TypeProto result_type_proto = Encode(Decode(orig_type_proto));
+  arcs::TypeProto result_type_proto =
+      Encode(Decode(type_factory_, orig_type_proto));
   ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
       orig_type_proto, result_type_proto));
 }

--- a/src/ir/proto/handle_connection_spec.cc
+++ b/src/ir/proto/handle_connection_spec.cc
@@ -20,7 +20,8 @@
 
 namespace raksha::ir::proto {
 
-HandleConnectionSpec Decode(const arcs::HandleConnectionSpecProto &proto) {
+HandleConnectionSpec Decode(types::TypeFactory &type_factory,
+                            const arcs::HandleConnectionSpecProto &proto) {
   std::string name = proto.name();
   CHECK(!name.empty()) << "Found connection spec without required name.";
   bool reads = false;
@@ -45,7 +46,7 @@ HandleConnectionSpec Decode(const arcs::HandleConnectionSpecProto &proto) {
   }
   CHECK(proto.has_type())
     << "Found connection spec " << name << " without required type.";
-  types::Type type = types::proto::Decode(proto.type());
+  types::Type type = types::proto::Decode(type_factory, proto.type());
   return HandleConnectionSpec(std::move(name), reads, writes, std::move(type));
 }
 

--- a/src/ir/proto/handle_connection_spec.h
+++ b/src/ir/proto/handle_connection_spec.h
@@ -18,11 +18,13 @@
 #define SRC_IR_PROTO_HANDLE_CONNECTION_SPEC_H_
 
 #include "src/ir/handle_connection_spec.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::proto {
 
-HandleConnectionSpec Decode(const arcs::HandleConnectionSpecProto &proto);
+HandleConnectionSpec Decode(types::TypeFactory &type_factory,
+                            const arcs::HandleConnectionSpecProto &proto);
 
 arcs::HandleConnectionSpecProto Encode(const HandleConnectionSpec &hcs);
 

--- a/src/ir/proto/particle_spec.cc
+++ b/src/ir/proto/particle_spec.cc
@@ -26,6 +26,7 @@
 namespace raksha::ir::proto {
 
 std::unique_ptr<ParticleSpec> Decode(
+    types::TypeFactory &type_factory,
     const arcs::ParticleSpecProto &particle_spec_proto) {
   std::string name = particle_spec_proto.name();
   CHECK(!name.empty()) << "Expected particle spec to have a name.";
@@ -33,7 +34,7 @@ std::unique_ptr<ParticleSpec> Decode(
   std::vector<HandleConnectionSpec> handle_connection_specs;
   for (const arcs::HandleConnectionSpecProto &hcs_proto :
       particle_spec_proto.connections()) {
-    handle_connection_specs.push_back(proto::Decode(hcs_proto));
+    handle_connection_specs.push_back(proto::Decode(type_factory, hcs_proto));
   }
 
   std::vector<TagClaim> tag_claims;

--- a/src/ir/proto/particle_spec.h
+++ b/src/ir/proto/particle_spec.h
@@ -20,11 +20,13 @@
 #include <memory>
 
 #include "src/ir/particle_spec.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::proto {
 
-std::unique_ptr<ParticleSpec> Decode(const arcs::ParticleSpecProto &proto);
+std::unique_ptr<ParticleSpec> Decode(types::TypeFactory& type_factory,
+                                     const arcs::ParticleSpecProto& proto);
 
 }  // namespace raksha::ir::proto
 

--- a/src/ir/proto/primitive_type.cc
+++ b/src/ir/proto/primitive_type.cc
@@ -16,11 +16,13 @@
 #include "src/ir/proto/primitive_type.h"
 
 #include "src/ir/types/primitive_type.h"
+#include "src/ir/types/type_factory.h"
 
 namespace raksha::ir::types::proto {
 
-PrimitiveType decode(const arcs::PrimitiveTypeProto &primitive_type_proto) {
-  return PrimitiveType();
+Type decode(TypeFactory& type_factory,
+            const arcs::PrimitiveTypeProto& primitive_type_proto) {
+  return type_factory.MakePrimitiveType();
 }
 
 arcs::PrimitiveTypeProto encode(const PrimitiveType& primitive_type) {

--- a/src/ir/proto/primitive_type.h
+++ b/src/ir/proto/primitive_type.h
@@ -17,12 +17,14 @@
 #define SRC_IR_PROTO_PRIMITIVE_TYPE_H_
 
 #include "src/ir/types/primitive_type.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::types::proto {
 
 // Decodes the given `primitive_type_proto` as a PrimitiveType.
-PrimitiveType decode(const arcs::PrimitiveTypeProto& primitive_type_proto);
+Type decode(TypeFactory& type_factory,
+            const arcs::PrimitiveTypeProto& primitive_type_proto);
 
 // Encodes the given `primitive_type` as an PrimitiveTypeProto.
 arcs::PrimitiveTypeProto encode(const PrimitiveType& primitive_type);
@@ -33,4 +35,3 @@ arcs::TypeProto encodeAsTypeProto(const PrimitiveType& primitive_type);
 }  // namespace raksha::ir::types::proto
 
 #endif  // SRC_IR_PROTO_PRIMITIVE_TYPE_H_
-

--- a/src/ir/proto/schema.cc
+++ b/src/ir/proto/schema.cc
@@ -22,7 +22,8 @@
 
 namespace raksha::ir::types::proto {
 
-Schema decode(const arcs::SchemaProto& schema_proto) {
+const Schema &decode(types::TypeFactory &type_factory,
+                     const arcs::SchemaProto &schema_proto) {
   auto schema_names = schema_proto.names();
   CHECK(schema_names.size() <= 1)
     << "Multiple names for a Schema not yet supported.";
@@ -36,12 +37,11 @@ Schema decode(const arcs::SchemaProto& schema_proto) {
     const std::string &field_name = field_name_type_pair.first;
     const arcs::TypeProto &type_proto = field_name_type_pair.second;
 
-    field_map.insert({field_name, Decode(type_proto)});
+    field_map.insert({field_name, Decode(type_factory, type_proto)});
   }
 
-  return Schema(std::move(name), std::move(field_map));
+  return type_factory.RegisterSchema(std::move(name), std::move(field_map));
 }
-
 
 // Create an arcs::SchemaProto message from the contents of this Schema object.
 arcs::SchemaProto encode(const Schema& schema) {

--- a/src/ir/proto/system_spec.cc
+++ b/src/ir/proto/system_spec.cc
@@ -25,13 +25,15 @@
 
 namespace raksha::ir::proto {
 
-std::unique_ptr<SystemSpec> Decode(const arcs::ManifestProto &manifest_proto) {
+std::unique_ptr<SystemSpec> Decode(types::TypeFactory &type_factory,
+                                   const arcs::ManifestProto &manifest_proto) {
   // Turn each ParticleSpecProto indicated in the manifest_proto into a
   // ParticleSpec object, which we can use directly.
   auto system_spec = std::make_unique<SystemSpec>();
   for (const arcs::ParticleSpecProto &particle_spec_proto :
        manifest_proto.particle_specs()) {
-    system_spec->AddParticleSpec(ir::proto::Decode(particle_spec_proto));
+    system_spec->AddParticleSpec(
+        ir::proto::Decode(type_factory, particle_spec_proto));
   }
   return system_spec;
 }

--- a/src/ir/proto/system_spec.h
+++ b/src/ir/proto/system_spec.h
@@ -17,11 +17,13 @@
 #define SRC_IR_PROTO_SYSTEM_SPEC_H_
 
 #include "src/ir/system_spec.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::proto {
 
-std::unique_ptr<SystemSpec> Decode(const arcs::ManifestProto &manifest_proto);
+std::unique_ptr<SystemSpec> Decode(types::TypeFactory& type_factory,
+                                   const arcs::ManifestProto& manifest_proto);
 
 }  // namespace raksha::ir::proto
 

--- a/src/ir/proto/type.cc
+++ b/src/ir/proto/type.cc
@@ -20,11 +20,13 @@
 #include "src/common/logging/logging.h"
 #include "src/ir/proto/entity_type.h"
 #include "src/ir/proto/primitive_type.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::types::proto {
 
-Type Decode(const arcs::TypeProto &type_proto) {
+Type Decode(types::TypeFactory& type_factory,
+            const arcs::TypeProto& type_proto) {
   // Delegate to the various CreateFromProto implementations on the base types
   // depending upon which specific type is contained within the TypeProto.
   CHECK(!type_proto.optional())
@@ -38,7 +40,8 @@ Type Decode(const arcs::TypeProto &type_proto) {
       return Type(
           std::make_unique<PrimitiveType>(decode(type_proto.primitive())));
     case arcs::TypeProto::kEntity:
-      return Type(std::make_unique<EntityType>(decode(type_proto.entity())));
+      return Type(std::make_unique<EntityType>(
+          decode(type_factory, type_proto.entity())));
     default:
       LOG(FATAL) << "Found unimplemented type. Only Primitive and Entity "
                     "types are currently implemented.";

--- a/src/ir/proto/type.cc
+++ b/src/ir/proto/type.cc
@@ -37,11 +37,9 @@ Type Decode(types::TypeFactory& type_factory,
     case arcs::TypeProto::DATA_NOT_SET:
       LOG(FATAL) << "Found a TypeProto with an unset specific type.";
     case arcs::TypeProto::kPrimitive:
-      return Type(
-          std::make_unique<PrimitiveType>(decode(type_proto.primitive())));
+      return decode(type_factory, type_proto.primitive());
     case arcs::TypeProto::kEntity:
-      return Type(std::make_unique<EntityType>(
-          decode(type_factory, type_proto.entity())));
+      return decode(type_factory, type_proto.entity());
     default:
       LOG(FATAL) << "Found unimplemented type. Only Primitive and Entity "
                     "types are currently implemented.";

--- a/src/ir/proto/type.h
+++ b/src/ir/proto/type.h
@@ -17,12 +17,13 @@
 #define SRC_IR_PROTO_TYPE_H_
 
 #include "src/ir/types/type.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::ir::types::proto {
 
-// Decodes the given `type_proto` and returns Type as a unique_ptr.
-Type Decode(const arcs::TypeProto &type_proto);
+// Decodes the given `type_proto` and returns Type.
+Type Decode(TypeFactory& type_factory, const arcs::TypeProto& type_proto);
 
 // Encodes the given `type` in an arcs::TypeProto.
 arcs::TypeProto Encode(const Type& type);

--- a/src/ir/system_spec.h
+++ b/src/ir/system_spec.h
@@ -17,6 +17,7 @@
 #define SRC_IR_SYSTEM_SPEC_H_
 
 #include "src/ir/particle_spec.h"
+#include "src/ir/types/type_factory.h"
 
 namespace raksha::ir {
 

--- a/src/ir/types/BUILD
+++ b/src/ir/types/BUILD
@@ -2,12 +2,16 @@ package(default_visibility = ["//src:__subpackages__"])
 
 cc_library(
     name = "types",
-    srcs = ["schema.cc"],
+    srcs = [
+        "schema.cc",
+        "type_factory.cc",
+    ],
     hdrs = [
         "entity_type.h",
         "primitive_type.h",
         "schema.h",
         "type.h",
+        "type_factory.h",
     ],
     deps = [
         "//src/common/logging",

--- a/src/ir/types/entity_type.h
+++ b/src/ir/types/entity_type.h
@@ -2,28 +2,29 @@
 #define SRC_IR_TYPES_ENTITY_TYPE_H_
 
 #include "absl/container/flat_hash_set.h"
-#include "src/ir/types/schema.h"
-#include "src/ir/types/type.h"
+#include "absl/hash/hash.h"
 #include "src/ir/access_path_selectors.h"
 #include "src/ir/access_path_selectors_set.h"
+#include "src/ir/types/schema.h"
+#include "src/ir/types/type.h"
 
 namespace raksha::ir::types {
 
 class EntityType : public TypeBase {
  public:
-  explicit EntityType(Schema schema) : schema_(std::move(schema)) {}
+  explicit EntityType(const Schema& schema) : schema_(&schema) {}
 
   TypeBase::Kind kind() const override { return TypeBase::Kind::kEntity; }
 
   raksha::ir::AccessPathSelectorsSet
   GetAccessPathSelectorsSet() const override {
-    return schema_.GetAccessPathSelectorsSet();
+    return schema_->GetAccessPathSelectorsSet();
   }
 
-  const Schema& schema() const { return schema_; }
+  const Schema& schema() const { return *schema_; }
 
  private:
-  Schema schema_;
+  const Schema* schema_;
 };
 
 }  // namespace raksha::ir::types

--- a/src/ir/types/schema.h
+++ b/src/ir/types/schema.h
@@ -12,10 +12,6 @@ namespace raksha::ir::types {
 
 class Schema {
  public:
-  explicit Schema(std::optional<std::string> name,
-                  absl::flat_hash_map<std::string, Type> fields)
-      : name_(std::move(name)), fields_(std::move(fields)) {}
-
   raksha::ir::AccessPathSelectorsSet GetAccessPathSelectorsSet() const;
 
   const std::optional<std::string>& name() const { return name_; }
@@ -24,7 +20,13 @@ class Schema {
     return fields_;
   }
 
+  friend class TypeFactory;
+
  private:
+  explicit Schema(std::optional<std::string> name,
+                  absl::flat_hash_map<std::string, Type> fields)
+      : name_(std::move(name)), fields_(std::move(fields)) {}
+
   std::optional<std::string> name_;
   absl::flat_hash_map<std::string, Type> fields_;
 };

--- a/src/ir/types/type.h
+++ b/src/ir/types/type.h
@@ -19,7 +19,6 @@ class TypeBase {
   virtual Kind kind() const = 0;
 };
 
-
 class Type {
  public:
   Type(std::unique_ptr<TypeBase> type) : type_(std::move(type)) {}

--- a/src/ir/types/type.h
+++ b/src/ir/types/type.h
@@ -21,7 +21,6 @@ class TypeBase {
 
 class Type {
  public:
-  Type(std::unique_ptr<TypeBase> type) : type_(std::move(type)) {}
 
   raksha::ir::AccessPathSelectorsSet GetAccessPathSelectorsSet() const {
     return type_->GetAccessPathSelectorsSet();
@@ -31,7 +30,10 @@ class Type {
   // stop-gap solution to work with the rest of the code base.
   const TypeBase& type_base() const { return *type_.get(); }
 
+  friend class TypeFactory;
  private:
+  Type(std::unique_ptr<TypeBase> type) : type_(std::move(type)) {}
+
   std::unique_ptr<TypeBase> type_;
 };
 

--- a/src/ir/types/type_factory.cc
+++ b/src/ir/types/type_factory.cc
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,23 +12,23 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//-----------------------------------------------------------------------------
-#ifndef SRC_IR_PROTO_SCHEMA_H_
-#define SRC_IR_PROTO_SCHEMA_H_
+//----------------------------------------------------------------------------
+#include "src/ir/types/type_factory.h"
+
+#include <memory>
 
 #include "src/ir/types/schema.h"
-#include "src/ir/types/type_factory.h"
-#include "third_party/arcs/proto/manifest.pb.h"
 
-namespace raksha::ir::types::proto {
+namespace raksha::ir::types {
 
-// Decodes the given `schema_proto` and returns the resulting Schema.
-const Schema& decode(types::TypeFactory& type_factory,
-                     const arcs::SchemaProto& schema_proto);
+const Schema& TypeFactory::RegisterSchema(
+    std::optional<std::string> name,
+    absl::flat_hash_map<std::string, Type> fields) {
+  std::unique_ptr<Schema> new_schema(
+      new Schema(std::move(name), std::move(fields)));
+  const Schema* result = new_schema.get();
+  schemas_.push_back(std::move(new_schema));
+  return *result;
+}
 
-// Encodes the given `schema` as an arcs::SchemaProto.
-arcs::SchemaProto encode(const Schema& schema);
-
-}  // namespace raksha::ir::types::proto
-
-#endif  // SRC_IR_PROTO_SCHEMA_H_
+}  // namespace raksha::ir::types

--- a/src/ir/types/type_factory.cc
+++ b/src/ir/types/type_factory.cc
@@ -17,9 +17,19 @@
 
 #include <memory>
 
+#include "src/ir/types/entity_type.h"
+#include "src/ir/types/primitive_type.h"
 #include "src/ir/types/schema.h"
 
 namespace raksha::ir::types {
+
+Type TypeFactory::MakePrimitiveType() {
+  return Type(std::make_unique<PrimitiveType>());
+}
+
+Type TypeFactory::MakeEntityType(const Schema& schema) {
+  return Type(std::make_unique<EntityType>(schema));
+}
 
 const Schema& TypeFactory::RegisterSchema(
     std::optional<std::string> name,

--- a/src/ir/types/type_factory.h
+++ b/src/ir/types/type_factory.h
@@ -28,6 +28,13 @@ class Schema;
 
 class TypeFactory {
  public:
+
+  // Create a primitive type and wrap it in `types::Type`.
+  Type MakePrimitiveType();
+
+  // Create an entity type and wrap it in `types::Type`.
+  Type MakeEntityType(const Schema& schema);
+
   // Create and register the given schema.
   const Schema& RegisterSchema(std::optional<std::string> name,
                                absl::flat_hash_map<std::string, Type> fields);

--- a/src/ir/types/type_factory.h
+++ b/src/ir/types/type_factory.h
@@ -1,0 +1,42 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+#ifndef SRC_IR_TYPES_TYPE_FACTORY_H_
+#define SRC_IR_TYPES_TYPE_FACTORY_H_
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "src/ir/types/primitive_type.h"
+#include "src/ir/types/schema.h"
+#include "src/ir/types/type.h"
+
+namespace raksha::ir::types {
+
+class Schema;
+
+class TypeFactory {
+ public:
+  // Create and register the given schema.
+  const Schema& RegisterSchema(std::optional<std::string> name,
+                               absl::flat_hash_map<std::string, Type> fields);
+
+ private:
+  // Known schemas.
+  std::vector<std::unique_ptr<types::Schema>> schemas_;
+};
+
+}  // namespace raksha::ir::types
+
+#endif  // SRC_IR_TYPES_TYPE_H_

--- a/src/xform_to_datalog/generate_datalog_program.cc
+++ b/src/xform_to_datalog/generate_datalog_program.cc
@@ -27,6 +27,7 @@
 #include "src/ir/datalog_print_context.h"
 #include "src/ir/proto/system_spec.h"
 #include "src/ir/system_spec.h"
+#include "src/ir/types/type_factory.h"
 #include "src/xform_to_datalog/authorization_logic_datalog_facts.h"
 #include "src/xform_to_datalog/datalog_facts.h"
 #include "src/xform_to_datalog/manifest_datalog_facts.h"
@@ -89,11 +90,12 @@ int main(int argc, char *argv[]) {
 
   // Turn each ParticleSpecProto indicated in the manifest_proto into a
   // ParticleSpec object, which we can use directly.
+  raksha::ir::types::TypeFactory type_factory;
   std::unique_ptr<raksha::ir::SystemSpec> system_spec =
-      raksha::ir::proto::Decode(manifest_proto);
+      raksha::ir::proto::Decode(type_factory, manifest_proto);
   CHECK(system_spec != nullptr);
   auto manifest_datalog_facts = ManifestDatalogFacts::CreateFromManifestProto(
-      *system_spec, manifest_proto);
+      type_factory, *system_spec, manifest_proto);
 
   std::filesystem::path auth_logic_filename = auth_logic_filepath.filename();
   auth_logic_filepath.remove_filename();

--- a/src/xform_to_datalog/manifest_datalog_facts.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts.cc
@@ -18,8 +18,9 @@
 #include "absl/container/flat_hash_map.h"
 #include "src/ir/handle_connection_spec.h"
 #include "src/ir/particle_spec.h"
-#include "src/ir/proto/type.h"
 #include "src/ir/proto/system_spec.h"
+#include "src/ir/proto/type.h"
+#include "src/ir/types/type_factory.h"
 
 namespace raksha::xform_to_datalog {
 
@@ -33,7 +34,7 @@ namespace types = raksha::ir::types;
 //  traversal. This works, but it is hard to read and hard to test. We should
 //  break this up.
 ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
-    const ir::SystemSpec& system_spec,
+    types::TypeFactory &type_factory, const ir::SystemSpec &system_spec,
     const arcs::ManifestProto &manifest_proto) {
   // These collections will be used as inputs to the constructor that we
   // return from this function.
@@ -115,7 +116,7 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
         CHECK(connection_proto.has_type())
           << "Handle connection with absent type not allowed.";
         types::Type connection_type =
-            ir::types::proto::Decode(connection_proto.type());
+            ir::types::proto::Decode(type_factory, connection_proto.type());
         ir::AccessPathSelectorsSet access_path_selectors_set =
             connection_type.GetAccessPathSelectorsSet();
 

--- a/src/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/xform_to_datalog/manifest_datalog_facts.h
@@ -26,6 +26,7 @@
 #include "src/ir/system_spec.h"
 #include "src/ir/tag_check.h"
 #include "src/ir/tag_claim.h"
+#include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
 namespace raksha::xform_to_datalog {
@@ -60,7 +61,8 @@ class ManifestDatalogFacts {
   };
 
   static ManifestDatalogFacts CreateFromManifestProto(
-      const ir::SystemSpec& system_spec,
+      raksha::ir::types::TypeFactory &type_factory,
+      const ir::SystemSpec &system_spec,
       const arcs::ManifestProto &manifest_proto);
 
   // A default constructor creates a sensible, legal state (no facts) and

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -301,16 +301,17 @@ class ParseBigManifestTest : public testing::Test {
     arcs::ManifestProto manifest_proto;
     google::protobuf::TextFormat::ParseFromString(
         kManifestTextproto, &manifest_proto);
-    system_spec_ = ir::proto::Decode(manifest_proto);
+    system_spec_ = ir::proto::Decode(type_factory_, manifest_proto);
     CHECK(system_spec_ != nullptr);
     datalog_facts_ = ManifestDatalogFacts::CreateFromManifestProto(
-        *system_spec_, manifest_proto);
+        type_factory_, *system_spec_, manifest_proto);
 
     std::string datalog = datalog_facts_.ToDatalog(ctxt_, "~");
     datalog_strings_ = absl::StrSplit(datalog, "~", absl::SkipEmpty());
   }
 
  protected:
+  ir::types::TypeFactory type_factory_;
   std::unique_ptr<ir::SystemSpec> system_spec_;
   ir::DatalogPrintContext ctxt_;
   ManifestDatalogFacts datalog_facts_;

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -42,6 +42,8 @@ TEST_P(ManifestDatalogFactsToDatalogTest, ManifestDatalogFactsToDatalogTest) {
   EXPECT_EQ(datalog_facts.ToDatalog(ctxt), expected_result_string);
 }
 
+static ir::types::TypeFactory type_factory;
+
 static const ir::AccessPath kHandleH1AccessPath(
     ir::AccessPathRoot(ir::HandleAccessPathRoot("recipe", "h1")),
     ir::AccessPathSelectors());
@@ -62,12 +64,12 @@ static const ir::AccessPath kHandleConnectionOutAccessPath(
 
 std::vector<ir::HandleConnectionSpec> GetHandleConnectionSpecs() {
   std::vector<ir::HandleConnectionSpec> result;
-  result.push_back(ir::HandleConnectionSpec(
-      "in", /*reads=*/true, /*writes=*/false,
-      /*type=*/ir::types::Type(std::make_unique<ir::types::PrimitiveType>())));
-  result.push_back(ir::HandleConnectionSpec(
-      "out", /*reads=*/false, /*writes=*/true,
-      /*type=*/ir::types::Type(std::make_unique<ir::types::PrimitiveType>())));
+  result.push_back(
+      ir::HandleConnectionSpec("in", /*reads=*/true, /*writes=*/false,
+                               /*type=*/type_factory.MakePrimitiveType()));
+  result.push_back(
+      ir::HandleConnectionSpec("out", /*reads=*/false, /*writes=*/true,
+                               /*type=*/type_factory.MakePrimitiveType()));
   return result;
 }
 
@@ -301,17 +303,16 @@ class ParseBigManifestTest : public testing::Test {
     arcs::ManifestProto manifest_proto;
     google::protobuf::TextFormat::ParseFromString(
         kManifestTextproto, &manifest_proto);
-    system_spec_ = ir::proto::Decode(type_factory_, manifest_proto);
+    system_spec_ = ir::proto::Decode(type_factory, manifest_proto);
     CHECK(system_spec_ != nullptr);
     datalog_facts_ = ManifestDatalogFacts::CreateFromManifestProto(
-        type_factory_, *system_spec_, manifest_proto);
+        type_factory, *system_spec_, manifest_proto);
 
     std::string datalog = datalog_facts_.ToDatalog(ctxt_, "~");
     datalog_strings_ = absl::StrSplit(datalog, "~", absl::SkipEmpty());
   }
 
  protected:
-  ir::types::TypeFactory type_factory_;
   std::unique_ptr<ir::SystemSpec> system_spec_;
   ir::DatalogPrintContext ctxt_;
   ManifestDatalogFacts datalog_facts_;


### PR DESCRIPTION
This PR introduces a `TypeFactory` class that is used to create and register types.  The `TypeFactory` will eventually be used to canonicalize types. For now, the `TypeFactory` simply owns all the Schemas that are created. The newly introduced `TypeFactory` instance is plumbed through to all the methods that need to create Schemas/Types.