### PR TITLE
Clean up headers claimed by multiple packages in src/ir/BUILD.

### DIFF
--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -22,21 +22,6 @@ licenses(["notice"])
 package(default_visibility = ["//src:__subpackages__"])
 
 cc_library(
-    name = "new_ir",
-    hdrs = [
-        "block.h",
-        "data_decl.h",
-        "operation.h",
-        "operator.h",
-        "value.h",
-    ],
-    deps = [
-        "//src/ir/types",
-        "@absl//absl/container:flat_hash_map",
-    ],
-)
-
-cc_library(
     name = "attribute",
     hdrs = ["attribute.h"],
     deps = [


### PR DESCRIPTION
The src/ir/BUILD file had headers in multiple packages. The main
culprit for this was //src/ir:new_ir, which appears to have been split
up into smaller packages, but not deleted. This PR cleans that up.