### PR TITLE
Decode `TagTransform` proto.

### DIFF
--- a/src/frontends/sql/BUILD
+++ b/src/frontends/sql/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "//src/ir:block_builder",
         "//src/ir:ir_context",
         "//src/ir:value",
+        "//src/utils:map_iter",
         "@absl//absl/container:flat_hash_map",
     ],
 )
@@ -80,6 +81,7 @@ cc_test(
         "//src/common/testing:gtest",
         "//src/frontends/sql/testing:literal_operation_view",
         "//src/frontends/sql/testing:merge_operation_view",
+        "//src/frontends/sql/testing:tag_transform_operation_view",
         "@absl//absl/strings",
     ],
 )
@@ -149,6 +151,20 @@ cc_test(
         "//src/frontends/sql:sql_ir_cc_proto",
         "//src/frontends/sql/testing:merge_operation_view",
         "//src/frontends/sql/testing:utils",
+        "@absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "decode_tag_transform_operation_test",
+    srcs = ["decode_tag_transform_operation_test.cc"],
+    deps = [
+        ":decode",
+        ":decoder_context",
+        "//src/common/proto:protobuf",
+        "//src/common/testing:gtest",
+        "//src/frontends/sql:sql_ir_cc_proto",
+        "//src/frontends/sql/testing:tag_transform_operation_view",
         "@absl//absl/strings",
     ],
 )

--- a/src/frontends/sql/BUILD
+++ b/src/frontends/sql/BUILD
@@ -44,10 +44,10 @@ cc_library(
     hdrs = ["decoder_context.h"],
     visibility = [":__subpackages__"],
     deps = [
+        "//src/common/utils:map_iter",
         "//src/ir:block_builder",
         "//src/ir:ir_context",
         "//src/ir:value",
-        "//src/utils:map_iter",
         "@absl//absl/container:flat_hash_map",
     ],
 )
@@ -163,6 +163,7 @@ cc_test(
         ":decoder_context",
         "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
+        "//src/common/utils:map_iter",
         "//src/frontends/sql:sql_ir_cc_proto",
         "//src/frontends/sql/testing:literal_operation_view",
         "//src/frontends/sql/testing:merge_operation_view",

--- a/src/frontends/sql/BUILD
+++ b/src/frontends/sql/BUILD
@@ -164,7 +164,11 @@ cc_test(
         "//src/common/proto:protobuf",
         "//src/common/testing:gtest",
         "//src/frontends/sql:sql_ir_cc_proto",
+        "//src/frontends/sql/testing:literal_operation_view",
+        "//src/frontends/sql/testing:merge_operation_view",
         "//src/frontends/sql/testing:tag_transform_operation_view",
+        "//src/frontends/sql/testing:utils",
         "@absl//absl/strings",
+        "@absl//absl/strings:str_format",
     ],
 )

