### PR TITLE
Turn off header modules everywhere where exceptions are turned on.

### DIFF
--- a/build_defs/raksha.bzl
+++ b/build_defs/raksha.bzl
@@ -119,6 +119,7 @@ def policy_check(name, dataflow_graph, auth_logic, expect_failure = False, visib
             "-fexceptions",
             "-Iexternal/souffle/src/include/souffle",
         ],
+        features = ["-use_header_modules"],  # Incompatible with -fexceptions.
         linkopts = ["-pthread"],
         deps = [
             "@souffle//:souffle_include_lib",

--- a/build_defs/souffle.bzl
+++ b/build_defs/souffle.bzl
@@ -107,6 +107,7 @@ def souffle_cc_library(
             # don't care about non-critical issues in it. Turn off warnings.
             "-w",
         ],
+        features = ["-use_header_modules"],  # Incompatible with -fexceptions.
         defines = [
             "__EMBEDDED_SOUFFLE__",
         ],
@@ -140,6 +141,7 @@ def souffle_cc_binary(
             # don't care about non-critical issues in it. Turn off warnings.
             "-w",
         ],
+        features = ["-use_header_modules"],  # Incompatible with -fexceptions.
         deps = ["@souffle//:souffle_include_lib"],
         visibility = visibility,
     )

--- a/build_defs/test_helpers.bzl
+++ b/build_defs/test_helpers.bzl
@@ -35,7 +35,11 @@ def extracted_datalog_string_test(
         name = "dl_string_test_file_generator_for_" + name,
         testonly = True,
         srcs = ["//src/test_utils/dl_string_extractor:dl_string_test_file_generator.cc"],
-        copts = ["-std=c++17", "-fexceptions"],
+        copts = [
+          "-std=c++17",
+          "-fexceptions"
+        ],
+        features = ["-use_header_modules"],  # Incompatible with -fexceptions.
         deps = [
             dl_string_lib,
             "//src/common/logging:logging",
@@ -84,6 +88,7 @@ def extracted_datalog_string_test(
             "-fexceptions",
             "-Iexternal/souffle/src/include/souffle",
         ],
+        features = ["-use_header_modules"],  # Incompatible with -fexceptions.
         linkopts = ["-pthread"],
         deps = [
             name + "_souffle_lib",

--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -16,6 +16,7 @@ cc_test(
         "-fexceptions",
         "-Iexternal/souffle/src/include/souffle",
     ],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     linkopts = ["-pthread"],
     deps = [
         ":taint_dl",

--- a/src/analysis/souffle/tests/arcs_fact_tests/BUILD
+++ b/src/analysis/souffle/tests/arcs_fact_tests/BUILD
@@ -55,6 +55,7 @@ exports_files([
         "-fexceptions",
         "-Iexternal/souffle/src/include/souffle",
     ],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     linkopts = ["-pthread"],
     deps = [
         "@souffle//:souffle_include_lib",
@@ -97,6 +98,7 @@ exports_files([
         "-Iexternal/souffle/src/include/souffle",
         "-DALL_PRINCIPALS_OWN_ALL_TAGS=1",
     ],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     linkopts = ["-pthread"],
     deps = [
         "@souffle//:souffle_include_lib",


### PR DESCRIPTION
Using exceptions with header modules causes problems within Google's
internal code base. This PR turns off header modules everywhere where
`-fexceptions` is used.