### PR TITLE
Add marker dependencies to indicate targets that need protobufs.

### DIFF
--- a/src/common/proto/BUILD
+++ b/src/common/proto/BUILD
@@ -17,6 +17,8 @@
 
 package(default_visibility = ["//src:__subpackages__"])
 
+licenses(["notice"])
+
 # These files contain dummy marker libraries for indicating a dependency upon
 # protobuf libraries. We have to use them because Bazel cannot be configured
 # to just force explicit inclusion of protobuf dependencies. This causes

--- a/src/common/proto/BUILD
+++ b/src/common/proto/BUILD
@@ -1,0 +1,30 @@
+#-------------------------------------------------------------------------------
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------------------------
+
+package(default_visibility = ["//src:__subpackages__"])
+
+# These files contain dummy marker libraries for indicating a dependency upon
+# protobuf libraries. We have to use them because Bazel cannot be configured
+# to just force explicit inclusion of protobuf dependencies. This causes
+# problems when we try to import Raksha into Google's internal repository.
+cc_library(
+    name = "protobuf",
+)
+
+cc_library(
+    name = "proto_message_differencer",
+)

--- a/src/frontends/sql/BUILD
+++ b/src/frontends/sql/BUILD
@@ -87,6 +87,7 @@ cc_test(
     deps = [
         ":decode",
         ":decoder_context",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/frontends/sql:sql_ir_cc_proto",
         "//src/frontends/sql/testing:merge_operation_view",

--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -397,6 +397,7 @@ cc_test(
     deps = [
         ":access_path",
         ":ir",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/ir/proto:tag_claim",
         "@absl//absl/strings:str_format",
@@ -409,6 +410,7 @@ cc_test(
     deps = [
         ":access_path",
         ":ir",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/ir/proto:predicate",
         "//src/ir/proto:tag_check",
@@ -432,6 +434,7 @@ cc_test(
     srcs = ["derives_from_claim_test.cc"],
     deps = [
         ":ir",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/ir/proto:access_path",
         "//src/ir/proto:derives_from_claim",
@@ -457,6 +460,7 @@ cc_test(
     deps = [
         ":ir",
         ":predicate_textproto_to_rule_body_testdata",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/ir/proto:predicate",
         "//third_party/arcs/proto:manifest_cc_proto",
@@ -469,6 +473,8 @@ cc_test(
     srcs = ["handle_connection_spec_test.cc"],
     deps = [
         ":ir",
+        "//src/common/proto:proto_message_differencer",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/ir/proto:handle_connection_spec",
         "//src/ir/types",
@@ -482,6 +488,7 @@ cc_test(
     deps = [
         ":ir",
         "//src/common/logging",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/ir/proto:particle_spec",
         "//src/ir/types",

--- a/src/ir/proto/BUILD
+++ b/src/ir/proto/BUILD
@@ -136,6 +136,7 @@ cc_test(
     srcs = ["access_path_test.cc"],
     deps = [
         ":access_path",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
     ],
 )
@@ -145,6 +146,8 @@ cc_test(
     srcs = ["access_path_root_test.cc"],
     deps = [
         ":access_path",
+        "//src/common/proto:proto_message_differencer",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
     ],
 )
@@ -154,6 +157,8 @@ cc_test(
     srcs = ["access_path_selector_test.cc"],
     deps = [
         ":access_path",
+        "//src/common/proto:proto_message_differencer",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
     ],
 )
@@ -163,6 +168,8 @@ cc_test(
     srcs = ["entity_type_test.cc"],
     deps = [
         "types",
+        "//src/common/proto:proto_message_differencer",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/ir/types",
         "//third_party/arcs/proto:manifest_cc_proto",

--- a/src/ir/types/BUILD
+++ b/src/ir/types/BUILD
@@ -58,6 +58,7 @@ cc_test(
     deps = [
         ":types",
         "//src/common/logging",
+        "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/ir:access_path",
         "//src/ir/proto:types",


### PR DESCRIPTION
Bazel implicitly adds the protobuf library as an implicit dependency on
every target. This makes it hard to perform an automatic import into
Google's internal repo effectively. This PR adds a `protobuf` or
`message_differencer` dependency to every target that needs protocol
buffers that is not some kind of proto library already. This allows us
to automatically tranform these targets to the internal Google
equivalent in a more robust fashion.