### PR TITLE
Create `Attribute`s on `Operation`s in Datalog.

### DIFF
--- a/build_defs/raksha.bzl
+++ b/build_defs/raksha.bzl
@@ -95,6 +95,7 @@ def policy_check(name, dataflow_graph, auth_logic, expect_failure = False, visib
         name = datalog_cxx_source_target_name,
         src = datalog_source_target,
         included_dl_scripts = [
+            "//src/analysis/souffle:attributes.dl",
             "//src/analysis/souffle:authorization_logic.dl",
             "//src/analysis/souffle:check_predicate.dl",
             "//src/analysis/souffle:dataflow_graph.dl",

--- a/build_defs/test_helpers.bzl
+++ b/build_defs/test_helpers.bzl
@@ -66,6 +66,7 @@ def extracted_datalog_string_test(
         src = name + "_dl",
         for_test = True,
         included_dl_scripts = [
+            "//src/analysis/souffle:attributes.dl",
             "//src/analysis/souffle:authorization_logic.dl",
             "//src/analysis/souffle:check_predicate.dl",
             "//src/analysis/souffle:dataflow_graph.dl",

--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -34,6 +34,7 @@ gen_souffle_cxx_code(
     name = "taint_cxx",
     src = "taint.dl",
     included_dl_scripts = [
+        "attributes.dl",
         "authorization_logic.dl",
         "check_predicate.dl",
         "dataflow_graph.dl",
@@ -47,6 +48,7 @@ gen_souffle_cxx_code(
     src = "taint.dl",
     for_test = True,
     included_dl_scripts = [
+        "attributes.dl",
         "authorization_logic.dl",
         "check_predicate.dl",
         "dataflow_graph.dl",
@@ -67,6 +69,7 @@ souffle_cc_binary(
 )
 
 exports_files([
+    "attributes.dl",
     "authorization_logic.dl",
     "check_predicate.dl",
     "dataflow_graph.dl",

--- a/src/analysis/souffle/attributes.dl
+++ b/src/analysis/souffle/attributes.dl
@@ -16,8 +16,6 @@
 #ifndef SRC_ANALYSIS_SOUFFLE_ATTRIBUTES_DL_
 #define SRC_ANALYSIS_SOUFFLE_ATTRIBUTES_DL_
 
-.type AttributeKind <: symbol
-.type AttributePayloadId <: number
 .type AttributeName <: symbol
 .type AttributePayload =
   StringAttributePayload { str: symbol } | NumberAttributePayload { num: number }

--- a/src/analysis/souffle/attributes.dl
+++ b/src/analysis/souffle/attributes.dl
@@ -1,0 +1,31 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#ifndef SRC_ANALYSIS_SOUFFLE_ATTRIBUTES_DL_
+#define SRC_ANALYSIS_SOUFFLE_ATTRIBUTES_DL_
+
+.type AttributeKind <: symbol
+.type AttributePayloadId <: number
+.type AttributeName <: symbol
+.type AttributePayload =
+  StringAttributePayload { str: symbol } | NumberAttributePayload { num: number }
+
+.type Attribute = [attr_name: AttributeName, attr_payload: AttributePayload]
+
+.type AttributeList = [attr: Attribute, next: AttributeList]
+
+.decl isAttributePayload(payload: AttributePayload)
+
+#endif // SRC_ANALYSIS_SOUFFLE_ATTRIBUTES_DL_

--- a/src/analysis/souffle/operations.dl
+++ b/src/analysis/souffle/operations.dl
@@ -16,6 +16,7 @@
 #ifndef SRC_ANALYSIS_SOUFFLE_OPERATIONS_DL_
 #define SRC_ANALYSIS_SOUFFLE_OPERATIONS_DL_
 
+#include "src/analysis/souffle/attributes.dl"
 #include "src/analysis/souffle/dataflow_graph.dl"
 
 // The symbol representing the operator. For operations commonly represented by
@@ -27,28 +28,42 @@
 // regardless of arity. Useful for rules that apply to any operation.
 .type OperandList = [ operand: AccessPath, next: OperandList ]
 
-// Operations of any arity go in this relation.
-.decl operation(owner: Principal, operator: Operator, result: AccessPath, operandList: OperandList)
+// An Operation.
+.type Operation = [owner: Principal, operator: Operator, result: AccessPath,
+                   operandList: OperandList, attributes: AttributeList]
+
+// Operation universe.
+.decl isOperation(operation: Operation)
 
 // BINARY_OPERATION is a convenience macro for the very-common-case of binary operations.
-#define BINARY_OPERATION(owner, operator, result, input1, input2) \
-operation(owner, operator, result, [input1, [input2, nil]])
+#define BINARY_OPERATION(owner, operator, result, attrs, input1, input2) \
+isOperation([owner, operator, result, [input1, [input2, nil]], attrs])
 
 // Explode the operand lists so that we can extract the heads of each sublist
 // to get a mapping from operations to their operands.
-.decl operationToPartialOperandLists(
-  owner: Principal, operator: Operator, result: AccessPath, partialList: OperandList)
+.decl operationToPartialOperandLists(operation: Operation, partialList: OperandList)
 
-operationToPartialOperandLists(owner, operator, result, operandList) :-
-  operation(owner, operator, result, operandList).
-operationToPartialOperandLists(owner, operator, result, tail) :-
-  operationToPartialOperandLists(owner, operator, result, [_, tail]).
+operationToPartialOperandLists([owner, op, result, operandList, attrs], operandList) :-
+  isOperation([owner, op, result, operandList, attrs]).
+operationToPartialOperandLists(operation, tail) :-
+  operationToPartialOperandLists(operation, [_, tail]).
 
 // Map full operations to operands.
-.decl operationToOperands(
-  owner: Principal, operator: Operator, result: AccessPath, operand: AccessPath)
+.decl operationToOperands(operation:Operation, operand: AccessPath)
 
-operationToOperands(owner, operator, result, operand) :-
-  operationToPartialOperandLists(owner, operator, result, [operand, _]).
+operationToOperands(operation, operand) :-
+  isOperation(operation), operationToPartialOperandLists(operation, [operand, _]).
+
+// A helper relation that produces all partial attribute lists of an
+// `Operation`.
+.decl operationToPartialAttributeLists(operation: Operation, attributes: AttributeList)
+operationToPartialAttributeLists([owner, op, result, operandList, attrs], attrs) :-
+  isOperation([owner, op, result, operandList, attrs]).
+operationToPartialAttributeLists(op, tail) :- operationToPartialAttributeLists(op, [_, tail]).
+
+// A mapping from an `Operation` to each individual `Attribute` on that
+// `Operation`.
+.decl operationToAttribute(op: Operation, attr: Attribute)
+operationToAttribute(op, attr) :- operationToPartialAttributeLists(op, [attr, _]).
 
 #endif // SRC_ANALYSIS_SOUFFLE_OPERATIONS_DL_

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -85,14 +85,14 @@
 //-----------------------------------------------------------------------------
 
 // Draw an edge from any operation's operand to its result.
-resolvedEdge(owner, src, tgt) :- operationToOperands(owner, _, tgt, src).
+resolvedEdge(owner, src, tgt) :- operationToOperands([owner, _, tgt, _, _], src).
 
 // For all operations other than `=`, draw an edge from the special
 // "ArbitraryComputation" `AccessPath` to the result. This prevents default
 // propagation of `IntegrityTag`s through the operation.
 isAccessPath("ArbitraryComputation").
 resolvedEdge(owner, "ArbitraryComputation", tgt) :-
-  operationToOperands(owner, operand, tgt, _), operand != "=".
+  isOperation([owner, operator, tgt, _, _]), operator != "=".
 
 ownsAccessPath(principal, path) :- says_ownsAccessPath(principal, principal, path).
 ownsAccessPath(principal, tgt) :-

--- a/src/analysis/souffle/tests/arcs_fact_tests/BUILD
+++ b/src/analysis/souffle/tests/arcs_fact_tests/BUILD
@@ -31,6 +31,7 @@ exports_files([
     included_dl_scripts = [
         ":integrity_tag_prop_helper.dl",
         ":confidentiality_tag_prop_helper.dl",
+        "//src/analysis/souffle:attributes.dl",
         "//src/analysis/souffle:authorization_logic.dl",
         "//src/analysis/souffle:check_predicate.dl",
         "//src/analysis/souffle:dataflow_graph.dl",
@@ -76,6 +77,7 @@ exports_files([
     for_test = True,
     included_dl_scripts = [
         ":integrity_tag_prop_helper.dl",
+        "//src/analysis/souffle:attributes.dl",
         "//src/analysis/souffle:authorization_logic.dl",
         "//src/analysis/souffle:check_predicate.dl",
         "//src/analysis/souffle:dataflow_graph.dl",

--- a/src/analysis/souffle/tests/arcs_fact_tests/arbitrary_operation_tag_propagation.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/arbitrary_operation_tag_propagation.dl
@@ -10,7 +10,7 @@ isAccessPath("in3").
 isAccessPath("in4").
 
 // Create some arbitrary operation that the analysis has never seen before.
-operation("owner", "???", "result", ["in1", ["in2", ["in3", ["in4", nil]]]]).
+isOperation(["owner", "???", "result", ["in1", ["in2", ["in3", ["in4", nil]]]], nil]).
 
 // Because we have a general rule that causes inputs to operations to influence
 // the output, show that we can put a tag on any input and have it show up on

--- a/src/analysis/souffle/tests/arcs_fact_tests/find_operations_by_attributes.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/find_operations_by_attributes.dl
@@ -1,0 +1,87 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#include "src/analysis/souffle/taint.dl"
+#include "src/analysis/souffle/fact_test_helper.dl"
+
+isAccessPath("result1").
+isAccessPath("result2").
+isAccessPath("result3").
+isAccessPath("result4").
+isAccessPath("result5").
+isAccessPath("result6").
+isAccessPath("result7").
+
+#define PAYLOAD1 $StringAttributePayload("payload1")
+#define PAYLOAD2 $NumberAttributePayload(2)
+#define PAYLOAD3 $StringAttributePayload("payload3")
+#define PAYLOAD4 $NumberAttributePayload(4)
+
+isAttributePayload(PAYLOAD1).
+isAttributePayload(PAYLOAD2).
+isAttributePayload(PAYLOAD3).
+isAttributePayload(PAYLOAD4).
+
+// Create some operations with some attributes.
+isOperation(["owner", "op1", "result1", nil, nil]).
+isOperation(["owner", "op1", "result2", nil, [["attr1", PAYLOAD1], nil]]).
+isOperation(["owner", "op1", "result3", nil, [["attr2", PAYLOAD2], nil]]).
+
+isOperation(["owner", "op1", "result4", nil, [["attr1", PAYLOAD1], [["attr2", PAYLOAD2], nil]]]).
+
+isOperation(["owner", "op1", "result5", nil, [["attr1", PAYLOAD3], nil]]).
+isOperation(["owner", "op1", "result6", nil, [["attr2", PAYLOAD4], nil]]).
+isOperation(["owner", "op1", "result7", nil, [["attr3", PAYLOAD2], nil]]).
+
+.decl resultToAttrNameAndPayload(
+  result: AccessPath, attrName: AttributeName, payload: AttributePayload)
+
+resultToAttrNameAndPayload(result, attrName, payload) :-
+  operationToAttribute([_, _, result, _, _], [attrName, payload]).
+
+.decl expectedResultToAttrNameAndPayload(
+  result: AccessPath, attrName: AttributeName, payload: AttributePayload)
+
+expectedResultToAttrNameAndPayload("result2", "attr1", PAYLOAD1).
+expectedResultToAttrNameAndPayload("result3", "attr2", PAYLOAD2).
+expectedResultToAttrNameAndPayload("result4", "attr1", PAYLOAD1).
+expectedResultToAttrNameAndPayload("result4", "attr2", PAYLOAD2).
+expectedResultToAttrNameAndPayload("result5", "attr1", PAYLOAD3).
+expectedResultToAttrNameAndPayload("result6", "attr2", PAYLOAD4).
+expectedResultToAttrNameAndPayload("result7", "attr3", PAYLOAD2).
+
+.decl entryInExpectedAndNotInActual(
+  result: AccessPath, attrName: AttributeName, payload: AttributePayload)
+entryInExpectedAndNotInActual(result, attrName, payload) :-
+  expectedResultToAttrNameAndPayload(result, attrName, payload),
+  !resultToAttrNameAndPayload(result, attrName, payload).
+
+.decl entryInActualAndNotInExpected(
+  result: AccessPath, attrName: AttributeName, payload: AttributePayload)
+entryInActualAndNotInExpected(result, attrName, payload) :-
+  resultToAttrNameAndPayload(result, attrName, payload),
+  !expectedResultToAttrNameAndPayload(result, attrName, payload).
+
+TEST_CASE("expected_and_actual_same_size_and_not_zero") :-
+  expectedSize = count : { resultToAttrNameAndPayload(_, _, _) },
+  actualSize = count : { expectedResultToAttrNameAndPayload(_, _, _) },
+  expectedSize = actualSize,
+  expectedSize != 0.
+
+TEST_CASE("expected_not_in_actual_empty") :-
+  count : { entryInExpectedAndNotInActual(_, _, _) } = 0.
+TEST_CASE("actual_not_in_expected_empty") :-
+  count : { entryInActualAndNotInExpected(_, _, _) } = 0.

--- a/src/analysis/souffle/tests/arcs_fact_tests/timestamp_redaction.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/timestamp_redaction.dl
@@ -13,8 +13,8 @@ isAccessPath("div_result").
 isAccessPath("c").
 isAccessPath("final_result").
 
-BINARY_OPERATION("owner", "/", "div_result", "a", "b").
-BINARY_OPERATION("owner", "*", "final_result", "div_result", "c").
+BINARY_OPERATION("owner", "/", "div_result", nil, "a", "b").
+BINARY_OPERATION("owner", "*", "final_result", nil, "div_result", "c").
 
 // "a" contains a millsecond-granularity timestamp.
 hasAppliedIntegrityTag("a", "owner", "TimestampMilliseconds").
@@ -32,14 +32,14 @@ hasAppliedIntegrityTag("c", "owner", "Constant_1000").
 // "TimestampMilliseconds" confidentiality tag.
 mustHaveIntegrityTag(result, owner, "TimestampSeconds"),
 removeTag(result, owner, "SensitiveTimestamp") :-
-  BINARY_OPERATION(owner, "/", result, op1, op2),
+  BINARY_OPERATION(owner, "/", result, nil, op1, op2),
   mustHaveIntegrityTag(op1, owner, "TimestampMilliseconds"),
   mustHaveIntegrityTag(op2, owner, "Constant_1000").
 
 // An AST matching policy that says that "TimestampSeconds", multiplied by
 // 1000, is now a "TimestampMillisecondsRedacted".
 mustHaveIntegrityTag(result, owner, "TimestampMillisecondsRedacted") :-
-  BINARY_OPERATION(owner, "*", result, op1, op2),
+  BINARY_OPERATION(owner, "*", result, nil,op1, op2),
   mustHaveIntegrityTag(op1, owner, "TimestampSeconds"),
   mustHaveIntegrityTag(op2, owner, "Constant_1000").
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/timestamp_redaction.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/timestamp_redaction.dl
@@ -39,7 +39,7 @@ removeTag(result, owner, "SensitiveTimestamp") :-
 // An AST matching policy that says that "TimestampSeconds", multiplied by
 // 1000, is now a "TimestampMillisecondsRedacted".
 mustHaveIntegrityTag(result, owner, "TimestampMillisecondsRedacted") :-
-  BINARY_OPERATION(owner, "*", result, nil,op1, op2),
+  BINARY_OPERATION(owner, "*", result, nil, op1, op2),
   mustHaveIntegrityTag(op1, owner, "TimestampSeconds"),
   mustHaveIntegrityTag(op2, owner, "Constant_1000").
 


### PR DESCRIPTION
In the Raksha IR, we have a concept of an `Attribute`, which is
essentially statically known data attached to some IR structure.
`Attribute`s seem like they could be very useful in Datalog, especially
for finding IR structures relevant to some analysis.

This PR adds `Attribute`s to `Operation`s and adds a unit test showing
us gathering `Operation`s by `Attribute`.