### PR TITLE
Utility for creating SSA names when printing IR.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -28,7 +28,6 @@ cc_library(
         "data_decl.h",
         "operation.h",
         "operator.h",
-        "storage.h",
         "value.h",
     ],
     deps = [
@@ -88,6 +87,32 @@ cc_test(
     srcs = ["operator_test.cc"],
     deps = [
         ":operator",
+        "//src/common/testing:gtest",
+    ],
+)
+
+cc_library(
+    name = "ssa_names",
+    hdrs = ["ssa_names.h"],
+    deps = [
+        ":operator",
+        "@absl//absl/container:flat_hash_map",
+    ],
+)
+
+cc_test(
+    name = "ssa_names_test",
+    srcs = [
+        # The headers will be removed by a subsequent PR.
+        "block.h",
+        "operation.h",
+        "value.h",
+        "ssa_names_test.cc",
+    ],
+    deps = [
+        ":data_decl",
+        ":ssa_names",
+        ":storage",
         "//src/common/testing:gtest",
     ],
 )

--- a/src/ir/ssa_names.h
+++ b/src/ir/ssa_names.h
@@ -1,0 +1,62 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#ifndef SRC_IR_SSA_NAMES_H_
+#define SRC_IR_SSA_NAMES_H_
+
+#include "absl/container/flat_hash_map.h"
+
+namespace raksha::ir {
+
+class Block;
+class Operation;
+
+class SSANames {
+ public:
+  using ID = int;
+  SSANames() : next_block_id_(0), next_operation_id_(0) {}
+
+  // Disable copy (and move) semantics.
+  SSANames(const SSANames &) = delete;
+  SSANames &operator=(const SSANames &) = delete;
+
+  ID GetOrCreateID(const Operation &operation) {
+    return GetOrCreateIDHelper(operation_ids_, next_operation_id_, &operation);
+  }
+
+  ID GetOrCreateID(const Block &block) {
+    return GetOrCreateIDHelper(block_ids_, next_block_id_, &block);
+  }
+
+ private:
+  template <typename T, typename U>
+  static ID GetOrCreateIDHelper(T &ids_table, ID &next_id, U entity) {
+    auto find_result = ids_table.find(entity);
+    if (find_result == ids_table.end()) {
+      ID result = next_id++;
+      ids_table.insert({entity, result});
+      return result;
+    }
+    return find_result->second;
+  }
+  ID next_block_id_;
+  absl::flat_hash_map<const Block *, ID> block_ids_;
+  ID next_operation_id_;
+  absl::flat_hash_map<const Operation *, ID> operation_ids_;
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_CONTEXT_H_

--- a/src/ir/ssa_names.h
+++ b/src/ir/ssa_names.h
@@ -23,13 +23,13 @@ namespace raksha::ir {
 class Block;
 class Operation;
 
-class SSANames {
+class SsaNames {
  public:
   using ID = int;
-  SSANames() {}
+  SsaNames() {}
   // Disable copy (and move) semantics.
-  SSANames(const SSANames &) = delete;
-  SSANames &operator=(const SSANames &) = delete;
+  SsaNames(const SsaNames &) = delete;
+  SsaNames &operator=(const SsaNames &) = delete;
 
   ID GetOrCreateID(const Operation &operation) {
     return operation_ids_.GetOrCreateID(&operation);
@@ -44,13 +44,13 @@ class SSANames {
   class IDManager {
    public:
     ID GetOrCreateID(const T *entity) {
-      auto insert_result = item_ids_.insert({entity, next_id_});
-      if (insert_result.second) ++next_id_;
+      // Note that if `entity` is already in the map, the `insert` call below
+      // will return the existing entity. Otherwise, a new entity is added.
+      auto insert_result = item_ids_.insert({entity, item_ids_.size()});
       return insert_result.first->second;
     }
 
    private:
-    ID next_id_;
     absl::flat_hash_map<const T *, ID> item_ids_;
   };
 

--- a/src/ir/ssa_names_test.cc
+++ b/src/ir/ssa_names_test.cc
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+#include "src/ir/ssa_names.h"
+
+#include "src/common/testing/gtest.h"
+#include "src/ir/block.h"
+#include "src/ir/data_decl.h"
+#include "src/ir/operation.h"
+#include "src/ir/operator.h"
+
+namespace raksha::ir {
+namespace {
+
+class SSANamesTest : public ::testing::Test {
+ public:
+  SSANamesTest() : test_op_("test") {}
+
+ protected:
+  Operator test_op_;
+};
+
+TEST_F(SSANamesTest, GetOrCreateIDReturnsUniqueIDsForOperations) {
+  SSANames names;
+  Operation first_operation(nullptr, test_op_, {});
+  Operation second_operation(nullptr, test_op_, {});
+  SSANames::ID first_operation_id = names.GetOrCreateID(first_operation);
+  SSANames::ID second_operation_id = names.GetOrCreateID(second_operation);
+
+  EXPECT_NE(first_operation_id, second_operation_id);
+  EXPECT_EQ(names.GetOrCreateID(first_operation), first_operation_id);
+}
+
+TEST_F(SSANamesTest, GetOrCreateIDReturnsUniqueIDsForBlocks) {
+  SSANames names;
+  Block first_block;
+  Block second_block;
+  SSANames::ID first_block_id = names.GetOrCreateID(first_block);
+  SSANames::ID second_block_id = names.GetOrCreateID(second_block);
+
+  EXPECT_NE(first_block_id, second_block_id);
+  EXPECT_EQ(names.GetOrCreateID(first_block), first_block_id);
+}
+
+}  // namespace
+}  // namespace raksha::ir

--- a/src/ir/ssa_names_test.cc
+++ b/src/ir/ssa_names_test.cc
@@ -24,31 +24,31 @@
 namespace raksha::ir {
 namespace {
 
-class SSANamesTest : public ::testing::Test {
+class SsaNamesTest : public ::testing::Test {
  public:
-  SSANamesTest() : test_op_("test") {}
+  SsaNamesTest() : test_op_("test") {}
 
  protected:
   Operator test_op_;
 };
 
-TEST_F(SSANamesTest, GetOrCreateIDReturnsUniqueIDsForOperations) {
-  SSANames names;
+TEST_F(SsaNamesTest, GetOrCreateIDReturnsUniqueIDsForOperations) {
+  SsaNames names;
   Operation first_operation(nullptr, test_op_, {});
   Operation second_operation(nullptr, test_op_, {});
-  SSANames::ID first_operation_id = names.GetOrCreateID(first_operation);
-  SSANames::ID second_operation_id = names.GetOrCreateID(second_operation);
+  SsaNames::ID first_operation_id = names.GetOrCreateID(first_operation);
+  SsaNames::ID second_operation_id = names.GetOrCreateID(second_operation);
 
   EXPECT_NE(first_operation_id, second_operation_id);
   EXPECT_EQ(names.GetOrCreateID(first_operation), first_operation_id);
 }
 
-TEST_F(SSANamesTest, GetOrCreateIDReturnsUniqueIDsForBlocks) {
-  SSANames names;
+TEST_F(SsaNamesTest, GetOrCreateIDReturnsUniqueIDsForBlocks) {
+  SsaNames names;
   Block first_block;
   Block second_block;
-  SSANames::ID first_block_id = names.GetOrCreateID(first_block);
-  SSANames::ID second_block_id = names.GetOrCreateID(second_block);
+  SsaNames::ID first_block_id = names.GetOrCreateID(first_block);
+  SsaNames::ID second_block_id = names.GetOrCreateID(second_block);
 
   EXPECT_NE(first_block_id, second_block_id);
   EXPECT_EQ(names.GetOrCreateID(first_block), first_block_id);

--- a/src/ir/ssa_names_test.cc
+++ b/src/ir/ssa_names_test.cc
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ir/value.h
+++ b/src/ir/value.h
@@ -107,6 +107,8 @@ class StoredValue {
   StoredValue(const StoredValue&) = default;
   StoredValue& operator=(const StoredValue&) = default;
 
+  const Storage& storage() const { return *storage_; }
+
  private:
   const Storage* storage_;
 };
@@ -124,8 +126,8 @@ class Any {};
 // A class that represents a data value.
 class Value {
  public:
-  Value(value::BlockArgument arg): value_(std::move(arg)) {}
-  Value(value::BlockResult arg): value_(std::move(arg)) {}
+  Value(value::BlockArgument arg) : value_(std::move(arg)) {}
+  Value(value::BlockResult arg) : value_(std::move(arg)) {}
   Value(value::OperationResult arg) : value_(std::move(arg)) {}
   Value(value::Field arg) : value_(std::move(arg)) {}
   Value(value::Constant arg) : value_(std::move(arg)) {}

--- a/src/ir/value.h
+++ b/src/ir/value.h
@@ -126,8 +126,8 @@ class Any {};
 // A class that represents a data value.
 class Value {
  public:
-  Value(value::BlockArgument arg) : value_(std::move(arg)) {}
-  Value(value::BlockResult arg) : value_(std::move(arg)) {}
+  Value(value::BlockArgument arg): value_(std::move(arg)) {}
+  Value(value::BlockResult arg): value_(std::move(arg)) {}
   Value(value::OperationResult arg) : value_(std::move(arg)) {}
   Value(value::Field arg) : value_(std::move(arg)) {}
   Value(value::Constant arg) : value_(std::move(arg)) {}


### PR DESCRIPTION
e.g, this will be useful to print values like `OperationResult(op, "value")` as `%39.value`.