### PR TITLE
Remove trailing comment from licenses rule.

### DIFF
--- a/gcb/rbe/configs/path/cc/BUILD
+++ b/gcb/rbe/configs/path/cc/BUILD
@@ -20,7 +20,7 @@ load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 load(":armeabi_cc_toolchain_config.bzl", "armeabi_cc_toolchain_config")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 cc_library(
     name = "malloc",


### PR DESCRIPTION
This prevents the comment from getting out of date if the license
details change.