### PR TITLE
Made operator.h use `Block`'s full defn rather than a forward decl.

### DIFF
--- a/src/ir/data_decl.h
+++ b/src/ir/data_decl.h
@@ -19,10 +19,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
-#include "src/ir/operation.h"
-#include "src/ir/operator.h"
 #include "src/ir/types/type.h"
-#include "src/ir/value.h"
 
 namespace raksha::ir {
 

--- a/src/ir/operator.h
+++ b/src/ir/operator.h
@@ -20,11 +20,10 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "src/ir/types/type.h"
+#include "src/ir/block.h"
 #include "src/ir/value.h"
 
 namespace raksha::ir {
-
-class Block;
 
 // Signature of an operator. An operator could be simple operators (e.g., `+`,
 // `-`) or complex operators (e.g., particle, function) that is compose of other


### PR DESCRIPTION
The `Operator` class contains within it a member, `implementation_`,
that uses a `std::unique_ptr` pointing to `Block`. Previously, this
header had only a forward declaration for `Block`. This is bad, because
`unique_ptr` needs `Block`'s full definition to get its dtor and to
perform `sizeof` upon that class. This change makes `operator.h` include
the full `block.h` header, giving it access to the full definition of
`Block`.