### PR TITLE
Change the `TagTransform` preconditions to be a map from name to ID.

### DIFF
--- a/src/frontends/sql/decode.cc
+++ b/src/frontends/sql/decode.cc
@@ -93,7 +93,7 @@ static Value DecodeTagTransform(const TagTransform &tag_transform,
       tag_transform.tag_preconditions().end());
   return WrapOperationResultValue(decoder_context.MakeTagTransformOperation(
       std::move(transformed_value), transform_rule_name,
-      std::move(preconditions)));
+      preconditions));
 }
 
 // A helper function to decode the specific subclass of the Expression.

--- a/src/frontends/sql/decode.cc
+++ b/src/frontends/sql/decode.cc
@@ -88,14 +88,12 @@ static Value DecodeTagTransform(const TagTransform &tag_transform,
   std::string transform_rule_name = tag_transform.transform_rule_name();
   CHECK(!transform_rule_name.empty())
       << "Required TagTransform field transform_rule_name not present.";
-  std::vector<uint64_t> precondition_ids;
-  precondition_ids.reserve(tag_transform.tag_precondition_ids_size());
-  for (uint64_t id : tag_transform.tag_precondition_ids()) {
-    precondition_ids.push_back(id);
-  }
+  absl::flat_hash_map<std::string, uint64_t> preconditions(
+      tag_transform.tag_preconditions().begin(),
+      tag_transform.tag_preconditions().end());
   return WrapOperationResultValue(decoder_context.MakeTagTransformOperation(
       std::move(transformed_value), transform_rule_name,
-      std::move(precondition_ids)));
+      std::move(preconditions)));
 }
 
 // A helper function to decode the specific subclass of the Expression.

--- a/src/frontends/sql/decode_tag_transform_operation_test.cc
+++ b/src/frontends/sql/decode_tag_transform_operation_test.cc
@@ -96,7 +96,7 @@ tag_transform : {
       &expr));
   Value decoded_value = DecodeExpression(expr, decoder_context);
 
