### PR TITLE
Quote included protobuf files with `"` instead of `<`.

### DIFF
--- a/src/ir/derives_from_claim_test.cc
+++ b/src/ir/derives_from_claim_test.cc
@@ -16,7 +16,7 @@
 
 #include "src/ir/derives_from_claim.h"
 
-#include <google/protobuf/text_format.h>
+#include "google/protobuf/text_format.h"
 
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"

--- a/src/ir/handle_connection_spec_test.cc
+++ b/src/ir/handle_connection_spec_test.cc
@@ -16,8 +16,8 @@
 
 #include "src/ir/handle_connection_spec.h"
 
-#include <google/protobuf/util/message_differencer.h>
-#include <google/protobuf/text_format.h>
+#include "google/protobuf/util/message_differencer.h"
+#include "google/protobuf/text_format.h"
 
 #include "src/common/testing/gtest.h"
 #include "src/ir/proto/handle_connection_spec.h"

--- a/src/ir/particle_spec_test.cc
+++ b/src/ir/particle_spec_test.cc
@@ -16,7 +16,7 @@
 
 #include "src/ir/particle_spec.h"
 
-#include <google/protobuf/text_format.h>
+#include "google/protobuf/text_format.h"
 
 #include "src/common/logging/logging.h"
 #include "src/common/testing/gtest.h"

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -1,7 +1,7 @@
 #include "src/ir/tag_check.h"
 
-#include <google/protobuf/util/message_differencer.h>
-#include <google/protobuf/text_format.h>
+#include "google/protobuf/util/message_differencer.h"
+#include "google/protobuf/text_format.h"
 
 #include "absl/strings/str_format.h"
 #include "absl/strings/substitute.h"

--- a/src/ir/tag_claim_test.cc
+++ b/src/ir/tag_claim_test.cc
@@ -16,8 +16,8 @@
 
 #include "src/ir/tag_claim.h"
 
-#include <google/protobuf/util/message_differencer.h>
-#include <google/protobuf/text_format.h>
+#include "google/protobuf/util/message_differencer.h"
+#include "google/protobuf/text_format.h"
 
 #include "absl/strings/str_format.h"
 #include "src/common/testing/gtest.h"

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -16,7 +16,7 @@
 
 #include "src/xform_to_datalog/manifest_datalog_facts.h"
 
-#include <google/protobuf/text_format.h>
+#include "google/protobuf/text_format.h"
 
 #include "absl/strings/substitute.h"
 #include "src/common/testing/gtest.h"


### PR DESCRIPTION
Initially, I started adding protobuf headers using `<` because that is
what the protobuf documentation does. Others started adding protobuf
headers using `"` because that is what is usually standard in C++
projects. This PR changes the style to always use `"` for these header
files.