### PR TITLE
Generalize MapIter to take an iterable container, use std::transform, and reorder template arguments.

### DIFF
--- a/src/common/utils/map_iter.h
+++ b/src/common/utils/map_iter.h
@@ -23,13 +23,12 @@
 
 namespace raksha::utils {
 
-template <typename T, typename U, typename F>
-std::vector<U> MapIter(const std::vector<T>& input, F f) {
+template <typename U, typename C, typename F>
+std::vector<U> MapIter(const C& input, F map_fn) {
   std::vector<U> result;
   result.reserve(input.size());
-  for (auto& entity : input) {
-    result.push_back(f(entity));
-  }
+  std::transform(std::begin(input), std::end(input), std::back_inserter(result),
+                 map_fn);
   return result;
 }
 

--- a/src/common/utils/map_iter.h
+++ b/src/common/utils/map_iter.h
@@ -19,10 +19,13 @@
 #ifndef SRC_COMMON_UTILS_MAP_ITER_H_
 #define SRC_COMMON_UTILS_MAP_ITER_H_
 
+#include <algorithm>
 #include <vector>
 
 namespace raksha::utils {
 
+// Returns a vector that is generating by applying `map_fn: (C::value_type ->
+// U)` to every elemnent of the input container `C`.
 template <typename U, typename C, typename F>
 std::vector<U> MapIter(const C& input, F map_fn) {
   std::vector<U> result;

--- a/src/common/utils/map_iter_test.cc
+++ b/src/common/utils/map_iter_test.cc
@@ -15,14 +15,23 @@
 //-----------------------------------------------------------------------------
 #include "src/common/utils/map_iter.h"
 
+#include <deque>
+#include <vector>
+
 #include "src/common/testing/gtest.h"
 
 namespace raksha::utils {
 
 TEST(MapIterTestSuite, SimpleMapIterTest) {
-  std::vector test_vec = MapIter<int, int>(std::vector({1, 5, 3, 9, 5}),
-                                           [](const int& x) { return x + 3; });
-  EXPECT_EQ(test_vec, std::vector({4, 8, 6, 12, 8}));
+  std::vector test_vec = MapIter<int>(std::vector({1, 5, 3, 9, 5}),
+                                      [](const int& x) { return x + 3; });
+  EXPECT_THAT(test_vec, testing::ElementsAre(4, 8, 6, 12, 8));
+}
+
+TEST(MapIterTestSuite, SimpleMapIterOnDequeTest) {
+  std::vector test_vec = MapIter<int>(std::deque({1, 5, 3, 9, 5}),
+                                      [](const int& x) { return x + 4; });
+  EXPECT_THAT(test_vec, testing::ElementsAre(5, 9, 7, 13, 9));
 }
 
 }  // namespace raksha::utils

--- a/src/ir/auth_logic/lowering_ast_datalog.cc
+++ b/src/ir/auth_logic/lowering_ast_datalog.cc
@@ -228,7 +228,7 @@ std::vector<datalog::DLIRAssertion>
 LoweringToDatalogPass::GenerateDLIRAssertions(
     const Principal& speaker,
     const ConditionalAssertion& conditional_assertion) {
-  auto dlir_rhs = utils::MapIter<BaseFact, datalog::Predicate>(
+  auto dlir_rhs = utils::MapIter<datalog::Predicate>(
       conditional_assertion.rhs(), [this, speaker](const BaseFact& base_fact) {
         auto [dlir_translation, not_used] = BaseFactToDLIR(speaker, base_fact);
         return PushPrincipal("says_", speaker, dlir_translation);
@@ -281,7 +281,7 @@ std::vector<datalog::DLIRAssertion> LoweringToDatalogPass::SaysAssertionsToDLIR(
 
 std::vector<datalog::DLIRAssertion> LoweringToDatalogPass::QueriesToDLIR(
     const std::vector<Query>& queries) {
-  return utils::MapIter<Query, datalog::DLIRAssertion>(
+  return utils::MapIter<datalog::DLIRAssertion>(
       queries, [this](const Query& query) {
         auto [main_pred, not_used] =
             FactToDLIR(query.principal(), query.fact());
@@ -301,7 +301,7 @@ datalog::DLIRProgram LoweringToDatalogPass::ProgToDLIR(const Program& program) {
   utils::MoveAppend(dlir_assertions, std::move(dlir_queries));
   dlir_assertions.push_back(dummy_assertion);
 
-  auto outputs = utils::MapIter<Query, std::string>(
+  auto outputs = utils::MapIter<std::string>(
       program.queries(), [](const Query& query) { return query.name(); });
   return datalog::DLIRProgram(dlir_assertions, outputs);
 }

--- a/src/ir/auth_logic/souffle_emitter.h
+++ b/src/ir/auth_logic/souffle_emitter.h
@@ -50,14 +50,14 @@ class SouffleEmitter {
   // from generating two declarations, the sign here is always positive.
   datalog::Predicate PredToDeclaration(const datalog::Predicate& predicate) {
     int i = 0;
-    return datalog::Predicate(predicate.name(),
-                              utils::MapIter<std::string, std::string>(
-                                  predicate.args(),
-                                  [i](const std::string& arg) mutable {
-                                    return absl::StrCat("x",
-                                                        std::to_string(i++));
-                                  }),
-                              datalog::kPositive);
+    return datalog::Predicate(
+        predicate.name(),
+        utils::MapIter<std::string>(predicate.args(),
+                                    [i](const std::string& arg) mutable {
+                                      return absl::StrCat("x",
+                                                          std::to_string(i++));
+                                    }),
+        datalog::kPositive);
   }
 
   std::string EmitPredicate(const datalog::Predicate& predicate) {
@@ -75,11 +75,9 @@ class SouffleEmitter {
 
   std::string EmitAssertionInner(
       const datalog::DLIRCondAssertion& cond_assertion) {
-    std::vector rhs_translated =
-        utils::MapIter<datalog::Predicate, std::string>(
-            cond_assertion.rhs(), [this](const datalog::Predicate& arg) {
-              return EmitPredicate(arg);
-            });
+    std::vector rhs_translated = utils::MapIter<std::string>(
+        cond_assertion.rhs(),
+        [this](const datalog::Predicate& arg) { return EmitPredicate(arg); });
     return absl::StrCat(EmitPredicate(cond_assertion.lhs()), " :- ",
                         absl::StrJoin(rhs_translated, ", "), ".");
   }
@@ -90,12 +88,12 @@ class SouffleEmitter {
   }
 
   std::string EmitProgramBody(const datalog::DLIRProgram& program) {
-    return absl::StrJoin(utils::MapIter<datalog::DLIRAssertion, std::string>(
-                             program.assertions(),
-                             [this](const datalog::DLIRAssertion& astn) {
-                               return EmitAssertion(astn);
-                             }),
-                         "\n");
+    return absl::StrJoin(
+        utils::MapIter<std::string>(program.assertions(),
+                                    [this](const datalog::DLIRAssertion& astn) {
+                                      return EmitAssertion(astn);
+                                    }),
+        "\n");
   }
 
   std::string EmitOutputs(const datalog::DLIRProgram& program) {


### PR DESCRIPTION
This commit has the following changes:
   - Generalizes MapIter a bit to accept any iterable container.
   - Uses std::transform instead of a `for`-loop.
   - Reordering template arguments helps argument deduction at call sites.
   - Updates the test to use appropriate matchers to help debugging test failures.