### PR TITLE
Allow the ID on SQL IR expressions to be optional.

### DIFF
--- a/src/frontends/sql/decode.cc
+++ b/src/frontends/sql/decode.cc
@@ -126,10 +126,12 @@ static Value GetExprValue(const Expression &expr,
 Value DecodeExpression(const Expression &expr,
                        DecoderContext &decoder_context) {
   uint64_t id = expr.id();
-  CHECK(id != 0) << "Required field id was not present in Expression.";
   // TODO(#413): Figure out what to do with the optional name field.
   Value value = GetExprValue(expr, decoder_context);
-  decoder_context.RegisterValue(id, value);
+  // If the id is present, add it to the map from ids to values.
+  if (id != 0) {
+    decoder_context.RegisterValue(id, value);
+  }
   return value;
 }
 

--- a/src/frontends/sql/decode_expr_death_test.cc
+++ b/src/frontends/sql/decode_expr_death_test.cc
@@ -92,11 +92,6 @@ TEST_P(DecodeExprDeathTest, DecodeExprDeathTest) {
 }
 
 const TextprotoDeathMessagePair kTextprotoDeathMessagePairs[] = {
-    {.textproto =
-         R"(id: 0 source_table_column: { column_path: "table1.col" } )",
-     .death_message = "Required field id was not present in Expression."},
-    {.textproto = R"(source_table_column: { column_path: "table1.col" } )",
-     .death_message = "Required field id was not present in Expression."},
     {.textproto = R"(id: 1)",
      .death_message = "Required field expr_variant not set."},
     {.textproto = R"(id: 1 merge_operation: { })",

--- a/src/frontends/sql/decode_literal_test.cc
+++ b/src/frontends/sql/decode_literal_test.cc
@@ -47,7 +47,7 @@ using ::testing::UnorderedElementsAreArray;
 using ::testing::Values;
 using ::testing::ValuesIn;
 
-constexpr uint64_t kSampleIds[] = {1, 5, 1000};
+constexpr uint64_t kSampleIds[] = {0, 1, 5, 1000};
 
 constexpr std::optional<absl::string_view> kSampleExprNames[] = {
     {}, {"name1"}, {"another_name"}};
@@ -76,7 +76,14 @@ TEST_P(DecodeLiteralExprTest, DecodeLiteralExprTest) {
   const Operation &operation = testing::UnwrapDefaultOperationResult(result);
   EXPECT_EQ(operation.parent(), &top_block);
   EXPECT_THAT(operation.impl_module(), IsNull());
-  EXPECT_EQ(result, decoder_context_.GetValue(id));
+
+  if (id == 0) {
+    EXPECT_DEATH(
+        { decoder_context_.GetValue(id); },
+        "Attempt to get a value with id 0, which is not a legal value id.");
+  } else {
+    EXPECT_EQ(result, decoder_context_.GetValue(id));
+  }
 
   const LiteralOp *literal_op = SqlOp::GetIf<LiteralOp>(operation);
   ASSERT_NE(literal_op, nullptr);

--- a/src/frontends/sql/decoder_context.h
+++ b/src/frontends/sql/decoder_context.h
@@ -67,6 +67,8 @@ class DecoderContext {
   // Get a copy of the value associated with a particular id. Assumes that the
   // ID is present; it will error if it is not.
   ir::Value GetValue(uint64_t id) const {
+    CHECK(id != 0)
+      << "Attempt to get a value with id 0, which is not a legal value id.";
     // We could use `at`, which would be more concise and would also fail if the
     // id is not present in the map, but it will not provide a nice error
     // message. Use `find` and `CHECK` to get a better error message.

--- a/src/frontends/sql/sql_ir.proto
+++ b/src/frontends/sql/sql_ir.proto
@@ -71,10 +71,9 @@ message TagTransform {
 };
 
 message Expression {
-  // A unique ID assigned to each Expression. Allows TagTransform nodes to
-  // point at Expression, as the need to be able to check the tag state of
-  // particular MergeOperations to decide whether to perform the
-  // transform.
+  // An ID which, if present, uniquely identifies this `Expression`. This is
+  // used by `TagTransform`s to point at `Expression`s which must have a
+  // particular tag state for that `TagTransform` to execute.
   uint64 id = 1;
   // We may optionally associate expressions with names to help with building
   // `AccessPaths`. This name may include column and/or table aliases provided


### PR DESCRIPTION
Previously, we required every expression to be given a unique ID. This
was so `TagTransform`s would always be able to point uniquely to their
precondition expressions. However, during the integration with the SQL
verifier, I realized that assigning unique IDs to every expression was
harder than just assigning unique IDs to those expressions that need to
be pointed to by `TagTransform`s.

This PR makes Raksha handle expressions with a missing id (or,
equivalently in Protobuf, explicitly given the id 0) by just not adding
them to the map from IDs to expressions. Otherwise, they are
deserialized exactly the same as expressions with an ID.