### PR TITLE
Make inputs to an operation to be simply an ordered list.

### DIFF
--- a/src/frontends/sql/BUILD
+++ b/src/frontends/sql/BUILD
@@ -56,6 +56,7 @@ cc_library(
         "//src/ir:value",
         "//src/ir/attributes:attribute",
         "//src/ir/attributes:int_attribute",
+        "//src/ir/attributes:string_attribute",
         "@absl//absl/container:flat_hash_map",
     ],
 )

--- a/src/frontends/sql/BUILD
+++ b/src/frontends/sql/BUILD
@@ -54,7 +54,8 @@ cc_library(
         "//src/ir:block_builder",
         "//src/ir:ir_context",
         "//src/ir:value",
-        "//src/ir/attributes:string_attribute",
+        "//src/ir/attributes:attribute",
+        "//src/ir/attributes:int_attribute",
         "@absl//absl/container:flat_hash_map",
     ],
 )

--- a/src/frontends/sql/decoder_context.cc
+++ b/src/frontends/sql/decoder_context.cc
@@ -33,8 +33,6 @@ const ir::Operation &DecoderContext::MakeTagTransformOperation(
   // We need to reserve one space for the transformed value plus one for each
   // precondition.
   ir::ValueList inputs;
-  // Not adding +1 to avoid potential overflow.
-  inputs.reserve(preconditions.size());
 
   // Insert the value to be transformed.
   inputs.push_back(transformed_value);

--- a/src/frontends/sql/decoder_context.cc
+++ b/src/frontends/sql/decoder_context.cc
@@ -23,8 +23,8 @@ const Operation &DecoderContext::MakeMergeOperation(
                                   static_cast<int64_t>(control_start_index))}});
   // Combine the direct and control inputs.
   absl::c_move(control_inputs, std::back_inserter(direct_inputs));
-  return top_level_block_builder_.AddOperation(merge_operator_, attributes,
-                                               std::move(direct_inputs));
+  return top_level_block_builder_.AddOperation(
+      merge_operator_, std::move(attributes), std::move(direct_inputs));
 }
 
 const ir::Operation &DecoderContext::MakeTagTransformOperation(

--- a/src/frontends/sql/decoder_context.h
+++ b/src/frontends/sql/decoder_context.h
@@ -33,10 +33,8 @@ namespace raksha::frontends::sql {
 class DecoderContext {
  public:
   static constexpr absl::string_view kSqlMergeOpName = "sql.merge";
-  static constexpr absl::string_view kMergeOpDirectInputPrefix =
-      "direct_input_";
-  static constexpr absl::string_view kMergeOpControlInputPrefix =
-      "control_input_";
+  static constexpr absl::string_view kMergeOpControlStartIndex =
+      "control_start_index";
   static constexpr absl::string_view kTagTransformOpName = "sql.tag_transform";
   static constexpr absl::string_view kTagTransformTransformedValueInputName =
       "transformed_value";

--- a/src/frontends/sql/ops/literal_op.cc
+++ b/src/frontends/sql/ops/literal_op.cc
@@ -34,7 +34,7 @@ std::unique_ptr<LiteralOp> LiteralOp::Create(const ir::Block* parent_block,
       ir::NamedAttributeMap(
           {{std::string(kLiteralStringAttrName),
             ir::Attribute::Create<ir::StringAttribute>(literal)}}),
-      ir::NamedValueMap({}),
+      ir::ValueList({}),
       /*impl_module=*/nullptr);
 }
 

--- a/src/frontends/sql/ops/sql_op_test.cc
+++ b/src/frontends/sql/ops/sql_op_test.cc
@@ -89,10 +89,10 @@ class SqlOpGetIfTest : public testing::Test {
     SqlOp::RegisterOperator<AnotherTestOp>(context_);
     test_operation_ = std::make_unique<ir::Operation>(
         nullptr, *CHECK_NOTNULL(SqlOp::GetOperator<TestOp>(context_)),
-        ir::NamedAttributeMap({}), ir::NamedValueMap({}));
+        ir::NamedAttributeMap({}), ir::ValueList({}));
     another_test_operation_ = std::make_unique<ir::Operation>(
         nullptr, *CHECK_NOTNULL(SqlOp::GetOperator<AnotherTestOp>(context_)),
-        ir::NamedAttributeMap({}), ir::NamedValueMap({}));
+        ir::NamedAttributeMap({}), ir::ValueList({}));
   }
 
  protected:

