### PR TITLE
Replace manual args with StructOpt

### DIFF
--- a/rust/tools/authorization-logic/README.md
+++ b/rust/tools/authorization-logic/README.md
@@ -77,11 +77,19 @@ claim, and the recipient uses the public key to check the signature.
 To compile a program called FILENAME stored in INPUT_DIR, run:
 
 ```
-cargo run FILENAME INPUT_DIR OUTPUT_DIR
+cargo run -- --in-dir INPUT_DIR --out-dir OUTPUT_DIR FILENAME
 ```
 
-which will result in a Souffle file called FILENAME.dl in OUTPUT_DIR. If Souffle
-is installed, it will be run on the generated code.
+which will result in a Souffle file called FILENAME.dl in OUTPUT_DIR. INPUT_DIR
+and OUTPUT_DIR are optional, and will use the current working directory if
+unspecified. If Souffle is installed, it will be run on the generated code.
+
+To see more details of how to compile a program, including other command-line
+options available, run:
+
+```
+cargo run -- --help
+```
 
 ### Language Guide
 

--- a/rust/tools/authorization-logic/src/compilation_top_level.rs
+++ b/rust/tools/authorization-logic/src/compilation_top_level.rs
@@ -46,17 +46,15 @@ pub fn source_file_to_ast_test_only(filename: &str, in_dir: &str) -> AstProgram 
     source_file_to_ast(filename, &resolved_in_dir)
 }
 