-  std::vector<std::pair<std::string, Value>> expected_name_to_value_vec =
+  auto expected_name_to_value_vec =
       MapIter<std::pair<std::string, Value>>(
           precondition_name_to_id, [&decoder_context](auto name_id_pair) {
             return std::make_pair(

--- a/src/frontends/sql/decoder_context.cc
+++ b/src/frontends/sql/decoder_context.cc
@@ -38,7 +38,7 @@ const Operation &DecoderContext::MakeMergeOperation(
 
 const ir::Operation &DecoderContext::MakeTagTransformOperation(
     ir::Value transformed_value, absl::string_view rule_name,
-    absl::flat_hash_map<std::string, uint64_t> preconditions) {
+    const absl::flat_hash_map<std::string, uint64_t> &preconditions) {
   // We need to reserve one space for the transformed value plus one for each
   // precondition.
   NamedValueMap values_map;
@@ -50,7 +50,7 @@ const ir::Operation &DecoderContext::MakeTagTransformOperation(
 
   // Each precondition is given the same input name prefix plus an incrementing
   // number in the same order as in the original ID list.
-  for (auto &[name, id] : preconditions) {
+  for (const auto &[name, id] : preconditions) {
     auto insert_result = values_map.insert(
         {absl::StrCat(kTagTransformPreconditionInputPrefix, name),
          GetValue(id)});

--- a/src/frontends/sql/decoder_context.cc
+++ b/src/frontends/sql/decoder_context.cc
@@ -38,7 +38,7 @@ const Operation &DecoderContext::MakeMergeOperation(
 
 const ir::Operation &DecoderContext::MakeTagTransformOperation(
     ir::Value transformed_value, absl::string_view rule_name,
-    std::vector<uint64_t> preconditions) {
+    absl::flat_hash_map<std::string, uint64_t> preconditions) {
   // We need to reserve one space for the transformed value plus one for each
   // precondition.
   NamedValueMap values_map;
@@ -48,16 +48,12 @@ const ir::Operation &DecoderContext::MakeTagTransformOperation(
   values_map.insert(
       {std::string(kTagTransformTransformedValueInputName), transformed_value});
 
-  // Look up each precondition ID to get the corresponding Value.
-  std::vector<ir::Value> precondition_values_vec = utils::MapIter<ir::Value>(
-      preconditions, [&](uint64_t id) { return GetValue(id); });
-
   // Each precondition is given the same input name prefix plus an incrementing
   // number in the same order as in the original ID list.
-  for (uint64_t i = 0; i < precondition_values_vec.size(); ++i) {
+  for (auto &[name, id] : preconditions) {
     auto insert_result = values_map.insert(
-        {absl::StrCat(kTagTransformPreconditionInputPrefix, i),
-         precondition_values_vec.at(i)});
+        {absl::StrCat(kTagTransformPreconditionInputPrefix, name),
+         GetValue(id)});
     CHECK(insert_result.second)
         << "Found duplicate entry for " << insert_result.first->first;
   }

--- a/src/frontends/sql/decoder_context.h
+++ b/src/frontends/sql/decoder_context.h
@@ -106,7 +106,7 @@ class DecoderContext {
 
   const ir::Operation &MakeTagTransformOperation(
       ir::Value transformed_value, absl::string_view rule_name,
-      absl::flat_hash_map<std::string, uint64_t> tag_preconditions);
+      const absl::flat_hash_map<std::string, uint64_t> &tag_preconditions);
 
   // Finish building the top level block and
   const ir::Block &BuildTopLevelBlock() {

--- a/src/frontends/sql/decoder_context.h
+++ b/src/frontends/sql/decoder_context.h
@@ -68,7 +68,7 @@ class DecoderContext {
   // ID is present; it will error if it is not.
   ir::Value GetValue(uint64_t id) const {
     CHECK(id != 0)
-      << "Attempt to get a value with id 0, which is not a legal value id.";
+        << "Attempt to get a value with id 0, which is not a legal value id.";
     // We could use `at`, which would be more concise and would also fail if the
     // id is not present in the map, but it will not provide a nice error
     // message. Use `find` and `CHECK` to get a better error message.
@@ -106,7 +106,7 @@ class DecoderContext {
 
   const ir::Operation &MakeTagTransformOperation(
       ir::Value transformed_value, absl::string_view rule_name,
-      std::vector<uint64_t> preconditions);
+      absl::flat_hash_map<std::string, uint64_t> tag_preconditions);
 
   // Finish building the top level block and
   const ir::Block &BuildTopLevelBlock() {

--- a/src/frontends/sql/sql_ir.proto
+++ b/src/frontends/sql/sql_ir.proto
@@ -63,11 +63,11 @@ message TagTransform {
   // The name of the rule that will govern whether this `TagTransform` is
   // active and what it does when active.
   string transform_rule_name = 2;
-  // A list of unique IDs of the expressions to be considered as
-  // preconditions of the `TagTransform`. The order matters here: the order
-  // number will be used to match these tag IDs with the requirements imposed
-  // by some rule.
-  repeated uint64 tag_precondition_ids = 3;
+  // A map from precondition names to unique IDs of expressions considered to
+  // be preconditions of the `TagTransform`. The names will also be used by
+  // the policy to match these tag IDs with the requirements imposed by some
+  // rule.
+  map<string, uint64> tag_preconditions = 3;
 };
 
 message Expression {

--- a/src/frontends/sql/testing/operation_view_utils.cc
+++ b/src/frontends/sql/testing/operation_view_utils.cc
@@ -49,7 +49,7 @@ std::vector<ir::Value> GetVecWithPrefix(const ir::NamedValueMap &map,
   return result;
 }
 
-absl::flat_hash_map<std::string, ir::Value> GetMapWithPrefix(
+absl::flat_hash_map<std::string, ir::Value> GetMapEntriesWithPrefix(
     const ir::NamedValueMap &map, absl::string_view prefix) {
   absl::flat_hash_map<std::string, ir::Value> result;
   for (auto &[key, value] : map) {

--- a/src/frontends/sql/testing/operation_view_utils.cc
+++ b/src/frontends/sql/testing/operation_view_utils.cc
@@ -5,25 +5,32 @@
 
 namespace raksha::frontends::sql::testing {
 
-std::optional<uint64_t> ExtractIdxAfterPrefix(
+std::optional<absl::string_view> ExtractSubstrAfterPrefix(
     absl::string_view str, absl::string_view prefix) {
   if (!absl::StartsWith(str, prefix)) return std::nullopt;
+  return str.substr(prefix.size());
+}
+
+std::optional<uint64_t> ExtractIdxAfterPrefix(absl::string_view str,
+                                              absl::string_view prefix) {
+  std::optional<absl::string_view> suffix =
+      ExtractSubstrAfterPrefix(str, prefix);
+  if (!suffix) return std::nullopt;
   uint64_t result = 0;
-  std::string index_str(str.substr(prefix.size()));
+  std::string index_str(*suffix);
   if (!absl::SimpleAtoi(index_str, &result)) return std::nullopt;
   return result;
 }
 
 std::vector<ir::Value> GetVecWithPrefix(const ir::NamedValueMap &map,
-                                               absl::string_view prefix) {
+                                        absl::string_view prefix) {
   uint64_t inferred_vec_length = 0;
 
   // The numbering of inputs should be dense. Thus, we can find the largest
   // index with the given prefix, add one to it, and consider that the
   // length of the vector.
   for (auto &[key, value] : map) {
-    if (std::optional<uint64_t> opt_idx =
-            ExtractIdxAfterPrefix(key, prefix)) {
+    if (std::optional<uint64_t> opt_idx = ExtractIdxAfterPrefix(key, prefix)) {
       inferred_vec_length = std::max(inferred_vec_length, *opt_idx + 1);
     }
   }
@@ -38,6 +45,18 @@ std::vector<ir::Value> GetVecWithPrefix(const ir::NamedValueMap &map,
     CHECK(find_result != map.end())
         << "Found a hole in the key numbering: " << find_result->first;
     result.push_back(find_result->second);
+  }
+  return result;
+}
+
+absl::flat_hash_map<std::string, ir::Value> GetMapWithPrefix(
+    const ir::NamedValueMap &map, absl::string_view prefix) {
+  absl::flat_hash_map<std::string, ir::Value> result;
+  for (auto &[key, value] : map) {
+    if (std::optional<absl::string_view> opt_key =
+            ExtractSubstrAfterPrefix(key, prefix)) {
+      result.insert({std::string(*opt_key), value});
+    }
   }
   return result;
 }

--- a/src/frontends/sql/testing/operation_view_utils.h
+++ b/src/frontends/sql/testing/operation_view_utils.h
@@ -31,7 +31,7 @@ std::vector<ir::Value> GetVecWithPrefix(const ir::NamedValueMap &map,
 // subset of elements that start with some prefix `prefix` and end with a key
 // that should be associated with that value in the resulting map. It
 // composes that map and returns it.
-absl::flat_hash_map<std::string, ir::Value> GetMapWithPrefix(
+absl::flat_hash_map<std::string, ir::Value> GetMapEntriesWithPrefix(
     const ir::NamedValueMap &map, absl::string_view prefix);
 
 }  // namespace raksha::frontends::sql::testing

--- a/src/frontends/sql/testing/operation_view_utils.h
+++ b/src/frontends/sql/testing/operation_view_utils.h
@@ -14,8 +14,8 @@ namespace raksha::frontends::sql::testing {
 // This function skips past the prefix, interprets the number as an unsigned
 // int, and returns it. If any of those assumptions are not met, it returns
 // std::nullopt instead.
-std::optional<uint64_t> ExtractIdxAfterPrefix(
-      absl::string_view str, absl::string_view prefix);
+std::optional<uint64_t> ExtractIdxAfterPrefix(absl::string_view str,
+                                              absl::string_view prefix);
 
 // This method assumes that, within the given `NamedValueMap`, there are a
 // subset of elements that start with some prefix `prefix` and end with a
@@ -25,7 +25,15 @@ std::optional<uint64_t> ExtractIdxAfterPrefix(
 // trailing numeric suffixes being translated into positions in the resulting
 // vector. If the density assumption is not met, this method asserts.
 std::vector<ir::Value> GetVecWithPrefix(const ir::NamedValueMap &map,
-                                               absl::string_view prefix);
+                                        absl::string_view prefix);
+
+// This method assumes that, within the given `NamedValueMap`, there are a
+// subset of elements that start with some prefix `prefix` and end with a key
+// that should be associated with that value in the resulting map. It
+// composes that map and returns it.
+absl::flat_hash_map<std::string, ir::Value> GetMapWithPrefix(
+    const ir::NamedValueMap &map, absl::string_view prefix);
+
 }  // namespace raksha::frontends::sql::testing
 
 #endif  // SRC_FRONTENDS_SQL_TESTING_OPERATION_VIEW_UTILS_H_

--- a/src/frontends/sql/testing/tag_transform_operation_view.h
+++ b/src/frontends/sql/testing/tag_transform_operation_view.h
@@ -47,7 +47,7 @@ class TagTransformOperationView {
   }
 
   absl::flat_hash_map<std::string, ir::Value> GetPreconditions() const {
-    return GetMapWithPrefix(
+    return GetMapEntriesWithPrefix(
         tag_transform_operation_->inputs(),
         DecoderContext::kTagTransformPreconditionInputPrefix);
   }

--- a/src/frontends/sql/testing/tag_transform_operation_view.h
+++ b/src/frontends/sql/testing/tag_transform_operation_view.h
@@ -46,8 +46,8 @@ class TagTransformOperationView {
     return find_result->second;
   }
 
-  std::vector<ir::Value> GetPreconditions() const {
-    return GetVecWithPrefix(
+  absl::flat_hash_map<std::string, ir::Value> GetPreconditions() const {
+    return GetMapWithPrefix(
         tag_transform_operation_->inputs(),
         DecoderContext::kTagTransformPreconditionInputPrefix);
   }


### PR DESCRIPTION
While integrating with the SQL verifier that we wish to integrate with
Raksha, I noticed that it associates each of the preconditions on its
tag transforms with a name in an unordered map. This is an awkward fit
with the way we had originally written the `TagTransform`, which would
associate its preconditions with the preconditions of a policy rule by
an order imposed on the preconditions. For one, it would require me to
repeatedly sort the preconditions on the verifier side when building the
protos, repeatedly performing an O(n * log(n)) operation. For another,
the names would preserve debugging information in Datalog and probably
produce better results if a mechansim like Souffle's `explain` were
used.

For these reasons, this PR modifies the `TagTransform` preconditions to
be a map from precondition name to the ID of the AST node that will be
associated with that precondition. These names are used as the names of
the `input`s to the `TagTransform`, and can be matched by the policy
datalog produced from the SQL verifier's rules.