### PR TITLE
Enable layering_check in all packages.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,7 +18,9 @@
 load("@buildtools//buildifier:def.bzl", "buildifier")
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
-licenses(["notice"])
+package(
+    licenses = ["notice"],
+)
 
 # Target to fix all bazel files in Raksha repo.
 buildifier(

--- a/build_defs/BUILD
+++ b/build_defs/BUILD
@@ -1,1 +1,3 @@
-licenses(["notice"])
+package(
+    licenses = ["notice"],
+)

--- a/rust/tools/authorization-logic/BUILD
+++ b/rust/tools/authorization-logic/BUILD
@@ -14,11 +14,13 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-package(default_visibility = ["//visibility:public"])
 
 load("@rules_rust//rust:rust.bzl", "rust_binary", "rust_library")
 
-licenses(["notice"])
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
 
 filegroup(
     name = "antlr_gen_mod_rs",

--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -5,9 +5,11 @@ load(
     "souffle_cc_library",
 )
 
-package(default_visibility = ["//src:__subpackages__"])
-
-licenses(["notice"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_test(
     name = "cpp_interface_test",

--- a/src/analysis/souffle/examples/multimic/BUILD
+++ b/src/analysis/souffle/examples/multimic/BUILD
@@ -14,10 +14,12 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
-
 load("//build_defs:raksha.bzl", "policy_check")
+
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 policy_check(
     name = "check_multimic_userc_tag_fail",

--- a/src/analysis/souffle/examples/simple/BUILD
+++ b/src/analysis/souffle/examples/simple/BUILD
@@ -15,7 +15,10 @@
 #-------------------------------------------------------------------------------
 load("//build_defs:raksha.bzl", "raksha_policy_check")
 
-licenses(["notice"])
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 # To invoke policy engine, `bazel test :ok_claim_propagates_check`.
 raksha_policy_check(

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/BUILD
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/BUILD
@@ -15,7 +15,10 @@
 #-------------------------------------------------------------------------------
 load("//build_defs:raksha.bzl", "policy_check")
 
-licenses(["notice"])
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 policy_check(
     name = "delegation_granted",

--- a/src/analysis/souffle/examples/simple_canSayHasTag/BUILD
+++ b/src/analysis/souffle/examples/simple_canSayHasTag/BUILD
@@ -15,7 +15,10 @@
 #-------------------------------------------------------------------------------
 load("//build_defs:raksha.bzl", "policy_check")
 
-licenses(["notice"])
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 policy_check(
     name = "delegation_granted",

--- a/src/analysis/souffle/examples/simple_may_will/BUILD
+++ b/src/analysis/souffle/examples/simple_may_will/BUILD
@@ -15,7 +15,10 @@
 #-------------------------------------------------------------------------------
 load("//build_defs:raksha.bzl", "policy_check")
 
-licenses(["notice"])
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 policy_check(
     name = "may_will_pass",

--- a/src/analysis/souffle/tests/arcs_fact_tests/BUILD
+++ b/src/analysis/souffle/tests/arcs_fact_tests/BUILD
@@ -4,7 +4,10 @@ load(
     "souffle_cc_library",
 )
 
-licenses(["notice"])
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 FAILURE_DL_TEST_FILES = glob(["*_expect_fails.dl"])
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/check_predicate_unit_test/BUILD
+++ b/src/analysis/souffle/tests/arcs_fact_tests/check_predicate_unit_test/BUILD
@@ -14,12 +14,14 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
-
 load(
     "//build_defs:test_helpers.bzl",
     "run_taint_exec_compare_check_results",
+)
+
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
 )
 
 run_taint_exec_compare_check_results(

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates_predicate_test/BUILD
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates_predicate_test/BUILD
@@ -15,11 +15,14 @@
 #
 #-------------------------------------------------------------------------------
 
-licenses(["notice"])
-
 load(
     "//build_defs:test_helpers.bzl",
     "run_taint_exec_compare_check_results",
+)
+
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
 )
 
 run_taint_exec_compare_check_results(

--- a/src/analysis/souffle/tests/arcs_manifest_tests_todo/BUILD
+++ b/src/analysis/souffle/tests/arcs_manifest_tests_todo/BUILD
@@ -14,10 +14,12 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
-
 load("//build_defs:arcs.bzl", "arcs_manifest_proto")
+
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 # TODO(Issue #61): Enable translating these manifests to proto once manifest2proto can parse them.
 BUILD_ERROR_ARCS_MANIFEST_PATTERNS = [

--- a/src/common/logging/BUILD
+++ b/src/common/logging/BUILD
@@ -1,6 +1,8 @@
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "logging",

--- a/src/common/proto/BUILD
+++ b/src/common/proto/BUILD
@@ -20,14 +20,16 @@ package(
     licenses = ["notice"],
 )
 
-# These files contain dummy marker libraries for indicating a dependency upon
-# protobuf libraries. We have to use them because Bazel cannot be configured
-# to just force explicit inclusion of protobuf dependencies. This causes
-# problems when we try to import Raksha into Google's internal repository.
-cc_library(
+# These files contain marker libraries for indicating a dependency upon
+# protobuf libraries. We have to use them because the external protobuf
+# library provides a single BUILD target that encompasses all protobuf
+# headers. However, the Google-intern targets are much more fine grained.
+alias(
     name = "protobuf",
+    actual = "@com_google_protobuf//:protobuf_headers",
 )
 
-cc_library(
+alias(
     name = "proto_message_differencer",
+    actual = "@com_google_protobuf//:protobuf_headers",
 )

--- a/src/common/proto/BUILD
+++ b/src/common/proto/BUILD
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-package(default_visibility = ["//src:__subpackages__"])
-
-licenses(["notice"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 # These files contain dummy marker libraries for indicating a dependency upon
 # protobuf libraries. We have to use them because Bazel cannot be configured

--- a/src/common/testing/BUILD
+++ b/src/common/testing/BUILD
@@ -1,6 +1,8 @@
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "gtest",

--- a/src/frontends/sql/BUILD
+++ b/src/frontends/sql/BUILD
@@ -21,7 +21,10 @@ load(
     "proto_library",
 )
 
-licenses(["notice"])
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 proto_library(
     name = "sql_ir_proto",

--- a/src/frontends/sql/testing/BUILD
+++ b/src/frontends/sql/testing/BUILD
@@ -14,8 +14,10 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "merge_operation_view",

--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -17,9 +17,11 @@
 
 load("//build_defs:test_helpers.bzl", "extracted_datalog_string_test")
 
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "attribute",

--- a/src/ir/auth_logic/BUILD
+++ b/src/ir/auth_logic/BUILD
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "ast",

--- a/src/ir/datalog/BUILD
+++ b/src/ir/datalog/BUILD
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "program",

--- a/src/ir/proto/BUILD
+++ b/src/ir/proto/BUILD
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "types",

--- a/src/ir/types/BUILD
+++ b/src/ir/types/BUILD
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "types",

--- a/src/test_utils/BUILD
+++ b/src/test_utils/BUILD
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #-----------------------------------------------------------------------------
-
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "utils",

--- a/src/test_utils/dl_string_extractor/BUILD
+++ b/src/test_utils/dl_string_extractor/BUILD
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #-----------------------------------------------------------------------------
-
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "datalog_string",

--- a/src/utils/BUILD
+++ b/src/utils/BUILD
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-
-licenses(["notice"])
-
-package(default_visibility = ["//src:__subpackages__"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "intrusive_ptr",

--- a/src/xform_to_datalog/BUILD
+++ b/src/xform_to_datalog/BUILD
@@ -13,9 +13,11 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-package(default_visibility = ["//src:__subpackages__"])
-
-licenses(["notice"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "authorization_logic",

--- a/src/xform_to_datalog/testdata/BUILD
+++ b/src/xform_to_datalog/testdata/BUILD
@@ -15,9 +15,11 @@
 #-------------------------------------------------------------------------------
 load("//build_defs:arcs.bzl", "arcs_manifest_proto")
 
-package(default_visibility = ["//src:__subpackages__"])
-
-licenses(["notice"])
+package(
+    default_visibility = ["//src:__subpackages__"],
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
 
 filegroup(
     name = "auth_logic",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -17,4 +17,6 @@
 
 # An empty file to mark this as a bazel package directory.
 # This is needed for building the third_party dependencies.
-licenses(["notice"])
+package(
+    licenses = ["notice"],
+)

--- a/third_party/arcs/examples/BUILD
+++ b/third_party/arcs/examples/BUILD
@@ -15,9 +15,11 @@
 #
 #-------------------------------------------------------------------------------
 
-licenses(["notice"])
-
 load("//build_defs:arcs.bzl", "arcs_manifest_proto")
+
+package(
+    licenses = ["notice"],
+)
 
 arcs_manifest_proto(
     name = "consume",

--- a/third_party/arcs/proto/BUILD
+++ b/third_party/arcs/proto/BUILD
@@ -4,9 +4,10 @@ load(
     "proto_library",
 )
 
-licenses(["notice"])
-
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
 
 filegroup(
     name = "proto_files",

--- a/third_party/arcs/tools/manifest2proto/BUILD
+++ b/third_party/arcs/tools/manifest2proto/BUILD
@@ -14,11 +14,12 @@
 # limitations under the License.
 #-----------------------------------------------------------------------------
 
-licenses(["notice"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
 
 # tool for converting an .arcs file to binary proto
 nodejs_binary(

--- a/third_party/souffle/BUILD
+++ b/third_party/souffle/BUILD
@@ -16,4 +16,6 @@
 #-------------------------------------------------------------------------------
 
 # Empty BUILD file to mark this directory as a package.
-licenses(["notice"])
+package(
+    licenses = ["notice"],
+)


### PR DESCRIPTION
This PR also fixes some formatting errors (e.g., `load` should be in the beginning) in the BUILD files.