### PR TITLE
Add prefixes to the SQL proto enums.

### DIFF
--- a/src/ir/proto/sql/sql_ir.proto
+++ b/src/ir/proto/sql/sql_ir.proto
@@ -49,16 +49,16 @@ message MergeOperation {
 
 // The kind of a tag.
 enum TagKind {
-  UNKNOWN = 0;
-  INTEGRITY = 1;
-  CONFIDENTIALITY = 2;
+  TK_UNKNOWN = 0;
+  TK_INTEGRITY = 1;
+  TK_CONFIDENTIALITY = 2;
 }
 
 // The action that is taken upon a tag by a TagTransform expression.
 enum TagAlteration {
-  NONE = 0;
-  ADD = 1;
-  REMOVE = 2;
+  TA_NONE = 0;
+  TA_ADD = 1;
+  TA_REMOVE = 2;
 }
 
 // A pair of an Expression's unique ID and an integrity tag that must be

--- a/src/ir/proto/sql/sql_ir.proto
+++ b/src/ir/proto/sql/sql_ir.proto
@@ -49,16 +49,16 @@ message MergeOperation {
 
 // The kind of a tag.
 enum TagKind {
-  TK_UNKNOWN = 0;
-  TK_INTEGRITY = 1;
-  TK_CONFIDENTIALITY = 2;
+  TAG_KIND_UNKNOWN = 0;
+  TAG_KIND_INTEGRITY = 1;
+  TAG_KIND_CONFIDENTIALITY = 2;
 }
 
 // The action that is taken upon a tag by a TagTransform expression.
 enum TagAlteration {
-  TA_NONE = 0;
-  TA_ADD = 1;
-  TA_REMOVE = 2;
+  TAG_ALTERATION_NONE = 0;
+  TAG_ALTERATION_ADD = 1;
+  TAG_ALTERATION_REMOVE = 2;
 }
 
 // A pair of an Expression's unique ID and an integrity tag that must be


### PR DESCRIPTION
Prevent name collisions in SQL proto enums by adding a per-enum prefix
to each proto constant.