### PR TITLE
Make attributes and values of operations be printed out in name order.

### DIFF
--- a/src/ir/operation.cc
+++ b/src/ir/operation.cc
@@ -26,10 +26,10 @@ namespace raksha::ir {
 // Note: I tried to make this only defined in terms of the type parameter T, but
 // the compiler was unhappy with me writing std::function<std::string(const T&)>
 // and I could not figure out how to placate it.
-template<class T, class U>
+template<class T, class F>
 static std::string PrintNamedMapInNameOrder(
     const absl::flat_hash_map<std::string, T> &map_to_print,
-    U value_printing_fn) {
+    F value_printing_fn) {
   std::vector<absl::string_view> names;
   names.reserve(map_to_print.size());
   for (auto &key_value_pair : map_to_print) {
@@ -39,10 +39,8 @@ static std::string PrintNamedMapInNameOrder(
   return absl::StrJoin(
       names, ", ",
       [&](std::string* out, const absl::string_view name) {
-        auto find_res = map_to_print.find(name);
-        CHECK(find_res != map_to_print.end())
-          << "Name " << name << " not found in map_to_print";
-        absl::StrAppend(out, name, ": ", value_printing_fn(find_res->second));
+        absl::StrAppend(
+            out, name, ": ", value_printing_fn(map_to_print.at(name)));
       });
 }
 

--- a/src/ir/operation.cc
+++ b/src/ir/operation.cc
@@ -29,7 +29,7 @@ namespace raksha::ir {
 template<class T, class F>
 static std::string PrintNamedMapInNameOrder(
     const absl::flat_hash_map<std::string, T> &map_to_print,
-    F value_printing_fn) {
+    F value_pretty_printer) {
   std::vector<absl::string_view> names;
   names.reserve(map_to_print.size());
   for (auto &key_value_pair : map_to_print) {
@@ -40,7 +40,7 @@ static std::string PrintNamedMapInNameOrder(
       names, ", ",
       [&](std::string* out, const absl::string_view name) {
         absl::StrAppend(
-            out, name, ": ", value_printing_fn(map_to_print.at(name)));
+            out, name, ": ", value_pretty_printer(map_to_print.at(name)));
       });
 }
 

--- a/src/ir/operation_test.cc
+++ b/src/ir/operation_test.cc
@@ -27,11 +27,8 @@ struct OperationTestData {
   const Operator* op{};
   NamedAttributeMap attributes{};
   NamedValueMap values{};
-  // We don't have a particular order for attributes and arguments.
-  // For now, we keep all possible string representation for the tests
-  // and make sure the `ToString` method generates at least on of the
-  // given representations.
-  absl::flat_hash_set<absl::string_view> string_reps{};
+  // The expected string representation.
+  absl::string_view string_rep;
 };
 
 class OperationTest : public testing::TestWithParam<OperationTestData> {
@@ -65,7 +62,7 @@ TEST_P(OperationTest, AccessorsAndToStringReturnCorrectValue) {
   // EXPECT_EQ(operation.attributes(), attributes);
   // TODO(337): Enable this when we have a comparator for values.
   // EXPECT_EQ(operation.inputs(), inputs);
-  EXPECT_THAT(string_reps, testing::Contains(operation.ToString(ssa_names)));
+  EXPECT_THAT(string_reps, testing::Eq(operation.ToString(ssa_names)));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -75,29 +72,28 @@ INSTANTIATE_TEST_SUITE_P(
                            &OperationTest::plus_op,
                            {},
                            {},
-                           {"%0 = core.plus []()"}}),
+                           "%0 = core.plus []()"}),
         OperationTestData({nullptr,
                            &OperationTest::plus_op,
                            {{"const", Int64Attribute::Create(10)}},
                            {},
-                           {"%0 = core.plus [const: 10]()"}}),
+                           "%0 = core.plus [const: 10]()"}),
         OperationTestData({nullptr,
                            &OperationTest::minus_op,
                            {{"predicate", StringAttribute::Create("a && b")}},
                            {},
-                           {"%0 = core.minus [predicate: a && b]()"}}),
+                           "%0 = core.minus [predicate: a && b]()"}),
         OperationTestData({nullptr,
                            &OperationTest::minus_op,
                            {{"const1", StringAttribute::Create("a")},
                             {"const2", Int64Attribute::Create(42)}},
                            {},
-                           {"%0 = core.minus [const1: a, const2: 42]()",
-                            "%0 = core.minus [const2: 42, const1: a]()"}}),
+                           "%0 = core.minus [const1: a, const2: 42]()"}),
         OperationTestData({nullptr,
                            &OperationTest::minus_op,
                            {{"const", Int64Attribute::Create(10)}},
                            {{"arg", Value(value::Any())}},
-                           {"%0 = core.minus [const: 10](arg: <<ANY>>)"}}),
+                           "%0 = core.minus [const: 10](arg: <<ANY>>)"}),
         OperationTestData(
             {&OperationTest::first_block_,
              &OperationTest::minus_op,
@@ -106,8 +102,7 @@ INSTANTIATE_TEST_SUITE_P(
                                                "arg0"))},
               {"b", Value(value::BlockArgument(OperationTest::first_block_,
                                                "arg1"))}},
-             {"%0 = core.minus [const: 10](a: %0.arg0, b: %0.arg1)",
-              "%0 = core.minus [const: 10](b: %0.arg1, a: %0.arg0)"}})));
+             "%0 = core.minus [const: 10](a: %0.arg0, b: %0.arg1)"})));
 
 }  // namespace
 }  // namespace raksha::ir


### PR DESCRIPTION
Previously, the attributes and names of operations would be printed out
in arbitrary order. As of this commit, they are always printed out in
the alphabetical order of their associated name.