--- a/src/frontends/sql/testing/BUILD
+++ b/src/frontends/sql/testing/BUILD
@@ -30,6 +30,7 @@ cc_library(
         "//src/frontends/sql:decoder_context",
         "//src/ir:module",
         "//src/ir:operator",
+        "//src/ir/attributes:int_attribute",
         "@absl//absl/strings",
     ],
 )
@@ -61,6 +62,7 @@ cc_library(
         "//src/frontends/sql/testing:utils",
         "//src/ir:module",
         "//src/ir:operator",
+        "//src/ir/attributes:int_attribute",
         "//src/ir/attributes:string_attribute",
         "@absl//absl/strings",
     ],

--- a/src/frontends/sql/testing/merge_operation_view.h
+++ b/src/frontends/sql/testing/merge_operation_view.h
@@ -35,6 +35,12 @@ class MergeOperationView {
     CHECK(merge_operation.op().name() == DecoderContext::kSqlMergeOpName);
     CHECK(merge_operation.attributes().count(
               DecoderContext::kMergeOpControlStartIndex) > 0);
+    auto index = merge_operation.attributes()
+                     .at(DecoderContext::kMergeOpControlStartIndex)
+                     .GetIf<ir::Int64Attribute>();
+    CHECK(index != nullptr);
+    CHECK(static_cast<size_t>(index->value()) <=
+          merge_operation.inputs().size());
   }
 
   std::vector<ir::Value> GetDirectInputs() const {

--- a/src/ir/block_builder.h
+++ b/src/ir/block_builder.h
@@ -49,8 +49,7 @@ class BlockBuilder {
 
   // Adds an operation to the block and returns the operation.
   const Operation& AddOperation(const Operator& op,
-                                NamedAttributeMap attributes,
-                                NamedValueMap inputs,
+                                NamedAttributeMap attributes, ValueList inputs,
                                 std::unique_ptr<Module> impl_module = nullptr) {
     block_->operations_.push_back(
         std::make_unique<Operation>(block_.get(), op, std::move(attributes),

--- a/src/ir/block_builder_test.cc
+++ b/src/ir/block_builder_test.cc
@@ -203,7 +203,7 @@ class TestOperation : public Operation {
     return std::make_unique<Operation>(
         op_name == "core.merge" ? nullptr : parent_block,
         *CHECK_NOTNULL(context.GetOperator(op_name)), NamedAttributeMap({}),
-        NamedValueMap({}));
+        ValueList({}));
   }
 };
 

--- a/src/ir/ir_printer.h
+++ b/src/ir/ir_printer.h
@@ -82,9 +82,10 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
         operation.attributes(),
         [](const Attribute& attr) { return attr.ToString(); });
 
-    std::string inputs_string = PrintNamedMapInNameOrder(
-        operation.inputs(),
-        [&](const Value& val) { return val.ToString(ssa_names_); });
+    std::string inputs_string = absl::StrJoin(
+        operation.inputs(), ", ", [this](std::string* out, const Value& value) {
+          absl::StrAppend(out, value.ToString(ssa_names_));
+        });
 
     out_ << Indent()
          << absl::StreamFormat(kOperationFormat, this_ssa_name,

--- a/src/ir/ir_printer_test.cc
+++ b/src/ir/ir_printer_test.cc
@@ -109,16 +109,16 @@ TEST_P(IRPrinterTest, PrettyPrintsOperationWithProperIndentation) {
 )");
 }
 
-TEST_P(IRPrinterTest, PrettyPrintAttributesAndArgsInSortedOrder) {
+TEST_P(IRPrinterTest, PrettyPrintAttributesInSortedOrder) {
   Operation operation(
       nullptr, minus_op(),
       {{"access", Attribute::Create<StringAttribute>("private")},
        {"name", Attribute::Create<StringAttribute>("addition")}},
-      {{"const", Value(value::Any())}, {"arg", Value(value::Any())}});
+      {Value(value::Any()), Value(value::Any())});
 
-  EXPECT_EQ(ToString(operation),
-            "%0 = core.minus [access: private, name: addition](arg: <<ANY>>, "
-            "const: <<ANY>>)\n");
+  EXPECT_EQ(
+      ToString(operation),
+      "%0 = core.minus [access: private, name: addition](<<ANY>>, <<ANY>>)\n");
 }
 
 }  // namespace

--- a/src/ir/module.h
+++ b/src/ir/module.h
@@ -35,7 +35,7 @@ class Block;
 class Operation {
  public:
   Operation(const Block* parent, const Operator& op,
-            NamedAttributeMap attributes, NamedValueMap inputs,
+            NamedAttributeMap attributes, ValueList inputs,
             std::unique_ptr<Module> impl_module = nullptr)
       : parent_(parent),
         op_(std::addressof(op)),
@@ -51,7 +51,7 @@ class Operation {
 
   const Operator& op() const { return *op_; }
   const Block* parent() const { return parent_; }
-  const NamedValueMap& inputs() const { return inputs_; }
+  const ValueList& inputs() const { return inputs_; }
   const NamedAttributeMap& attributes() const { return attributes_; }
   const Module* impl_module() const { return impl_module_.get(); }
 
@@ -70,7 +70,7 @@ class Operation {
   // The attributes of the operation.
   NamedAttributeMap attributes_;
   // The inputs of the operation.
-  NamedValueMap inputs_;
+  ValueList inputs_;
   // If the operation can be broken down into other operations, it is
   // specified in the optional module. If `module_` is nullptr, then this is a
   // basic operator like `+`, `-`, etc., which cannot be broken down further.

--- a/src/ir/operation_test.cc
+++ b/src/ir/operation_test.cc
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //----------------------------------------------------------------------------
+#include <memory>
+
 #include "absl/container/flat_hash_set.h"
 #include "src/common/testing/gtest.h"
 #include "src/ir/attributes/int_attribute.h"
@@ -28,7 +30,7 @@ struct OperationTestData {
   Block* block{};
   const Operator* op{};
   NamedAttributeMap attributes{};
-  NamedValueMap values{};
+  ValueList values{};
   // The expected string representation.
   absl::string_view string_rep;
 };
@@ -95,17 +97,17 @@ INSTANTIATE_TEST_SUITE_P(
         OperationTestData({nullptr,
                            &OperationTest::minus_op,
                            {{"const", Attribute::Create<Int64Attribute>(10)}},
-                           {{"arg", Value(value::Any())}},
-                           "%0 = core.minus [const: 10](arg: <<ANY>>)\n"}),
+                           {Value(value::Any())},
+
+                           "%0 = core.minus [const: 10](<<ANY>>)\n"}),
         OperationTestData(
             {&OperationTest::first_block_,
              &OperationTest::minus_op,
              {{"const", Attribute::Create<Int64Attribute>(10)}},
-             {{"a", Value(value::BlockArgument(OperationTest::first_block_,
-                                               "arg0"))},
-              {"b", Value(value::BlockArgument(OperationTest::first_block_,
-                                               "arg1"))}},
-             "%0 = core.minus [const: 10](a: %0.arg0, b: %0.arg1)\n"})));
+             {Value(value::BlockArgument(OperationTest::first_block_, "arg0")),
+              Value(value::BlockArgument(OperationTest::first_block_, "arg1"))},
+             "%0 = core.minus [const: "
+             "10](%0.arg0, %0.arg1)\n"})));
 
 }  // namespace
 }  // namespace raksha::ir

--- a/src/ir/operation_test.cc
+++ b/src/ir/operation_test.cc
@@ -98,7 +98,6 @@ INSTANTIATE_TEST_SUITE_P(
                            &OperationTest::minus_op,
                            {{"const", Attribute::Create<Int64Attribute>(10)}},
                            {Value(value::Any())},
-
                            "%0 = core.minus [const: 10](<<ANY>>)\n"}),
         OperationTestData(
             {&OperationTest::first_block_,
@@ -106,8 +105,7 @@ INSTANTIATE_TEST_SUITE_P(
              {{"const", Attribute::Create<Int64Attribute>(10)}},
              {Value(value::BlockArgument(OperationTest::first_block_, "arg0")),
               Value(value::BlockArgument(OperationTest::first_block_, "arg1"))},
-             "%0 = core.minus [const: "
-             "10](%0.arg0, %0.arg1)\n"})));
+             "%0 = core.minus [const: 10](%0.arg0, %0.arg1)\n"})));
 
 }  // namespace
 }  // namespace raksha::ir


### PR DESCRIPTION
Having a named list is quite cumbersome to deal with. If needed, we can attach names to the arguments using an alternate mechanism. e.g., the definition of operator could have a list of names and types.