### PR TITLE
Add Hedron's compile commands extractor to WORKSPACE.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bazel-testlogs
 **/*.swp
 .vscode/**
 .clwb/**
+.cache/clangd/**
+compile_commands.json

--- a/BUILD
+++ b/BUILD
@@ -35,7 +35,7 @@ refresh_compile_commands(
     # Specify the targets of interest.
     # For example, specify a dict of targets and their arguments:
     targets = {
-      "//src/...": "",
+        "//src/...": "",
     },
     # For more details, feel free to look into the following bzl file:
     #   `external/hedron_compile_commands/refresh_compile_commands.bzl`.

--- a/BUILD
+++ b/BUILD
@@ -18,8 +18,27 @@
 licenses(["notice"])
 
 load("@buildtools//buildifier:def.bzl", "buildifier")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 # Target to fix all bazel files in Raksha repo.
 buildifier(
     name = "buildifier",
 )
+
+# Generates `compile_commands.json` for use with clangd.
+#
+# Run `bazel run //:refresh_compile_commands` to generate.
+#
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+
+    # Specify the targets of interest.
+    # For example, specify a dict of targets and their arguments:
+    targets = {
+      "//src/...": "",
+    },
+    # For more details, feel free to look into the following bzl file:
+    #   `external/hedron_compile_commands/refresh_compile_commands.bzl`.
+)
+
+licenses(["notice"])

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -234,3 +234,15 @@ http_archive(
         "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.5.tar.gz",
     ],
 )
+
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+http_archive(
+    name = "hedron_compile_commands",
+    strip_prefix = "bazel-compile-commands-extractor-ba1751e3bb9865df2d4661ca778b0cd4ffd1fb10",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/ba1751e3bb9865df2d4661ca778b0cd4ffd1fb10.tar.gz",
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()

--- a/external
+++ b/external
@@ -1,0 +1,1 @@
+bazel-out/../../../external


### PR DESCRIPTION
This allows us to generate `compile_commands.json` which is required to integrate `clangd` into vscode.