### PR TITLE
Replace helper relations for specific-arity `operation`s with macros.

### DIFF
--- a/src/analysis/souffle/operations.dl
+++ b/src/analysis/souffle/operations.dl
@@ -30,28 +30,9 @@
 // Operations of any arity go in this relation.
 .decl operation(owner: Principal, operator: Operator, result: AccessPath, operandList: OperandList)
 
-// unaryOperation and binaryOperation are convenience relations for the
-// very-common-cases of unary and binary operators.
-.decl unaryOperation(owner: Principal, operator: Operator, result: AccessPath, input1: AccessPath)
-.decl binaryOperation(
-  owner: Principal, operator: Operator, result: AccessPath, input1: AccessPath, input2: AccessPath)
-
-// Assign is syntactic sugar for unaryOperation(owner, "=", ...).
-.decl assign(owner: Principal, result: AccessPath, input1: AccessPath)
-
-// Cross-populate unaryOperation and operation.
-operation(owner, operator, result, [input1, nil]) :- unaryOperation(owner, operator, result, input1).
-unaryOperation(owner, operator, result, input1) :- operation(owner, operator, result, [input1, nil]).
-
-// Cross-populate binaryOperation and operation.
-operation(owner, operator, result, [input1, [input2, nil]]) :-
-  binaryOperation(owner, operator, result, input1, input2).
-binaryOperation(owner, operator, result, input1, input2) :-
-  operation(owner, operator, result, [input1, [input2, nil]]).
-
-// assign is a '=' operation with a single operand.
-unaryOperation(owner, "=", result, input1) :- assign(owner, result, input1).
-assign(owner, result, input1) :- unaryOperation(owner, "=", result, input1).
+// BINARY_OPERATION is a convenience macro for the very-common-case of binary operations.
+#define BINARY_OPERATION(owner, operator, result, input1, input2) \
+operation(owner, operator, result, [input1, [input2, nil]])
 
 // Explode the operand lists so that we can extract the heads of each sublist
 // to get a mapping from operations to their operands.

--- a/src/analysis/souffle/tests/arcs_fact_tests/timestamp_redaction.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/timestamp_redaction.dl
@@ -13,8 +13,8 @@ isAccessPath("div_result").
 isAccessPath("c").
 isAccessPath("final_result").
 
-binaryOperation("owner", "/", "div_result", "a", "b").
-binaryOperation("owner", "*", "final_result", "div_result", "c").
+BINARY_OPERATION("owner", "/", "div_result", "a", "b").
+BINARY_OPERATION("owner", "*", "final_result", "div_result", "c").
 
 // "a" contains a millsecond-granularity timestamp.
 hasAppliedIntegrityTag("a", "owner", "TimestampMilliseconds").
@@ -32,14 +32,14 @@ hasAppliedIntegrityTag("c", "owner", "Constant_1000").
 // "TimestampMilliseconds" confidentiality tag.
 mustHaveIntegrityTag(result, owner, "TimestampSeconds"),
 removeTag(result, owner, "SensitiveTimestamp") :-
-  binaryOperation(owner, "/", result, op1, op2),
+  BINARY_OPERATION(owner, "/", result, op1, op2),
   mustHaveIntegrityTag(op1, owner, "TimestampMilliseconds"),
   mustHaveIntegrityTag(op2, owner, "Constant_1000").
 
 // An AST matching policy that says that "TimestampSeconds", multiplied by
 // 1000, is now a "TimestampMillisecondsRedacted".
 mustHaveIntegrityTag(result, owner, "TimestampMillisecondsRedacted") :-
-  binaryOperation(owner, "*", result, op1, op2),
+  BINARY_OPERATION(owner, "*", result, op1, op2),
   mustHaveIntegrityTag(op1, owner, "TimestampSeconds"),
   mustHaveIntegrityTag(op2, owner, "Constant_1000").
 


### PR DESCRIPTION
Previously, `operations.dl` declared a number of "helper" relations for
specific, common cases of `operation` such as `unaryOperation`,
`binaryOperation`, `assign`, etc. The problem with this is that it
requires each of those forms to be cross-populated to and from
`operation`, which increases toil.

This PR gets rid of the `unaryOperation` and `assign` helpers, which are
not currently used. It replaces the `binaryOperation` helper relation
with a `BINARY_OPERATION` helper macro, which just encodes a special
form for referring to the `operation` relation.