### PR TITLE
Simplify `TagTransform` proto message.

### DIFF
--- a/src/frontends/sql/sql_ir.proto
+++ b/src/frontends/sql/sql_ir.proto
@@ -47,27 +47,6 @@ message MergeOperation {
   repeated Expression control_inputs = 3;
 }
 
-// The kind of a tag.
-enum TagKind {
-  TAG_KIND_UNKNOWN = 0;
-  TAG_KIND_INTEGRITY = 1;
-  TAG_KIND_CONFIDENTIALITY = 2;
-}
-
-// The action that is taken upon a tag by a TagTransform expression.
-enum TagAlteration {
-  TAG_ALTERATION_NONE = 0;
-  TAG_ALTERATION_ADD = 1;
-  TAG_ALTERATION_REMOVE = 2;
-}
-
-// A pair of an Expression's unique ID and an integrity tag that must be
-// present upon that expression for this precondition to hold.
-message ExprTagPrecondition {
-  uint64 expr_id = 1;
-  string integrity_tag = 2;
-}
-
 // A transform upon the tag state of a program.
 //
 // A `TagTransform` is structured like a cast upon some `transformed_node`
@@ -81,21 +60,14 @@ message TagTransform {
   // The `Expression` that is having its tag state changed by the
   // `TagTransform`.
   Expression transformed_node = 1;
-  // A "map" from the unique ID of a particular input `Expression` to the
-  // integrity tags that are required to be present upon that operation for
-  // this transform to execute. Because it is possible that a `TagTransform`
-  // could require a single expression to have multiple integrity tag values,
-  // we express this `map` as a list of pairs.
-  repeated ExprTagPrecondition tag_preconditions = 2;
-  // The action to be performed on the tag state of the node indicated by the
-  // `transformed_node_id` if all of the required integrity tags are present
-  // on the nodes indicated in the `required_integrity_tags` map. Can be
-  // added or removed.
-  TagAlteration tag_alteration = 3;
-  // The kind of the tag given in tag that should be added or removed.
-  TagKind tag_kind = 4;
-  // The string form of the tag to add or remove.
-  string tag = 5;
+  // The name of the rule that will govern whether this `TagTransform` is
+  // active and what it does when active.
+  string transform_rule_name = 2;
+  // A list of unique IDs of the expressions to be considered as
+  // preconditions of the `TagTransform`. The order matters here: the order
+  // number will be used to match these tag IDs with the requirements imposed
+  // by some rule.
+  repeated uint64 tag_precondition_ids = 3;
 };
 
 message Expression {


### PR DESCRIPTION
After a conversation with @bgogul yesterday, I realized I had not split
things correctly across the dataflow graph and policy aspects. This
change simplifies the `TagTransform` structure to tighten its structural
focus and adds a name to allow it to link with the policy rule to which
it connects.