--- a/src/frontends/sql/decode.cc
+++ b/src/frontends/sql/decode.cc
@@ -89,6 +89,7 @@ static Value DecodeTagTransform(const TagTransform &tag_transform,
   CHECK(!transform_rule_name.empty())
       << "Required TagTransform field transform_rule_name not present.";
   std::vector<uint64_t> precondition_ids;
+  precondition_ids.reserve(tag_transform.tag_precondition_ids_size());
   for (uint64_t id : tag_transform.tag_precondition_ids()) {
     precondition_ids.push_back(id);
   }

--- a/src/frontends/sql/decode_tag_transform_operation_test.cc
+++ b/src/frontends/sql/decode_tag_transform_operation_test.cc
@@ -1,0 +1,149 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "google/protobuf/text_format.h"
+#include "src/common/testing/gtest.h"
+#include "src/frontends/sql/decode.h"
+#include "src/frontends/sql/decoder_context.h"
+#include "src/frontends/sql/sql_ir.pb.h"
+#include "src/frontends/sql/testing/literal_operation_view.h"
+#include "src/frontends/sql/testing/merge_operation_view.h"
+#include "src/frontends/sql/testing/tag_transform_operation_view.h"
+#include "src/frontends/sql/testing/utils.h"
+
+namespace raksha::frontends::sql {
+
+namespace {
+
+using ir::Attribute;
+using ir::Block;
+using ir::IRContext;
+using ir::Operation;
+using ir::Storage;
+using ir::Value;
+using ir::types::TypeBase;
+using ir::value::OperationResult;
+using ir::value::StoredValue;
+using ::testing::Combine;
+using ::testing::Eq;
+using ::testing::IsEmpty;
+using ::testing::IsNull;
+using testing::LiteralOperationView;
+using testing::MergeOperationView;
+using ::testing::NotNull;
+using ::testing::Pair;
+using ::testing::ResultOf;
+using testing::TagTransformOperationView;
+using ::testing::TestWithParam;
+using ::testing::UnorderedElementsAre;
+using ::testing::UnorderedElementsAreArray;
+using testing::UnwrapDefaultOperationResult;
+using ::testing::Values;
+using ::testing::ValuesIn;
+
+// This struct carries a textproto string describing a value and a lambda
+// that, given that value, verifies that its properties are as expected. This
+// allows us to combine the various pieces of a `TagTransform` and flexibly
+// verify that the value to which the transform is applied is as we expect.
+struct ValueTextprotoAndDeconstruction {
+  absl::string_view textproto;
+  std::function<void(Value)> deconstruction;
+};
+
+class DecodeTagTransformTest
+    : public ::testing::TestWithParam<std::tuple<
+          uint64_t, absl::string_view, ValueTextprotoAndDeconstruction>> {
+ protected:
+  DecodeTagTransformTest() : ir_context_(), decoder_context_(ir_context_) {}
+
+  static absl::ParsedFormat<'u', 's', 's'> GetProtoFormat() {
+    return absl::ParsedFormat<'u', 's', 's'>(R"(
+id: %u
+tag_transform : { transform_rule_name: "%s" transformed_node: { %s } })");
+  }
+
+  std::string GetTextproto() const {
+    const auto &[id, rule_name, value_textproto_and_deconstruction] =
+        GetParam();
+    return absl::StrFormat(GetProtoFormat(), id, rule_name,
+                           value_textproto_and_deconstruction.textproto);
+  }
+
+  Value GetValue() {
+    Expression expr;
+    EXPECT_TRUE(
+        google::protobuf::TextFormat::ParseFromString(GetTextproto(), &expr));
+    return DecodeExpression(expr, decoder_context_);
+  }
+
+  std::function<void(Value)> GetDeconstructionFunction() const {
+    return std::get<2>(GetParam()).deconstruction;
+  }
+
+  IRContext ir_context_;
+  DecoderContext decoder_context_;
+};
+
+TEST_P(DecodeTagTransformTest, DecodeTagTransformTest) {
+  const auto &[id, rule_name, value_textproto_and_deconstruction] = GetParam();
+
+  Value value = GetValue();
+
+  EXPECT_EQ(value, decoder_context_.GetValue(id));
+
+  TagTransformOperationView tag_xform_view(UnwrapDefaultOperationResult(value));
+  EXPECT_EQ(tag_xform_view.GetRuleName(), rule_name);
+  value_textproto_and_deconstruction.deconstruction(
+      tag_xform_view.GetTransformedValue());
+}
+
+static const ValueTextprotoAndDeconstruction kValuesAndDeconstructions[] = {
+    {.textproto = R"(id: 4 literal: { literal_str: "foo" })",
+     .deconstruction =
+         [](Value val) {
+           const LiteralOperationView literal_operation_view(
+               UnwrapDefaultOperationResult(val));
+           EXPECT_EQ(literal_operation_view.GetLiteralStr(), "foo");
+         }},
+    {.textproto =
+         R"(id: 6 merge_operation: { inputs: { id: 3 literal: { literal_str: "5" } } })",
+     .deconstruction = [](Value val) {
+       const MergeOperationView merge_operation_view(
+           UnwrapDefaultOperationResult(val));
+       EXPECT_THAT(merge_operation_view.GetControlInputs(), IsEmpty());
+       const std::vector<Value> merged_values =
+           merge_operation_view.GetDirectInputs();
+       EXPECT_EQ(merged_values.size(), 1);
+       Value merged_val = merged_values.at(0);
+       const LiteralOperationView literal(
+           UnwrapDefaultOperationResult(merged_val));
+       EXPECT_EQ(literal.GetLiteralStr(), "5");
+     }}};
+
+static const uint64_t kExampleIds[] = {7, 108, 300};
+static const absl::string_view kExampleRuleNames[] = {"rule1", "clearLowBits",
+                                                      "SQL.Identity"};
+
+INSTANTIATE_TEST_SUITE_P(DecodeTagTransformTest, DecodeTagTransformTest,
+                         Combine(ValuesIn(kExampleIds),
+                                 ValuesIn(kExampleRuleNames),
+                                 ValuesIn(kValuesAndDeconstructions)));
+
+}  // namespace
+
+}  // namespace raksha::frontends::sql

--- a/src/frontends/sql/decode_tag_transform_operation_test.cc
+++ b/src/frontends/sql/decode_tag_transform_operation_test.cc
@@ -18,6 +18,7 @@
 #include "absl/strings/string_view.h"
 #include "google/protobuf/text_format.h"
 #include "src/common/testing/gtest.h"
+#include "src/common/utils/map_iter.h"
 #include "src/frontends/sql/decode.h"
 #include "src/frontends/sql/decoder_context.h"
 #include "src/frontends/sql/sql_ir.pb.h"
@@ -25,7 +26,6 @@
 #include "src/frontends/sql/testing/merge_operation_view.h"
 #include "src/frontends/sql/testing/tag_transform_operation_view.h"
 #include "src/frontends/sql/testing/utils.h"
-#include "src/common/utils/map_iter.h"
 
 namespace raksha::frontends::sql {
 
@@ -89,10 +89,10 @@ tag_transform : {
         return decoder_context.GetValue(current_id);
       });
 
-  EXPECT_EQ(decoded_value, decoder_context.GetValue(std::get<0>(GetParam())));
+  EXPECT_EQ(decoded_value, decoder_context.GetValue(id));
   TagTransformOperationView tag_xform_view(
       UnwrapDefaultOperationResult(decoded_value));
-  EXPECT_EQ(tag_xform_view.GetRuleName(), std::get<1>(GetParam()));
+  EXPECT_EQ(tag_xform_view.GetRuleName(), rule_name);
   // Dealing with the internal structure of the sub-value is the job of
   // another test, so we don't inspect it here. What does matter is ensuring
   // that the value vec that we got corresponds to the ID vec that we took

--- a/src/frontends/sql/decoder_context.cc
+++ b/src/frontends/sql/decoder_context.cc
@@ -51,7 +51,7 @@ const ir::Operation &DecoderContext::MakeTagTransformOperation(
   // Look up each precondition ID to get the corresponding Value.
   std::vector<ir::Value> precondition_values_vec =
       utils::MapIter<uint64_t, ir::Value>(
-          std::move(preconditions), [&](uint64_t id) { return GetValue(id); });
+          preconditions, [&](uint64_t id) { return GetValue(id); });
 
   // Each precondition is given the same input name prefix plus an incrementing
   // number in the same order as in the original ID list.

--- a/src/frontends/sql/decoder_context.cc
+++ b/src/frontends/sql/decoder_context.cc
@@ -1,6 +1,6 @@
 #include "src/frontends/sql/decoder_context.h"
 
-#include "src/utils/map_iter.h"
+#include "src/common/utils/map_iter.h"
 
 namespace raksha::frontends::sql {
 
@@ -49,9 +49,8 @@ const ir::Operation &DecoderContext::MakeTagTransformOperation(
       {std::string(kTagTransformTransformedValueInputName), transformed_value});
 
   // Look up each precondition ID to get the corresponding Value.
-  std::vector<ir::Value> precondition_values_vec =
-      utils::MapIter<uint64_t, ir::Value>(
-          preconditions, [&](uint64_t id) { return GetValue(id); });
+  std::vector<ir::Value> precondition_values_vec = utils::MapIter<ir::Value>(
+      preconditions, [&](uint64_t id) { return GetValue(id); });
 
   // Each precondition is given the same input name prefix plus an incrementing
   // number in the same order as in the original ID list.

--- a/src/frontends/sql/decoder_context.cc
+++ b/src/frontends/sql/decoder_context.cc
@@ -1,7 +1,10 @@
 #include "src/frontends/sql/decoder_context.h"
 
+#include "src/utils/map_iter.h"
+
 namespace raksha::frontends::sql {
 
+using ir::NamedAttributeMap;
 using ir::NamedValueMap;
 using ir::Operation;
 using ir::Value;
@@ -31,6 +34,40 @@ const Operation &DecoderContext::MakeMergeOperation(
           "control_input_", std::move(control_inputs),
           MakeNamedValueMapFromVector("direct_input_", std::move(direct_inputs),
                                       {})));
+}
+
+const ir::Operation &DecoderContext::MakeTagTransformOperation(
+    ir::Value transformed_value, absl::string_view rule_name,
+    std::vector<uint64_t> preconditions) {
+  // We need to reserve one space for the transformed value plus one for each
+  // precondition.
+  NamedValueMap values_map;
+  values_map.reserve(preconditions.size() + 1);
+
+  // Insert the value to be transformed.
+  values_map.insert(
+      {std::string(kTagTransformTransformedValueInputName), transformed_value});
+
+  // Look up each precondition ID to get the corresponding Value.
+  std::vector<ir::Value> precondition_values_vec =
+      utils::MapIter<uint64_t, ir::Value>(
+          std::move(preconditions), [&](uint64_t id) { return GetValue(id); });
+
+  // Each precondition is given the same input name prefix plus an incrementing
+  // number in the same order as in the original ID list.
+  for (uint64_t i = 0; i < precondition_values_vec.size(); ++i) {
+    auto insert_result = values_map.insert(
+        {absl::StrCat(kTagTransformPreconditionInputPrefix, i),
+         precondition_values_vec.at(i)});
+    CHECK(insert_result.second)
+        << "Found duplicate entry for " << insert_result.first->first;
+  }
+
+  return top_level_block_builder_.AddOperation(
+      tag_transform_operator_,
+      NamedAttributeMap{{std::string(kTagTransformRuleAttributeName),
+                         ir::StringAttribute::Create(rule_name)}},
+      std::move(values_map));
 }
 
 }  // namespace raksha::frontends::sql

