### PR TITLE
Add an IRContext class

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -75,6 +75,25 @@ cc_test(
 )
 
 cc_library(
+    name = "ir_context",
+    hdrs = ["ir_context.h"],
+    deps = [
+        ":operator",
+        "//src/ir/types",
+        "@absl//absl/container:flat_hash_map",
+    ],
+)
+
+cc_test(
+    name = "ir_context_test",
+    srcs = ["ir_context_test.cc"],
+    deps = [
+        ":ir_context",
+        "//src/common/testing:gtest",
+    ],
+)
+
+cc_library(
     name = "operator",
     hdrs = ["operator.h"],
     deps = [

--- a/src/ir/ir_context.h
+++ b/src/ir/ir_context.h
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#ifndef SRC_IR_IR_CONTEXT_H_
+#define SRC_IR_IR_CONTEXT_H_
+
+#include "absl/container/flat_hash_map.h"
+#include "src/ir/operator.h"
+#include "src/ir/types/type_factory.h"
+
+namespace raksha::ir {
+
+class IRContext {
+ public:
+  IRContext() = default;
+  // Disable copy (and move) semantics.
+  IRContext(const IRContext &) = delete;
+  IRContext &operator=(const IRContext &) = delete;
+
+  types::TypeFactory &type_factory() { return type_factory_; }
+
+  // Register an operator and return the stored operator instances.
+  const Operator &RegisterOperator(std::unique_ptr<Operator> op) {
+    auto ins_res = operators_.insert({std::string(op->name()), std::move(op)});
+    CHECK(ins_res.second) << "Cannot register duplicate operator with name '"
+                          << ins_res.first->first << "'.";
+    return *ins_res.first->second.get();
+  }
+
+  // Returns the Operator with a particular name. If there is no
+  // operator with that name, returns nullptr.
+  const Operator *GetOperator(absl::string_view operators_name) const {
+    auto find_res = operators_.find(operators_name);
+    return (find_res != operators_.end()) ? find_res->second.get() : nullptr;
+  }
+
+ private:
+  // List of registered operators.
+  absl::flat_hash_map<std::string, std::unique_ptr<Operator>> operators_;
+  // TypeFactory for this context.
+  types::TypeFactory type_factory_;
+};
+
+}  // namespace raksha::ir
+
+#endif  // SRC_IR_IR_CONTEXT_H_

--- a/src/ir/ir_context.h
+++ b/src/ir/ir_context.h
@@ -41,9 +41,16 @@ class IRContext {
 
   // Returns the Operator with a particular name. If there is no
   // operator with that name, returns nullptr.
-  const Operator *GetOperator(absl::string_view operators_name) const {
+  const Operator &GetOperator(absl::string_view operators_name) const {
     auto find_res = operators_.find(operators_name);
-    return (find_res != operators_.end()) ? find_res->second.get() : nullptr;
+    CHECK(find_res != operators_.end())
+        << "Looking up an unregistered operator '" << operators_name << "'.";
+    return *find_res->second;
+  }
+
+  // Returns true if the operator is registered with this context.
+  bool IsRegisteredOperator(absl::string_view operators_name) const {
+    return operators_.find(operators_name) != operators_.end();
   }
 
  private:

--- a/src/ir/ir_context_test.cc
+++ b/src/ir/ir_context_test.cc
@@ -1,0 +1,54 @@
+//-----------------------------------------------------------------------------
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+#include "src/ir/ir_context.h"
+
+#include "src/common/testing/gtest.h"
+
+namespace raksha::ir {
+namespace {
+
+TEST(IRContextTest, RegisterOperatorReturnsRegisteredOp) {
+  IRContext context;
+  const Operator& op =
+      context.RegisterOperator(std::make_unique<Operator>("core.choose"));
+  EXPECT_EQ(op.name(), "core.choose");
+}
+
+TEST(IRContextTest, GetOperatorReturnsRegisteredOperator) {
+  IRContext context;
+  const Operator& registered_op =
+      context.RegisterOperator(std::make_unique<Operator>("core.choose"));
+  const Operator* op = context.GetOperator("core.choose");
+  EXPECT_EQ(op->name(), "core.choose");
+  EXPECT_EQ(op, &registered_op);
+}
+
+TEST(IRContextTest, GetOperatorReturnsNullptrForUnregisteredOperator) {
+  IRContext context;
+  const Operator* op = context.GetOperator("core.choose");
+  EXPECT_EQ(op, nullptr);
+}
+
+TEST(IRContextDeathTest, DuplicateRegistrationCausesFailure) {
+  IRContext context;
+  context.RegisterOperator(std::make_unique<Operator>("core.choose"));
+  EXPECT_DEATH(
+      { context.RegisterOperator(std::make_unique<Operator>("core.choose")); },
+      "Cannot register duplicate operator with name 'core.choose'.");
+}
+
+}  // namespace
+}  // namespace raksha::ir

--- a/src/ir/ir_context_test.cc
+++ b/src/ir/ir_context_test.cc
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,15 +31,22 @@ TEST(IRContextTest, GetOperatorReturnsRegisteredOperator) {
   IRContext context;
   const Operator& registered_op =
       context.RegisterOperator(std::make_unique<Operator>("core.choose"));
-  const Operator* op = context.GetOperator("core.choose");
-  EXPECT_EQ(op->name(), "core.choose");
-  EXPECT_EQ(op, &registered_op);
+  const Operator& op = context.GetOperator("core.choose");
+  EXPECT_EQ(op.name(), "core.choose");
+  EXPECT_EQ(&op, &registered_op);
 }
 
-TEST(IRContextTest, GetOperatorReturnsNullptrForUnregisteredOperator) {
+TEST(IRContextTest, IsRegisteredOperatorReturnsCorrectValues) {
   IRContext context;
-  const Operator* op = context.GetOperator("core.choose");
-  EXPECT_EQ(op, nullptr);
+  context.RegisterOperator(std::make_unique<Operator>("core.choose"));
+  EXPECT_TRUE(context.IsRegisteredOperator("core.choose"));
+  EXPECT_FALSE(context.IsRegisteredOperator("core.nose"));
+}
+
+TEST(IRContextDeathTest, GetOperatorFailsForUnregisteredOperator) {
+  IRContext context;
+  EXPECT_DEATH({ context.GetOperator("core.choose"); },
+               "Looking up an unregistered operator 'core.choose'.");
 }
 
 TEST(IRContextDeathTest, DuplicateRegistrationCausesFailure) {


### PR DESCRIPTION
This is needed to keep the global state (like registered operators) necessary for building the IR.