### PR TITLE
Revamp MapIter to work with different containers and have val variant.

### DIFF
--- a/src/frontends/sql/BUILD
+++ b/src/frontends/sql/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "//src/ir:block_builder",
         "//src/ir:ir_context",
         "//src/ir:value",
+        "//src/utils:map_iter",
         "@absl//absl/container:flat_hash_map",
     ],
 )

--- a/src/ir/auth_logic/lowering_ast_datalog.cc
+++ b/src/ir/auth_logic/lowering_ast_datalog.cc
@@ -20,7 +20,6 @@
 #include "src/utils/map_iter.h"
 #include "src/utils/move_append.h"
 
-
 namespace raksha::ir::auth_logic {
 
 namespace {
@@ -32,8 +31,8 @@ namespace {
 // This is used in a few places in the translation, for example, to translate
 // "X says blah(args)" into "says_blah(X, args)".
 datalog::Predicate PushOntoPredicate(absl::string_view modifier,
-                            std::vector<std::string> new_args,
-                            const datalog::Predicate& predicate) {
+                                     std::vector<std::string> new_args,
+                                     const datalog::Predicate& predicate) {
   std::string new_name = absl::StrCat(std::move(modifier), predicate.name());
   utils::MoveAppend(new_args, std::vector<std::string>(predicate.args()));
   datalog::Sign sign_copy = predicate.sign();
@@ -46,8 +45,9 @@ datalog::Predicate PushOntoPredicate(absl::string_view modifier,
 // This is a common case in this translation because it is used for
 // `x says blah(args)` and `x canActAs y` and other constructions involving a
 // principal name.
-datalog::Predicate PushPrincipal(absl::string_view modifier, const Principal& principal,
-                        const datalog::Predicate& predicate) {
+datalog::Predicate PushPrincipal(absl::string_view modifier,
+                                 const Principal& principal,
+                                 const datalog::Predicate& predicate) {
   return PushOntoPredicate(modifier, {principal.name()}, predicate);
 }
 
@@ -77,7 +77,8 @@ datalog::DLIRAssertion LoweringToDatalogPass::SpokenAttributeToDLIR(
   Principal prin_y(FreshVar());
 
   // This is `speaker says Y PredX`
-  datalog::Predicate y_predX = AttributeToDLIR(Attribute(prin_y, attribute.predicate()));
+  datalog::Predicate y_predX =
+      AttributeToDLIR(Attribute(prin_y, attribute.predicate()));
   datalog::Predicate generated_lhs = PushPrincipal("says_", speaker, y_predX);
 
   // This is `speaker says Y canActAs X`
@@ -94,9 +95,9 @@ datalog::DLIRAssertion LoweringToDatalogPass::SpokenAttributeToDLIR(
   // This is the full generated rule:
   // `speaker says Y PredX :-
   //    speaker says Y canActAs X, speaker says X PredX`
-  return datalog::DLIRAssertion(
-      datalog::DLIRCondAssertion(generated_lhs, {std::move(speaker_says_y_can_act_as_x),
-                                        std::move(speaker_says_x_pred)}));
+  return datalog::DLIRAssertion(datalog::DLIRCondAssertion(
+      generated_lhs, {std::move(speaker_says_y_can_act_as_x),
+                      std::move(speaker_says_x_pred)}));
 }
 
 datalog::DLIRAssertion LoweringToDatalogPass::SpokenCanActAsToDLIR(
@@ -113,7 +114,8 @@ datalog::DLIRAssertion LoweringToDatalogPass::SpokenCanActAsToDLIR(
   // This is `speaker says Y canActAs Z`
   datalog::Predicate y_can_act_as_z =
       CanActAsToDLIR(CanActAs(prin_y, can_act_as.right_principal()));
-  datalog::Predicate generated_lhs = PushPrincipal("says_", speaker, y_can_act_as_z);
+  datalog::Predicate generated_lhs =
+      PushPrincipal("says_", speaker, y_can_act_as_z);
 
   // This is `speaker says Y canActAs X`
   datalog::Predicate y_can_act_as_x =
@@ -135,25 +137,25 @@ datalog::DLIRAssertion LoweringToDatalogPass::SpokenCanActAsToDLIR(
 }
 
 std::pair<datalog::Predicate, std::vector<datalog::DLIRAssertion>>
-LoweringToDatalogPass::BaseFactToDLIRInner(const Principal& speaker,
-                                           const datalog::Predicate& predicate) {
+LoweringToDatalogPass::BaseFactToDLIRInner(
+    const Principal& speaker, const datalog::Predicate& predicate) {
   return std::make_pair(predicate, std::vector<datalog::DLIRAssertion>({}));
 }
 
 std::pair<datalog::Predicate, std::vector<datalog::DLIRAssertion>>
 LoweringToDatalogPass::BaseFactToDLIRInner(const Principal& speaker,
                                            const Attribute& attribute) {
-  return std::make_pair(
-      AttributeToDLIR(attribute),
-      std::vector<datalog::DLIRAssertion>({SpokenAttributeToDLIR(speaker, attribute)}));
+  return std::make_pair(AttributeToDLIR(attribute),
+                        std::vector<datalog::DLIRAssertion>(
+                            {SpokenAttributeToDLIR(speaker, attribute)}));
 }
 
 std::pair<datalog::Predicate, std::vector<datalog::DLIRAssertion>>
 LoweringToDatalogPass::BaseFactToDLIRInner(const Principal& speaker,
                                            const CanActAs& canActAs) {
-  return std::make_pair(
-      CanActAsToDLIR(canActAs),
-      std::vector<datalog::DLIRAssertion>({SpokenCanActAsToDLIR(speaker, canActAs)}));
+  return std::make_pair(CanActAsToDLIR(canActAs),
+                        std::vector<datalog::DLIRAssertion>(
+                            {SpokenCanActAsToDLIR(speaker, canActAs)}));
 }
 
 std::pair<datalog::Predicate, std::vector<datalog::DLIRAssertion>>
@@ -195,7 +197,8 @@ LoweringToDatalogPass::FactToDLIR(const Principal& speaker, const Fact& fact) {
                 "says_", speaker,
                 PushPrincipal("canSay_", fresh_principal, inner_fact_dlir));
             auto rhs = {fresh_prin_says_inner, speaker_says_fresh_cansay_inner};
-            datalog::DLIRAssertion generated_rule(datalog::DLIRCondAssertion(lhs, rhs));
+            datalog::DLIRAssertion generated_rule(
+                datalog::DLIRCondAssertion(lhs, rhs));
             gen_rules.push_back(generated_rule);
 
             // Note that prin_cansay_pred does not begin with "speaker says"
@@ -211,8 +214,9 @@ LoweringToDatalogPass::FactToDLIR(const Principal& speaker, const Fact& fact) {
       fact.GetValue());
 }
 
-std::vector<datalog::DLIRAssertion> LoweringToDatalogPass::GenerateDLIRAssertions(
-    const Principal& speaker, const Fact& fact) {
+std::vector<datalog::DLIRAssertion>
+LoweringToDatalogPass::GenerateDLIRAssertions(const Principal& speaker,
+                                              const Fact& fact) {
   auto [fact_predicate, generated_rules] = FactToDLIR(speaker, fact);
   datalog::DLIRAssertion main_assertion =
       datalog::DLIRAssertion(PushPrincipal("says_", speaker, fact_predicate));
@@ -220,23 +224,26 @@ std::vector<datalog::DLIRAssertion> LoweringToDatalogPass::GenerateDLIRAssertion
   return generated_rules;
 }
 
-std::vector<datalog::DLIRAssertion> LoweringToDatalogPass::GenerateDLIRAssertions(
+std::vector<datalog::DLIRAssertion>
+LoweringToDatalogPass::GenerateDLIRAssertions(
     const Principal& speaker,
     const ConditionalAssertion& conditional_assertion) {
-  auto dlir_rhs = utils::MapIter<BaseFact, datalog::Predicate>(
+  auto dlir_rhs = utils::MapIterRef<std::vector<datalog::Predicate>>(
       conditional_assertion.rhs(), [this, speaker](const BaseFact& base_fact) {
         auto [dlir_translation, not_used] = BaseFactToDLIR(speaker, base_fact);
         return PushPrincipal("says_", speaker, dlir_translation);
       });
   auto [dlir_lhs, gen_rules] = FactToDLIR(speaker, conditional_assertion.lhs());
   auto dlir_lhs_prime = PushPrincipal("says_", speaker, dlir_lhs);
-  datalog::DLIRAssertion dlir_assertion(datalog::DLIRCondAssertion(dlir_lhs_prime, dlir_rhs));
+  datalog::DLIRAssertion dlir_assertion(
+      datalog::DLIRCondAssertion(dlir_lhs_prime, dlir_rhs));
   gen_rules.push_back(dlir_assertion);
   return gen_rules;
 }
 
-std::vector<datalog::DLIRAssertion> LoweringToDatalogPass::SingleSaysAssertionToDLIR(
-    const Principal& speaker, const Assertion& assertion) {
+std::vector<datalog::DLIRAssertion>
+LoweringToDatalogPass::SingleSaysAssertionToDLIR(const Principal& speaker,
+                                                 const Assertion& assertion) {
   return std::visit(
       // I thought it would be possible to skip the overloaded (just like
       // in BaseFactToDLIR, but I needed to give the types for each
@@ -274,12 +281,15 @@ std::vector<datalog::DLIRAssertion> LoweringToDatalogPass::SaysAssertionsToDLIR(
 
 std::vector<datalog::DLIRAssertion> LoweringToDatalogPass::QueriesToDLIR(
     const std::vector<Query>& queries) {
-  return utils::MapIter<Query, datalog::DLIRAssertion>(queries, [this](const Query& query) {
-    auto [main_pred, not_used] = FactToDLIR(query.principal(), query.fact());
-    main_pred = PushPrincipal("says_", query.principal(), main_pred);
-    datalog::Predicate lhs(query.name(), {"dummy_var"}, datalog::kPositive);
-    return datalog::DLIRAssertion(datalog::DLIRCondAssertion(lhs, {main_pred, kDummyPredicate}));
-  });
+  return utils::MapIterRef<std::vector<datalog::DLIRAssertion>>(
+      queries, [this](const Query& query) {
+        auto [main_pred, not_used] =
+            FactToDLIR(query.principal(), query.fact());
+        main_pred = PushPrincipal("says_", query.principal(), main_pred);
+        datalog::Predicate lhs(query.name(), {"dummy_var"}, datalog::kPositive);
+        return datalog::DLIRAssertion(
+            datalog::DLIRCondAssertion(lhs, {main_pred, kDummyPredicate}));
+      });
 }
 
 datalog::DLIRProgram LoweringToDatalogPass::ProgToDLIR(const Program& program) {
@@ -291,7 +301,7 @@ datalog::DLIRProgram LoweringToDatalogPass::ProgToDLIR(const Program& program) {
   utils::MoveAppend(dlir_assertions, std::move(dlir_queries));
   dlir_assertions.push_back(dummy_assertion);
 
-  auto outputs = utils::MapIter<Query, std::string>(
+  auto outputs = utils::MapIterRef<std::vector<std::string>>(
       program.queries(), [](const Query& query) { return query.name(); });
   return datalog::DLIRProgram(dlir_assertions, outputs);
 }

--- a/src/ir/auth_logic/souffle_emitter.h
+++ b/src/ir/auth_logic/souffle_emitter.h
@@ -53,7 +53,7 @@ class SouffleEmitter {
   datalog::Predicate PredToDeclaration(const datalog::Predicate& predicate) {
     int i = 0;
     return datalog::Predicate(predicate.name(),
-                     utils::MapIter<std::string, std::string>(
+                     utils::MapIterRef<std::vector<std::string>>(
                          predicate.args(),
                          [i](const std::string& arg) mutable {
                            return absl::StrCat("x", std::to_string(i++));
@@ -75,7 +75,7 @@ class SouffleEmitter {
   }
 
   std::string EmitAssertionInner(const datalog::DLIRCondAssertion& cond_assertion) {
-    std::vector rhs_translated = utils::MapIter<datalog::Predicate, std::string>(
+    std::vector rhs_translated = utils::MapIterRef<std::vector<std::string>>(
         cond_assertion.rhs(),
         [this](const datalog::Predicate& arg) { return EmitPredicate(arg); });
     return absl::StrCat(EmitPredicate(cond_assertion.lhs()), " :- ",
@@ -89,7 +89,7 @@ class SouffleEmitter {
 
   std::string EmitProgramBody(const datalog::DLIRProgram& program) {
     return absl::StrJoin(
-        utils::MapIter<datalog::DLIRAssertion, std::string>(
+        utils::MapIterRef<std::vector<std::string>>(
             program.assertions(),
             [this](const datalog::DLIRAssertion& astn) { return EmitAssertion(astn); }),
         "\n");

--- a/src/utils/BUILD
+++ b/src/utils/BUILD
@@ -112,7 +112,11 @@ cc_test(
 cc_library(
     name = "map_iter",
     hdrs = ["map_iter.h"],
-    deps = [],
+    deps = [
+        "//src/common/logging",
+        "@absl//absl/container:flat_hash_map",
+        "@absl//absl/container:flat_hash_set",
+    ],
 )
 
 cc_test(
@@ -121,6 +125,8 @@ cc_test(
     deps = [
         ":map_iter",
         "//src/common/testing:gtest",
+        "@absl//absl/container:flat_hash_map",
+        "@absl//absl/container:flat_hash_set",
     ],
 )
 

--- a/src/utils/map_iter_test.cc
+++ b/src/utils/map_iter_test.cc
@@ -15,14 +15,125 @@
 //-----------------------------------------------------------------------------
 #include "src/utils/map_iter.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "src/common/testing/gtest.h"
 
 namespace raksha::utils {
 
 TEST(MapIterTestSuite, SimpleMapIterTest) {
-  std::vector test_vec = MapIter<int, int>(std::vector({1, 5, 3, 9, 5}),
-                                           [](const int& x) { return x + 3; });
+  std::vector test_vec = MapIterVal<std::vector<int>>(
+      std::vector({1, 5, 3, 9, 5}), [](const int& x) { return x + 3; });
   EXPECT_EQ(test_vec, std::vector({4, 8, 6, 12, 8}));
+}
+
+TEST(MapIterTestSuite, MapIterToMapTest) {
+  absl::flat_hash_map<int, int> test_map =
+      MapIterVal<absl::flat_hash_map<int, int>>(
+          std::vector({1, 5, 3, 9, 5}),
+          [](const int& x) { return std::make_pair(x, x); },
+          CollisionPolicy::kIgnore);
+  EXPECT_EQ(test_map,
+            (absl::flat_hash_map<int, int>({{1, 1}, {5, 5}, {3, 3}, {9, 9}})));
+}
+
+TEST(MapIterTestSuite, MapIterToSetTest) {
+  absl::flat_hash_set<int> test_set = MapIterVal<absl::flat_hash_set<int>>(
+      std::vector({1, 5, 3, 9, 5}), [](const int& x) { return x + 3; },
+      CollisionPolicy::kIgnore);
+  EXPECT_EQ(test_set, (absl::flat_hash_set<int>({4, 8, 6, 12})));
+}
+
+TEST(MapIterTestSuite, MapIterToMapCollisionDeath) {
+  EXPECT_DEATH(
+      {
+        (MapIterVal<absl::flat_hash_map<int, int>>(
+            (std::vector({1, 5, 3, 9, 5})),
+            ([](const int& x) { return std::make_pair(x, x); })));
+      },
+      "Found collision when mapping a container.");
+}
+
+TEST(MapIterTestSuite, MapIterToSetCollisionDeath) {
+  EXPECT_DEATH(
+      {
+        (MapIterVal<absl::flat_hash_set<int>>(
+            (std::vector({1, 5, 3, 9, 5})),
+            ([](const int& x) { return x + 3; })));
+      },
+      "Found collision when mapping a container.");
+}
+
+TEST(MapIterTestSuite, MapIterToMapTestNoCollisions) {
+  absl::flat_hash_map<int, int> test_map =
+      MapIterVal<absl::flat_hash_map<int, int>>(
+          std::vector({1, 5, 3, 9}),
+          [](const int& x) { return std::make_pair(x, x); });
+  EXPECT_EQ(test_map,
+            (absl::flat_hash_map<int, int>({{1, 1}, {5, 5}, {3, 3}, {9, 9}})));
+}
+
+TEST(MapIterTestSuite, MapIterToSetTestNoCollisions) {
+  absl::flat_hash_set<int> test_set = MapIterVal<absl::flat_hash_set<int>>(
+      std::vector({1, 5, 3, 9}), [](const int& x) { return x + 3; });
+  EXPECT_EQ(test_set, (absl::flat_hash_set<int>({4, 8, 6, 12})));
+}
+
+TEST(MapIterRefTestSuite, SimpleMapIterRefTest) {
+  std::vector test_vec = MapIterRef<std::vector<int>>(
+      std::vector({1, 5, 3, 9, 5}), [](const int& x) { return x + 3; });
+  EXPECT_EQ(test_vec, std::vector({4, 8, 6, 12, 8}));
+}
+
+TEST(MapIterRefTestSuite, MapIterToMapTest) {
+  absl::flat_hash_map<int, int> test_map =
+      MapIterRef<absl::flat_hash_map<int, int>>(
+          std::vector({1, 5, 3, 9, 5}),
+          [](const int& x) { return std::make_pair(x, x); },
+          CollisionPolicy::kIgnore);
+  EXPECT_EQ(test_map,
+            (absl::flat_hash_map<int, int>({{1, 1}, {5, 5}, {3, 3}, {9, 9}})));
+}
+
+TEST(MapIterRefTestSuite, MapIterToSetTest) {
+  absl::flat_hash_set<int> test_set = MapIterRef<absl::flat_hash_set<int>>(
+      std::vector({1, 5, 3, 9, 5}), [](const int& x) { return x + 3; },
+      CollisionPolicy::kIgnore);
+  EXPECT_EQ(test_set, (absl::flat_hash_set<int>({4, 8, 6, 12})));
+}
+
+TEST(MapIterRefTestSuite, MapIterToMapCollisionDeath) {
+  EXPECT_DEATH(
+      {
+        (MapIterRef<absl::flat_hash_map<int, int>>(
+            (std::vector({1, 5, 3, 9, 5})),
+            ([](const int& x) { return std::make_pair(x, x); })));
+      },
+      "Found collision when mapping a container.");
+}
+
+TEST(MapIterRefTestSuite, MapIterToSetCollisionDeath) {
+  EXPECT_DEATH(
+      {
+        (MapIterRef<absl::flat_hash_set<int>>(
+            (std::vector({1, 5, 3, 9, 5})),
+            ([](const int& x) { return x + 3; })));
+      },
+      "Found collision when mapping a container.");
+}
+
+TEST(MapIterRefTestSuite, MapIterToMapTestNoCollisions) {
+  absl::flat_hash_map<int, int> test_map =
+      MapIterRef<absl::flat_hash_map<int, int>>(
+          std::vector({1, 5, 3, 9}),
+          [](const int& x) { return std::make_pair(x, x); });
+  EXPECT_EQ(test_map,
+            (absl::flat_hash_map<int, int>({{1, 1}, {5, 5}, {3, 3}, {9, 9}})));
+}
+
+TEST(MapIterRefTestSuite, MapIterToSetTestNoCollisions) {
+  absl::flat_hash_set<int> test_set = MapIterRef<absl::flat_hash_set<int>>(
+      std::vector({1, 5, 3, 9}), [](const int& x) { return x + 3; });
+  EXPECT_EQ(test_set, (absl::flat_hash_set<int>({4, 8, 6, 12})));
 }
 
 }  // namespace raksha::utils


### PR DESCRIPTION
Previously, `MapIter` only would work for turning a `std::vector` into
a `std::vector`. This PR reworks it to work with vectors, maps, or sets.
It also introduces a variant that takes its input by value instead of by
reference, which is nice for chaining multiple maps.