### PR TITLE
Introduce an sql::OpTraits class to associate information with SqlOps

### DIFF
--- a/src/frontends/sql/ops/BUILD
+++ b/src/frontends/sql/ops/BUILD
@@ -1,0 +1,37 @@
+#-------------------------------------------------------------------------------
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------------------------
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "op_traits",
+    hdrs = ["op_traits.h"],
+    deps = [
+        "@absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "op_traits_test",
+    srcs = ["op_traits_test.cc"],
+    deps = [
+        ":op_traits",
+        "//src/common/testing:gtest",
+    ],
+)

--- a/src/frontends/sql/ops/op_traits.h
+++ b/src/frontends/sql/ops/op_traits.h
@@ -28,7 +28,7 @@ struct OpTraits {};
   template <>                                           \
   struct OpTraits<CLASS> {                              \
     static constexpr absl::string_view kName = OP_NAME; \
-  };
+  }
 
 DEFINE_OP_TRAITS(LiteralOp, "sql.literal");
 

--- a/src/frontends/sql/ops/op_traits.h
+++ b/src/frontends/sql/ops/op_traits.h
@@ -1,0 +1,39 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+#ifndef SRC_FRONTENDS_SQL_OPS_OP_TRAITS_H_
+#define SRC_FRONTENDS_SQL_OPS_OP_TRAITS_H_
+
+#include "absl/strings/string_view.h"
+
+namespace raksha::frontends::sql {
+
+template <typename Op>
+struct OpTraits {};
+
+#define DEFINE_OP_TRAITS(CLASS, OP_NAME)                \
+  class CLASS;                                          \
+  template <>                                           \
+  struct OpTraits<CLASS> {                              \
+    static constexpr absl::string_view kName = OP_NAME; \
+  };
+
+DEFINE_OP_TRAITS(LiteralOp, "sql.literal");
+
+#undef DEFINE_OP_TRAITS
+
+}  // namespace raksha::frontends::sql
+
+#endif  // SRC_FRONTENDS_SQL_OPS_OP_TRAITS_H_

--- a/src/frontends/sql/ops/op_traits_test.cc
+++ b/src/frontends/sql/ops/op_traits_test.cc
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+#include "src/frontends/sql/ops/op_traits.h"
+
+#include "src/common/testing/gtest.h"
+
+namespace raksha::frontends::sql {
+
+TEST(OpTraitsTest, NameReturnsCorrectValue) {
+  EXPECT_EQ(OpTraits<LiteralOp>::kName, "sql.literal");
+}
+
+}  // namespace raksha::frontends::sql


### PR DESCRIPTION
`OpTraits<T>` will be needed to support classes that provide `operator`-specific view of the underlying `ir::Operation`.