### PR TITLE
Remove unused imports

### DIFF
--- a/rust/tools/authorization-logic/src/test/test_claim_importing.rs
+++ b/rust/tools/authorization-logic/src/test/test_claim_importing.rs
@@ -17,10 +17,9 @@
 #[cfg(test)]
 mod test {
     use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*,
+        compilation_top_level::*, souffle::souffle_interface::*,
         test::test_queries::test::QueryTest, utils::*,
     };
-    use std::fs;
 
     // This dependency is used for generating keypairs.
     use crate::signing::tink_interface::*;

--- a/rust/tools/authorization-logic/src/test/test_decl_skip.rs
+++ b/rust/tools/authorization-logic/src/test/test_decl_skip.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test {
     use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*, utils::*
+        compilation_top_level::*, utils::*
     };
     use std::fs;
 

--- a/rust/tools/authorization-logic/src/test/test_dots_and_quotes.rs
+++ b/rust/tools/authorization-logic/src/test/test_dots_and_quotes.rs
@@ -16,7 +16,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::{ast::*, compilation_top_level::*, souffle::souffle_interface::*};
+    use crate::{compilation_top_level::*,};
     use crate::{utils::*};
 
     // This dependency is used for generating keypairs.

--- a/rust/tools/authorization-logic/src/test/test_export_signatures.rs
+++ b/rust/tools/authorization-logic/src/test/test_export_signatures.rs
@@ -16,8 +16,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::{ast::*, compilation_top_level::*, souffle::souffle_interface::*};
-    use std::fs;
+    use crate::{compilation_top_level::*};
     use crate::utils::*;
 
     // This dependency is used for generating keypairs.

--- a/rust/tools/authorization-logic/src/test/test_multimic_no_overrides.rs
+++ b/rust/tools/authorization-logic/src/test/test_multimic_no_overrides.rs
@@ -16,14 +16,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*,
-        test::test_queries::test::*,
-    };
-    use std::fs;
-
-    // This dependency is used for generating keypairs.
-    use crate::signing::tink_interface::*;
+    use crate::{test::test_queries::test::*};
     use crate::utils::*;
 
     #[test]

--- a/rust/tools/authorization-logic/src/test/test_multimic_overrides.rs
+++ b/rust/tools/authorization-logic/src/test/test_multimic_overrides.rs
@@ -16,14 +16,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*,
-        test::test_queries::test::*,
-    };
-    use std::fs;
-
-    // This dependency is used for generating keypairs.
-    use crate::signing::tink_interface::*;
+    use crate::{test::test_queries::test::*};
     use crate::utils::*;
 
     #[test]

--- a/rust/tools/authorization-logic/src/test/test_multiverse_handling.rs
+++ b/rust/tools/authorization-logic/src/test/test_multiverse_handling.rs
@@ -16,11 +16,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*,
-        test::test_queries::test::*,
-    };
-    use std::fs;
+    use crate::{test::test_queries::test::*};
 
     #[test]
     fn test_multiverse_handling() {

--- a/rust/tools/authorization-logic/src/test/test_negation.rs
+++ b/rust/tools/authorization-logic/src/test/test_negation.rs
@@ -16,11 +16,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*,
-        test::test_queries::test::*,
-    };
-    use std::fs;
+    use crate::{test::test_queries::test::*};
 
     #[test]
     fn test_negation() {

--- a/rust/tools/authorization-logic/src/test/test_num_string_names.rs
+++ b/rust/tools/authorization-logic/src/test/test_num_string_names.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test {
     use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*, utils::*,
+        compilation_top_level::*, utils::*,
     };
 
     #[test]

--- a/rust/tools/authorization-logic/src/test/test_relation_declarations.rs
+++ b/rust/tools/authorization-logic/src/test/test_relation_declarations.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test {
     use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*
+        ast::*, compilation_top_level::*,
     };
 
     #[test]

--- a/rust/tools/authorization-logic/src/test/test_type_error.rs
+++ b/rust/tools/authorization-logic/src/test/test_type_error.rs
@@ -16,8 +16,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::{ast::*, compilation_top_level::*, souffle::souffle_interface::*};
-    use std::fs;
+    use crate::{compilation_top_level::*};
 
     #[test]
     #[should_panic]


### PR DESCRIPTION
This eliminates the `unused imports` warnings that show up during compilation and tests. 