-pub fn compile(filename: &str, in_dir: &str, out_dir: &str,
-              decl_skip: &str) {
+pub fn compile(filename: &str, in_dir: &str, out_dir: &str, decl_skip: &Vec<String>){
     let resolved_in_dir = utils::get_resolved_path(&in_dir);
     let resolved_out_dir = utils::get_resolved_path(&out_dir);
     let prog = source_file_to_ast(filename, &resolved_in_dir);
     let prog_with_imports = import_assertions::handle_imports(&prog);
-    let decl_skip_vec = Some(decl_skip
-                             .split(',')
-                             .map(|s| s.to_string())
-                             .collect());
-    souffle_interface::ast_to_souffle_file(&prog_with_imports, filename,
-                                           &resolved_out_dir, &decl_skip_vec);
+    souffle_interface::ast_to_souffle_file(
+        &prog_with_imports,
+        filename,
+        out_dir,
+        &Some(decl_skip.to_vec()));
     export_assertions::export_assertions(&prog_with_imports);
 }

--- a/rust/tools/authorization-logic/src/compilation_top_level.rs
+++ b/rust/tools/authorization-logic/src/compilation_top_level.rs
@@ -54,7 +54,7 @@ pub fn compile(filename: &str, in_dir: &str, out_dir: &str, decl_skip: &Vec<Stri
     souffle_interface::ast_to_souffle_file(
         &prog_with_imports,
         filename,
-        out_dir,
+        &resolved_out_dir,
         &Some(decl_skip.to_vec()));
     export_assertions::export_assertions(&prog_with_imports);
 }

--- a/rust/tools/authorization-logic/src/lib.rs
+++ b/rust/tools/authorization-logic/src/lib.rs
@@ -34,16 +34,16 @@ pub extern "C" fn generate_datalog_facts_from_authorization_logic(
     c_filename:  *const c_char,
     c_in_dir: *const c_char,
     c_out_dir: *const c_char,
-    c_decl_skip_vec: *const c_char
+    c_decl_skip: *const c_char
 ) -> c_int {
   let result = std::panic::catch_unwind(|| {
     let filename = unsafe { CStr::from_ptr(c_filename) }.to_str().unwrap();
     let in_dir = unsafe { CStr::from_ptr(c_in_dir) }.to_str().unwrap();
     let out_dir = unsafe { CStr::from_ptr(c_out_dir) }.to_str().unwrap();
     let decl_skip_vec = unsafe {
-        CStr::from_ptr(c_decl_skip_vec)
-    }.to_str().unwrap();
-    compilation_top_level::compile(filename, in_dir, out_dir, decl_skip_vec);
+        CStr::from_ptr(c_decl_skip)
+    }.to_str().unwrap().split(',').map(|s| s.to_string()).collect();
+    compilation_top_level::compile(filename, in_dir, out_dir, &decl_skip_vec);
   });
   if result.is_err() {
     eprintln!("error: rust panicked");

--- a/rust/tools/authorization-logic/src/main.rs
+++ b/rust/tools/authorization-logic/src/main.rs
@@ -28,13 +28,44 @@ mod test;
 use std::env;
 use structopt::StructOpt;
 
+#[derive(StructOpt)]
+#[structopt(name = "auth-logic", about = "An authorization logic compiler.")]
+struct Opt {
+    /// The name of the auth logic program to compile
+    // First positional argument (should be passed as a raw value, not --filename=...)
+    #[structopt(required = true)]
+    filename: String,
+
+    /// Input directory where the auth logic program lives.
+    /// If unspecified, it will be the current working directory.
+    // Can be passed as -i or --in-dir
+    #[structopt(short, long, env("PWD"))]
+    in_dir: String,
+
+    /// Output directory, where the compiled datalog program will be saved.
+    /// If unspecified, it will be the current working directory.
+    // Can be passed as -o or --out-dir
+    #[structopt(short, long, env("PWD"))]
+    out_dir: String,
+
+    /// List of declarations to skip when generating Souffle code
+    // Can be passed as -s or --skip. Passed as a comma-separated list.
+    #[structopt(short = "s", long = "skip")]
+    decl_skip: Vec<String>,
+
+    /// Whether to skip running Souffle on the compiled datalog
+    // Can be passed only as --skip-souffle
+    #[structopt(long)]
+    skip_souffle: bool,
+}
+
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let filename = &args[1];
-    let in_dir = &args[2];
-    let out_dir = &args[3];
-    let decl_skip = if(args.len() > 4) { &args[4] } else { "" };
-    compilation_top_level::compile(filename, in_dir, out_dir, &decl_skip);
-    souffle::souffle_interface::run_souffle(&format!("{}/{}.dl", out_dir,
-                                                    filename), out_dir);
+    let opt = Opt::from_args();
+    compilation_top_level::compile(&opt.filename, &opt.in_dir, &opt.out_dir, &opt.decl_skip);
+    if (!opt.skip_souffle) {
+        souffle::souffle_interface::run_souffle(
+            &format!("{}/{}.dl", &opt.out_dir, &opt.filename),
+            &opt.out_dir,
+        );
+    };
 }

--- a/rust/tools/authorization-logic/src/souffle/souffle_interface.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_interface.rs
@@ -61,7 +61,7 @@ pub fn ast_to_souffle_file(prog: &AstProgram, filename: &str,
     let dlir_prog = LoweringToDatalogPass::lower(&universe_handled_prog);
     let souffle_code = souffle_emitter::emit_program(&dlir_prog, decl_skip);
     fs::write(&format!("{}/{}.dl", out_dir, filename), souffle_code)
-        .expect("failed to write output to file");
+        .expect("failed to write output to file")
 }
 
 /// The function this function calls the souffle command on a .dl file. CSVs

--- a/rust/tools/authorization-logic/src/test/test_claim_importing.rs
+++ b/rust/tools/authorization-logic/src/test/test_claim_importing.rs
@@ -26,7 +26,7 @@ mod test {
 
     fn query_test_with_imports(t: QueryTest) {
         utils::setup_directories_for_bazeltest(vec![t.input_dir], vec![t.output_dir]);     
-        compile(t.filename, t.input_dir, t.output_dir, "");
+        compile(t.filename, t.input_dir, t.output_dir, &Vec::new());
         run_souffle(
             &utils::get_resolved_path(&format!("test_outputs/{}.dl", t.filename)),
             &utils::get_resolved_path("test_outputs")
@@ -46,7 +46,8 @@ mod test {
         );
 
         // This code generates exported statements from test_inputs/exporting.
-        compile("importing_export_half", "test_inputs", "test_outputs", "");
+        compile("importing_export_half", "test_inputs", "test_outputs",
+                &Vec::new());
 
         // This code imports statements into test_inputs/importing
         // and checks queries for expected results.

--- a/rust/tools/authorization-logic/src/test/test_decl_skip.rs
+++ b/rust/tools/authorization-logic/src/test/test_decl_skip.rs
@@ -17,7 +17,7 @@ mod test {
     pub fn test_decl_skip() {
         utils::setup_directories_for_bazeltest(vec!["test_inputs"], vec!["test_outputs"]);
         // Compile with declarations
-        compile("testDeclSkip", "test_inputs", "test_outputs", "");
+        compile("testDeclSkip", "test_inputs", "test_outputs", &Vec::new());
         let contents1 = file_line_list(&utils::get_resolved_path("test_outputs/testDeclSkip.dl"));
         assert!(contents1.contains(&".decl grounded_dummy(dummy_param: DummyType)".to_string()));
         assert!(contents1.contains(
@@ -26,7 +26,7 @@ mod test {
         
         // Compile with some declarations removed
         compile("testDeclSkip", "test_inputs","test_outputs",
-            "grounded_dummy,says_isRelevantFor");
+             &vec!["grounded_dummy".to_string(),"says_isRelevantFor".to_string()]);
         let contents2 = file_line_list(&utils::get_resolved_path("test_outputs/testDeclSkip.dl"));
         assert!(!contents2.contains(&".decl grounded_dummy(dummy_param: DummyType)".to_string()));
         assert!(!contents2.contains(

--- a/rust/tools/authorization-logic/src/test/test_dots_and_quotes.rs
+++ b/rust/tools/authorization-logic/src/test/test_dots_and_quotes.rs
@@ -25,7 +25,7 @@ mod test {
     #[test]
     fn test_dots_in_ids() {
         utils::setup_directories_for_bazeltest(vec!["test_inputs"], vec!["test_outputs"]);
-        compile("dotsInNames", "test_inputs", "test_outputs", "");
+        compile("dotsInNames", "test_inputs", "test_outputs", &Vec::new());
         // this test is just about not having syntax errors
         assert!(true);
     }
@@ -41,7 +41,7 @@ mod test {
             &utils::get_resolved_path("test_keys/p1q_pub.json"),
             &utils::get_resolved_path("test_keys/p1q_priv.json")
         );
-        compile("quotesInExports", "test_inputs", "test_outputs", "");
+        compile("quotesInExports", "test_inputs", "test_outputs", &Vec::new());
 
         // this test is just about not having syntax errors
         assert!(true);

--- a/rust/tools/authorization-logic/src/test/test_export_signatures.rs
+++ b/rust/tools/authorization-logic/src/test/test_export_signatures.rs
@@ -32,7 +32,7 @@ mod test {
             &utils::get_resolved_path("test_keys/principal1_priv.json"),
         );
 
-        compile("exporting", "test_inputs", "test_outputs", "");
+        compile("exporting", "test_inputs", "test_outputs", &Vec::new());
 
         let deser_claim = deserialize_from_file(
             &utils::get_resolved_path("test_outputs/prin1_statement1.obj")).unwrap();

--- a/rust/tools/authorization-logic/src/test/test_num_string_names.rs
+++ b/rust/tools/authorization-logic/src/test/test_num_string_names.rs
@@ -9,7 +9,7 @@ mod test {
         utils::setup_directories_for_bazeltest(vec!["test_inputs"], vec!["test_outputs"]);
         // The point of this test is to just see if it parses or if an
         // error is thrown.
-        compile("numStringsInNames", "test_inputs", "test_outputs", "");
+        compile("numStringsInNames", "test_inputs", "test_outputs", &Vec::new());
     }
 
 }

--- a/rust/tools/authorization-logic/src/test/test_type_error.rs
+++ b/rust/tools/authorization-logic/src/test/test_type_error.rs
@@ -21,6 +21,6 @@ mod test {
     #[test]
     #[should_panic]
     fn test_type_error() {
-        compile("type_error", "test_inputs", "test_outputs", "");
+        compile("type_error", "test_inputs", "test_outputs", &Vec::new());
     }
 }


### PR DESCRIPTION
This is a re-implementation of
[Replace manual args with StructOpt #245 ](https://github.com/google-research/raksha/pull/245)
after splitting the `cargo raze` step into a separate part

Co-authored-by: bMacSwigg <mcswiggen@google.com>