### PR TITLE
Small bug fix for match on sign & lint fixes

### DIFF
--- a/rust/tools/authorization-logic/src/parsing/astconstructionvisitor.rs
+++ b/rust/tools/authorization-logic/src/parsing/astconstructionvisitor.rs
@@ -230,9 +230,9 @@ fn construct_import(ctx: &ImportAssertionContext) -> AstImport {
 
 fn construct_type(ctx: &AuthLogicTypeContextAll) -> AstType {
     match ctx {
-        AuthLogicTypeContextAll::NumberTypeContext(ctx_prime) =>
+        AuthLogicTypeContextAll::NumberTypeContext(_ctx_prime) =>
             AstType::NumberType,
-        AuthLogicTypeContextAll::PrincipalTypeContext(ctx_prime) =>
+        AuthLogicTypeContextAll::PrincipalTypeContext(_ctx_prime) =>
             AstType::PrincipalType,
         AuthLogicTypeContextAll::CustomTypeContext(ctx_prime) => {
             AstType::CustomType { type_name: ctx_prime.ID().unwrap().get_text() }

--- a/rust/tools/authorization-logic/src/souffle/lowering_ast_datalog.rs
+++ b/rust/tools/authorization-logic/src/souffle/lowering_ast_datalog.rs
@@ -445,7 +445,7 @@ impl LoweringToDatalogPass {
         // Generate relation declarations for delegated predicates with
         // each encountered delegation depth
         let mut cansay_decls = self.cansay_depth.iter()
-            .filter(|(name, depth)| **depth > 0)
+            .filter(|(_name, depth)| **depth > 0)
             .map(|(name, depth)| { 
                 prefix_with_cansay(type_environment.get(name).expect(
                         &format!("couldnt find type named: {}", name)), *depth)

--- a/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
@@ -83,7 +83,7 @@ fn emit_program_body(p: &DLIRProgram) -> String {
 fn emit_type_declarations(p: &DLIRProgram, decl_skip: &Vec<String>) -> String {
     let mut type_names : Vec<String> = p.relation_declarations.iter()
         .map(|rel_decl| rel_decl.arg_typings.iter()
-             .map(|(parameter, type_)| type_))
+             .map(|(_parameter, type_)| type_))
         .flatten()
         .filter_map(|type_| match type_ {
             AstType::CustomType { type_name } => Some(type_name.clone()),

--- a/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_emitter.rs
@@ -50,7 +50,7 @@ fn emit_decl(relation_declaration: &AstRelationDeclaration) -> String {
 fn emit_pred(p: &AstPredicate) -> String {
     let neg = match p.sign {
         Sign::Positive => "",
-        Negative => "!"
+        Sign::Negated => "!"
     };
     format!("{}{}({})", neg, &p.name, p.args.join(", "))
 }

--- a/rust/tools/authorization-logic/src/souffle/universe_translation.rs
+++ b/rust/tools/authorization-logic/src/souffle/universe_translation.rs
@@ -84,9 +84,9 @@ fn universe_declarations(rel_decls: &Vec<AstRelationDeclaration>)
     let mut custom_types = rel_decls.iter()
         .map(|rel_decl| rel_decl.arg_typings.clone())
         .flatten()
-        .map(|(name, typ)| typ)
+        .map(|(_name, typ)| typ)
         .filter(|type_| match type_ {
-            AstType::CustomType { type_name } => true,
+            AstType::CustomType { type_name: _ } => true,
             _ => false
         })
         .collect::<HashSet<_>>();
@@ -318,7 +318,7 @@ impl UniverseHandlingPass {
                 .map(|decl| {
                     let position_map = decl.arg_typings.clone()
                         .into_iter()
-                        .map(|(param_name, typ)| typ)
+                        .map(|(_param_name, typ)| typ)
                         .into_iter()
                         .enumerate()
                         .collect::<HashMap<usize, AstType>>();


### PR DESCRIPTION
Noticed a set of easy to clean up warnings on a first compile.

One, accidentally binding the variable `Negative` instead of using the `Sign::Negated` case could have caused a bug but happened to correctly match all cases of sign other than `Sign::Positive` so is just a cosmetic change unless other signs are added later.