--- a/src/frontends/sql/testing/BUILD
+++ b/src/frontends/sql/testing/BUILD
@@ -63,6 +63,24 @@ cc_library(
 )
 
 cc_library(
+    name = "tag_transform_operation_view",
+    testonly = True,
+    hdrs = ["tag_transform_operation_view.h"],
+    visibility = ["//src/frontends/sql:__subpackages__"],
+    deps = [
+        ":operation_view_utils",
+        "//src/common/logging",
+        "//src/frontends/sql:decoder_context",
+        "//src/frontends/sql/testing:literal_operation_view",
+        "//src/frontends/sql/testing:merge_operation_view",
+        "//src/frontends/sql/testing:utils",
+        "//src/ir:module",
+        "//src/ir:operator",
+        "@absl//absl/strings",
+    ],
+)
+
+cc_library(
     name = "operation_view_utils",
     testonly = True,
     srcs = ["operation_view_utils.cc"],

--- a/src/frontends/sql/testing/BUILD
+++ b/src/frontends/sql/testing/BUILD
@@ -70,6 +70,7 @@ cc_library(
     deps = [
         ":operation_view_utils",
         "//src/common/logging",
+        "//src/common/utils:map_iter",
         "//src/frontends/sql:decoder_context",
         "//src/frontends/sql/testing:literal_operation_view",
         "//src/frontends/sql/testing:merge_operation_view",

--- a/src/frontends/sql/testing/tag_transform_operation_view.h
+++ b/src/frontends/sql/testing/tag_transform_operation_view.h
@@ -1,0 +1,68 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#ifndef SRC_FRONTENDS_SQL_TESTING_TAG_TRANSFORM_OPERATION_VIEW_H_
+#define SRC_FRONTENDS_SQL_TESTING_TAG_TRANSFORM_OPERATION_VIEW_H_
+
+#include "src/common/logging/logging.h"
+#include "src/frontends/sql/decoder_context.h"
+#include "src/ir/module.h"
+#include "src/ir/operator.h"
+
+namespace raksha::frontends::sql::testing {
+
+// Construct a view onto an `Operation` that happens to be a
+// `TagTransformOperation` that provides a richer interface to the
+// `TagTransformOperation`.
+class TagTransformOperationView {
+ public:
+  TagTransformOperationView(const ir::Operation &tag_transform_operation)
+      : tag_transform_operation_(&tag_transform_operation) {
+    CHECK(tag_transform_operation.op().name() ==
+          DecoderContext::kTagTransformOpName);
+    CHECK(tag_transform_operation.attributes().size() == 1);
+  }
+
+  ir::Value GetTransformedValue() const {
+    const ir::NamedValueMap &inputs = tag_transform_operation_->inputs();
+    auto find_result =
+        inputs.find(DecoderContext::kTagTransformTransformedValueInputName);
+    CHECK(find_result != inputs.end());
+    return find_result->second;
+  }
+
+  std::vector<ir::Value> GetPreconditions() const {
+    return GetVecWithPrefix(
+        tag_transform_operation_->inputs(),
+        DecoderContext::kTagTransformPreconditionInputPrefix);
+  }
+
+  std::string GetRuleName() const {
+    const ir::NamedAttributeMap &attributes =
+        tag_transform_operation_->attributes();
+    auto find_result =
+        attributes.find(DecoderContext::kTagTransformRuleAttributeName);
+    CHECK(find_result != attributes.end());
+    return find_result->second->ToString();
+  }
+
+ private:
+  const ir::Operation *tag_transform_operation_;
+};
+
+}  // namespace raksha::frontends::sql::testing
+
+#endif  // SRC_FRONTENDS_SQL_TESTING_TAG_TRANSFORM_OPERATION_VIEW_H_

--- a/src/frontends/sql/testing/tag_transform_operation_view.h
+++ b/src/frontends/sql/testing/tag_transform_operation_view.h
@@ -19,6 +19,7 @@
 
 #include "src/common/logging/logging.h"
 #include "src/frontends/sql/decoder_context.h"
+#include "src/frontends/sql/testing/operation_view_utils.h"
 #include "src/ir/module.h"
 #include "src/ir/operator.h"
 


### PR DESCRIPTION
The `TagTransform` proto indicates that some policy may perform a cast
upon the tag state. The details of that cast are considered a policy
aspect, and are not handled in this structure, which is considered
a dataflow graph aspect structure. Instead, the `TagTransform` carries
a policy name which can be used for linking to this rule in the dataflow
analysis.