### PR TITLE
Make GetOperator and GetStorage return pointers.

### DIFF
--- a/src/frontends/sql/decoder_context.h
+++ b/src/frontends/sql/decoder_context.h
@@ -84,7 +84,7 @@ class DecoderContext {
   // like registering storages in advance, for the mature implementation.
   const ir::Storage &GetOrCreateStorage(absl::string_view storage_name) {
     return (ir_context_.IsRegisteredStorage(storage_name))
-               ? ir_context_.GetStorage(storage_name)
+               ? *CHECK_NOTNULL(ir_context_.GetStorage(storage_name))
                : ir_context_.RegisterStorage(std::make_unique<ir::Storage>(
                      storage_name,
                      ir_context_.type_factory().MakePrimitiveType()));

--- a/src/frontends/sql/ops/sql_op.h
+++ b/src/frontends/sql/ops/sql_op.h
@@ -30,11 +30,8 @@ class SqlOp : public ir::Operation {
  public:
   // Returns the operator associated with this type `T`.
   template <typename T>
-  static const ir::Operator& GetOperator(const ir::IRContext& context) {
-    absl::string_view operator_name = OpTraits<T>::kName;
-    CHECK(context.IsRegisteredOperator(operator_name))
-        << "SqlOp '" << operator_name << "' is not registered.";
-    return context.GetOperator(operator_name);
+  static const ir::Operator* GetOperator(const ir::IRContext& context) {
+    return context.GetOperator(OpTraits<T>::kName);
   }
 
   // Registers the operator for this type.

--- a/src/frontends/sql/ops/sql_op_test.cc
+++ b/src/frontends/sql/ops/sql_op_test.cc
@@ -32,8 +32,9 @@ TEST(SqlOpTest, RegisterOperatorRegistersInContext) {
   SqlOp::RegisterOperator<LiteralOp>(context);
   EXPECT_TRUE(context.IsRegisteredOperator(literal_op_name));
 
-  const ir::Operator& op = context.GetOperator(literal_op_name);
-  EXPECT_EQ(op.name(), literal_op_name);
+  const ir::Operator* op = context.GetOperator(literal_op_name);
+  ASSERT_NE(op, nullptr);
+  EXPECT_EQ(op->name(), literal_op_name);
 }
 
 TEST(SqlOpTest, GetOperatorReturnsRegisteredOperatorInContext) {
@@ -44,17 +45,14 @@ TEST(SqlOpTest, GetOperatorReturnsRegisteredOperatorInContext) {
   context.RegisterOperator(std::make_unique<ir::Operator>(literal_op_name));
   EXPECT_TRUE(context.IsRegisteredOperator(literal_op_name));
 
-  const ir::Operator& op = SqlOp::GetOperator<LiteralOp>(context);
-  EXPECT_EQ(op.name(), literal_op_name);
+  const ir::Operator* op = SqlOp::GetOperator<LiteralOp>(context);
+  ASSERT_NE(op, nullptr);
+  EXPECT_EQ(op->name(), literal_op_name);
 }
 
-TEST(SqlOpDeathTest, GettingUnregisteredOperatorFails) {
-  EXPECT_DEATH(
-      {
-        ir::IRContext context;
-        SqlOp::GetOperator<LiteralOp>(context);
-      },
-      "SqlOp 'sql.literal' is not registered.");
+TEST(SqlOpTest, GettingUnregisteredReturnsNullptr) {
+  ir::IRContext context;
+  EXPECT_EQ(SqlOp::GetOperator<LiteralOp>(context), nullptr);
 }
 
 }  // namespace

--- a/src/ir/block_builder_test.cc
+++ b/src/ir/block_builder_test.cc
@@ -123,15 +123,20 @@ TEST_F(BlockBuilderDeathTest, AddResultsVerifiesOutputIsDeclared) {
 
 TEST_F(BlockBuilderTest, AddOperationUpdatesOperationList) {
   BlockBuilder builder;
+  const Operator& core_plus = *CHECK_NOTNULL(context_.GetOperator("core.plus"));
+  const Operator& core_minus =
+      *CHECK_NOTNULL(context_.GetOperator("core.plus"));
+  const Operator& core_merge =
+      *CHECK_NOTNULL(context_.GetOperator("core.merge"));
   // std::vector<const Operator*> operations;
-  const Operation* plus_op = std::addressof(
-      builder.AddOperation(context_.GetOperator("core.plus"), {}, {}));
-  const Operation* minus_op = std::addressof(
-      builder.AddOperation(context_.GetOperator("core.minus"), {}, {}));
-  const Operation* merge_op = std::addressof(
-      builder.AddOperation(context_.GetOperator("core.merge"), {}, {}));
-  const Operation* merge_op_with_module = std::addressof(builder.AddOperation(
-      context_.GetOperator("core.merge"), {}, {}, std::make_unique<Module>()));
+  const Operation* plus_op =
+      std::addressof(builder.AddOperation(core_plus, {}, {}));
+  const Operation* minus_op =
+      std::addressof(builder.AddOperation(core_minus, {}, {}));
+  const Operation* merge_op =
+      std::addressof(builder.AddOperation(core_merge, {}, {}));
+  const Operation* merge_op_with_module = std::addressof(
+      builder.AddOperation(core_merge, {}, {}, std::make_unique<Module>()));
 
   auto block = builder.build();
   EXPECT_THAT(block->operations(),
@@ -162,8 +167,9 @@ TEST_F(BlockBuilderTest, AddImplementationMakingMultipleUpdates) {
     builder.AddInput("entity_input", MakeTestEntityType("InputTensor"));
     builder.AddOutput("primitive_output", MakePrimitiveType());
     builder.AddOutput("entity_output", MakeTestEntityType("OutputTensor"));
-    const Operation& op =
-        builder.AddOperation(context_.GetOperator("core.plus"), {}, {});
+    const Operator& core_plus =
+        *CHECK_NOTNULL(context_.GetOperator("core.plus"));
+    const Operation& op = builder.AddOperation(core_plus, {}, {});
     builder.AddResult("primitive_output",
                       Value(value::OperationResult(op, "primitive_value")));
     builder.AddResult("entity_output",

--- a/src/ir/ir_context_test.cc
+++ b/src/ir/ir_context_test.cc
@@ -32,9 +32,10 @@ TEST(IRContextTest, GetOperatorReturnsRegisteredOperator) {
   IRContext context;
   const Operator& registered_op =
       context.RegisterOperator(std::make_unique<Operator>("core.choose"));
-  const Operator& op = context.GetOperator("core.choose");
-  EXPECT_EQ(op.name(), "core.choose");
-  EXPECT_EQ(&op, &registered_op);
+  const Operator* op = context.GetOperator("core.choose");
+  ASSERT_NE(op, nullptr);
+  EXPECT_EQ(op->name(), "core.choose");
+  EXPECT_EQ(op, std::addressof(registered_op));
 }
 
 TEST(IRContextTest, IsRegisteredOperatorReturnsCorrectValues) {
@@ -44,10 +45,9 @@ TEST(IRContextTest, IsRegisteredOperatorReturnsCorrectValues) {
   EXPECT_FALSE(context.IsRegisteredOperator("core.nose"));
 }
 
-TEST(IRContextDeathTest, GetOperatorFailsForUnregisteredOperator) {
+TEST(IRContextTest, GetOperatorReturnsNullptrForUnregisteredOperator) {
   IRContext context;
-  EXPECT_DEATH({ context.GetOperator("core.choose"); },
-               "Looking up an unregistered operator 'core.choose'.");
+  EXPECT_EQ(context.GetOperator("core.choose"), nullptr);
 }
 
 TEST(IRContextDeathTest, DuplicateOperatorRegistrationCausesFailure) {
@@ -60,52 +60,52 @@ TEST(IRContextDeathTest, DuplicateOperatorRegistrationCausesFailure) {
 
 TEST(IRContextTest, RegisterStorageReturnsRegisteredStorage) {
   IRContext context;
-  types::TypeFactory &type_factory = context.type_factory();
+  types::TypeFactory& type_factory = context.type_factory();
 
-  const Storage& store =
-      context.RegisterStorage(std::make_unique<Storage>(
-          "store1", type_factory.MakePrimitiveType()));
+  const Storage& store = context.RegisterStorage(
+      std::make_unique<Storage>("store1", type_factory.MakePrimitiveType()));
   EXPECT_EQ(store.name(), "store1");
   EXPECT_EQ(store.type().type_base().kind(), types::TypeBase::Kind::kPrimitive);
 }
 
 TEST(IRContextTest, GetStorageReturnsRegisteredStorage) {
   IRContext context;
-  types::TypeFactory &type_factory = context.type_factory();
+  types::TypeFactory& type_factory = context.type_factory();
 
-  const Storage& registered_storage =
-      context.RegisterStorage(std::make_unique<Storage>(
-          "storage1", type_factory.MakePrimitiveType()));
-  const Storage& storage = context.GetStorage("storage1");
-  EXPECT_EQ(storage.name(), "storage1");
-  EXPECT_EQ(storage.type().type_base().kind(),
+  const Storage& registered_storage = context.RegisterStorage(
+      std::make_unique<Storage>("storage1", type_factory.MakePrimitiveType()));
+  const Storage* storage = context.GetStorage("storage1");
+  ASSERT_NE(storage, nullptr);
+  EXPECT_EQ(storage->name(), "storage1");
+  EXPECT_EQ(storage->type().type_base().kind(),
             types::TypeBase::Kind::kPrimitive);
-  EXPECT_EQ(&storage, &registered_storage);
+  EXPECT_EQ(storage, std::addressof(registered_storage));
 }
 
 TEST(IRContextTest, IsRegisteredStorageReturnsCorrectValues) {
   IRContext context;
-  types::TypeFactory &type_factory = context.type_factory();
-  context.RegisterStorage(std::make_unique<Storage>(
-      "storage1", type_factory.MakePrimitiveType()));
+  types::TypeFactory& type_factory = context.type_factory();
+  context.RegisterStorage(
+      std::make_unique<Storage>("storage1", type_factory.MakePrimitiveType()));
   EXPECT_TRUE(context.IsRegisteredStorage("storage1"));
   EXPECT_FALSE(context.IsRegisteredStorage("storage2"));
 }
 
-TEST(IRContextDeathTest, GetStorageFailsForUnregisteredStorage) {
+TEST(IRContextDeathTest, GetStorageReturnsNullptrForUnregisteredStorage) {
   IRContext context;
-  EXPECT_DEATH({ context.GetStorage("not_a_store"); },
-               "Looking up an unregistered storage 'not_a_store'.");
+  EXPECT_EQ(context.GetStorage("not_a_store"), nullptr);
 }
 
 TEST(IRContextDeathTest, DuplicateStorageRegistrationCausesFailure) {
   IRContext context;
-  types::TypeFactory &type_factory = context.type_factory();
+  types::TypeFactory& type_factory = context.type_factory();
   context.RegisterStorage(
       std::make_unique<Storage>("store", type_factory.MakePrimitiveType()));
   EXPECT_DEATH(
-      { context.RegisterStorage(std::make_unique<Storage>(
-          "store", type_factory.MakePrimitiveType())); },
+      {
+        context.RegisterStorage(std::make_unique<Storage>(
+            "store", type_factory.MakePrimitiveType()));
+      },
       "Cannot register duplicate storage with name 'store'.");
 }
 


### PR DESCRIPTION
This forces us to think whether an operator (resp. storage) is registered when a `GetOperator` (resp. `GetStorage`) method is called. Further, the expectation that the value should be non-null can be encoded with the `CHECK_NOTNULL` macro.