### PR TITLE
More fixups with proto tag hints.

### DIFF
--- a/src/frontends/sql/decode_test.cc
+++ b/src/frontends/sql/decode_test.cc
@@ -18,7 +18,6 @@
 
 #include "absl/strings/string_view.h"
 #include "google/protobuf/text_format.h"
-#include "google/protobuf/util/message_differencer.h"
 #include "src/common/testing/gtest.h"
 #include "src/frontends/sql/decoder_context.h"
 #include "src/frontends/sql/sql_ir.pb.h"

--- a/src/ir/tag_check_test.cc
+++ b/src/ir/tag_check_test.cc
@@ -1,6 +1,5 @@
 #include "src/ir/tag_check.h"
 
-#include "google/protobuf/util/message_differencer.h"
 #include "google/protobuf/text_format.h"
 
 #include "absl/strings/str_format.h"

--- a/src/ir/tag_claim_test.cc
+++ b/src/ir/tag_claim_test.cc
@@ -16,7 +16,6 @@
 
 #include "src/ir/tag_claim.h"
 
-#include "google/protobuf/util/message_differencer.h"
 #include "google/protobuf/text_format.h"
 
 #include "absl/strings/str_format.h"

--- a/src/ir/types/type_test.cc
+++ b/src/ir/types/type_test.cc
@@ -5,17 +5,14 @@
 #include <optional>
 
 #include "absl/container/flat_hash_map.h"
-#include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "google/protobuf/text_format.h"
-#include "google/protobuf/util/message_differencer.h"
 #include "src/common/logging/logging.h"
 #include "src/common/testing/gtest.h"
 #include "src/ir/access_path_selectors.h"
 #include "src/ir/access_path_selectors_set.h"
 #include "src/ir/proto/type.h"
 #include "src/ir/types/entity_type.h"
-#include "src/ir/types/primitive_type.h"
 #include "src/ir/types/schema.h"
 
 namespace raksha::ir::types {

--- a/src/xform_to_datalog/BUILD
+++ b/src/xform_to_datalog/BUILD
@@ -109,8 +109,8 @@ cc_test(
     srcs = ["manifest_datalog_facts_test.cc"],
     deps = [
         ":manifest_datalog_facts",
-        "//src/common/testing:gtest",
         "//src/common/proto:protobuf",
+        "//src/common/testing:gtest",
         "//src/ir",
         "//src/ir/proto:system_spec",
         "//src/ir/types",

--- a/src/xform_to_datalog/BUILD
+++ b/src/xform_to_datalog/BUILD
@@ -110,6 +110,7 @@ cc_test(
     deps = [
         ":manifest_datalog_facts",
         "//src/common/testing:gtest",
+        "//src/common/proto:protobuf",
         "//src/ir",
         "//src/ir/proto:system_spec",
         "//src/ir/types",


### PR DESCRIPTION
This PR contains more fixups needed for proto tag hints. Specifically,
remove many unnecessary inclusions of `message_differencer.h" and add
the protobuf tag to
"//src/xform_to_datalog:manifest_datalog_facts_test".