### PR TITLE
Decode `Literal` SQL IR protos.

### DIFF
--- a/src/ir/proto/sql/decode.h
+++ b/src/ir/proto/sql/decode.h
@@ -29,6 +29,8 @@ ir::Value DecodeSourceTableColumn(
     const SourceTableColumn &source_table_column,
     IRContext &ir_context);
 
+ir::Value DecodeLiteral(const Literal &literal, IRContext &ir_context);
+
 }  // namespace raksha::ir::proto::sql
 
 #endif  // SRC_IR_PROTO_SQL_MVP_DECODE_H_


### PR DESCRIPTION
This PR decodes `Literal` SQL IR protos. `Literal` protos are decoded
almost identically to `SourceTableColumn`s, even down to representing
them as `Storage`s. This is done because the IR does not currently have
a representation for `Storage`s and because in a verifier that does not
allow for modifications (as with the SQL verifier we are targeting),
there actually isn't that much difference between a named `Storage` and
a `Literal` associated with some canonical name.