### PR TITLE
Remove Kokoro configuration files.

### DIFF
--- a/kokoro/gcp_ubuntu/continuous.cfg
+++ b/kokoro/gcp_ubuntu/continuous.cfg
@@ -1,5 +1,0 @@
-# -*- protobuffer -*-
-# proto-file: google3/devtools/kokoro/config/proto/build.proto
-# proto-message: BuildConfig
-
-build_file: "raksha/kokoro/gcp_ubuntu/kokoro_build.sh"

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Fail on any error.
-set -e
-
-cd "${KOKORO_ARTIFACTS_DIR}/github/raksha"
-bazel build ...
-bazel test ...

--- a/kokoro/gcp_ubuntu/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/presubmit.cfg
@@ -1,5 +1,0 @@
-# -*- protobuffer -*-
-# proto-file: google3/devtools/kokoro/config/proto/build.proto
-# proto-message: BuildConfig
-
-build_file: "raksha/kokoro/gcp_ubuntu/kokoro_build.sh"


### PR DESCRIPTION
We switched from using kokoro to using GCB directly. That makes these
configuration files and scripts obsolete. This commit gets rid of them.