### PR TITLE
Update GRPC to 4.1.1.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,9 +14,9 @@ http_archive(
 # (See https://github.com/rules-proto-grpc/rules_proto_grpc)
 http_archive(
     name = "rules_proto_grpc",
-    sha256 = "7954abbb6898830cd10ac9714fbcacf092299fda00ed2baf781172f545120419",
-    strip_prefix = "rules_proto_grpc-3.1.1",
-    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/3.1.1.tar.gz"],
+    sha256 = "507e38c8d95c7efa4f3b1c0595a8e8f139c885cb41a76cab7e20e4e67ae87731",
+    strip_prefix = "rules_proto_grpc-4.1.1",
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.1.1.tar.gz"],
 )
 
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")


### PR DESCRIPTION
Initially, I upgraded this in hopes that 4.1.1 removed the need for the
`protos` attribute, allowing us to just put proto files in `deps` again.
That is not what happened. Committing the update anyway because it's
good to keep our dependencies fresh.