### PR TITLE
Make each particle name have its own index space within a recipe.

### DIFF
--- a/src/analysis/souffle/examples/multimic/multimic.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic.authlogic
@@ -4,20 +4,20 @@
 .decl ownsTag(principal : Principal, tag : Tag)
 
 "UserA" says {
-  ownsAccessPath("UserA", "DoASRUserAAndUserB.UserATainter#3.audioIn").
-  ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.UserATainter#3.audioIn").
+  ownsAccessPath("UserA", "DoASRUserAAndUserB.UserATainter.audioIn").
+  ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.UserATainter.audioIn").
 }
 
 "UserB" says {
-  ownsAccessPath("UserB", "DoASRUserAAndUserB.UserBTainter#4.audioIn").
-  ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.UserBTainter#4.audioIn").
+  ownsAccessPath("UserB", "DoASRUserAAndUserB.UserBTainter.audioIn").
+  ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.UserBTainter.audioIn").
 }
 
 // UserC is a very privacy sensitive user. They do not trust anyone to perform
 // ASR on their voice data.
 "UserC" says {
   // TODO(#220): we should claim ownership at the level of handles rather recipe access paths.
-  ownsAccessPath("UserC", "DoASRUserAAndUserBAndUserC.UserCTainter#5.audio").
+  ownsAccessPath("UserC", "DoASRUserAAndUserBAndUserC.UserCTainter.audio").
   // We want to use canSay hasTag but cannot due to issue #195.
   "UserCTainter" canSay hasTag(pathX, "UserC", "asrDisallowed") :- isAccessPath(pathX).
   // TODO(#195) remove this ownership claim.

--- a/src/analysis/souffle/examples/multimic/multimic_no_userc_tag.authlogic
+++ b/src/analysis/souffle/examples/multimic/multimic_no_userc_tag.authlogic
@@ -2,11 +2,11 @@
 
 // TODO(#220): we should claim ownership at the level of handles rather recipe access paths.
 "UserA" says {
-  ownsAccessPath("UserA", "DoASRUserAAndUserB.UserATainter#3.audioIn").
-  ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.UserATainter#3.audioIn").
+  ownsAccessPath("UserA", "DoASRUserAAndUserB.UserATainter.audioIn").
+  ownsAccessPath("UserA", "DoASRUserAAndUserBAndUserC.UserATainter.audioIn").
 }
 
 "UserB" says {
-  ownsAccessPath("UserB", "DoASRUserAAndUserB.UserBTainter#4.audioIn").
-  ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.UserBTainter#4.audioIn").
+  ownsAccessPath("UserB", "DoASRUserAAndUserB.UserBTainter.audioIn").
+  ownsAccessPath("UserB", "DoASRUserAAndUserBAndUserC.UserBTainter.audioIn").
 }

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted.authlogic
@@ -5,6 +5,6 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
 //TODO(#220): This should be at the level of handles which correspond to stores,
 // where ownership makes more sense.
-"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
+"EndUser" says ownsAccessPath("EndUser", "R.P1.foo").
 "EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection").
 "EndUser" says "P2" canSay removeTag(accessPathX, "EndUser", "userSelection").

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted_by_non_owner.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_granted_by_non_owner.authlogic
@@ -1,6 +1,6 @@
 .decl ownsAccessPath(principal : Principal, path : AccessPath)
 .decl removeTag(path : AccessPath, principal : Principal, tag : Tag)
 .decl hasTag(path : AccessPath, principal : Principal, tag : Tag)
-"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
+"EndUser" says ownsAccessPath("EndUser", "R.P1.foo").
 "P1" says "P1" canSay hasTag(accessPathX,  "EndUser", "userSelection").
 "P1" says "P2" canSay removeTag(accessPathX, "EndUser", "userSelection").

--- a/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_not_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayDowngrades/ok_claim_propagates_downgrade_not_granted.authlogic
@@ -2,5 +2,5 @@
 .decl ownsAccessPath(principal : Principal, path : AccessPath)
 .decl hasTag(path : AccessPath, principal : Principal, tag : Tag)
 "EndUser" says ownsTag("EndUser", "userSelection").
-"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
+"EndUser" says ownsAccessPath("EndUser", "R.P1.foo").
 "EndUser" says "P1" canSay hasTag(accessPathX, "EndUser", "userSelection").

--- a/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_not_granted.authlogic
+++ b/src/analysis/souffle/examples/simple_canSayHasTag/ok_claim_propagates_delegation_not_granted.authlogic
@@ -3,4 +3,4 @@
 "EndUser" says ownsTag("EndUser", "userSelection").
 //TODO(#220): We should claim ownership at the level of handles that correspond
 // to stores where ownership makes more sense.
-"EndUser" says ownsAccessPath("EndUser", "R.P1#0.foo").
+"EndUser" says ownsAccessPath("EndUser", "R.P1.foo").

--- a/src/analysis/souffle/examples/simple_may_will/simple_may_will_fail.authlogic
+++ b/src/analysis/souffle/examples/simple_may_will/simple_may_will_fail.authlogic
@@ -22,7 +22,7 @@
 
 "EndUser" says {
     ownsTag("EndUser", "rawVideo").
-    ownsAccessPath("EndUser", "R.P1#0.foo").
+    ownsAccessPath("EndUser", "R.P1.foo").
     "P1" canSay hasTag(PathX, "EndUser", "rawVideo").
 }
 
@@ -34,5 +34,5 @@
 // ```
 // or similar, but the equivalent auth logic is:
 "P2" says {
-    will("doLocalComputation", "R.P2#1.foo").
+    will("doLocalComputation", "R.P2.foo").
 }

--- a/src/analysis/souffle/examples/simple_may_will/simple_may_will_pass.authlogic
+++ b/src/analysis/souffle/examples/simple_may_will/simple_may_will_pass.authlogic
@@ -34,5 +34,5 @@
 // ```
 // or similar, but the equivalent auth logic (for the once instance) is:
 "P2" says {
-    will("doLocalComputation", "R.P2#1.foo").
+    will("doLocalComputation", "R.P2.foo").
 }

--- a/src/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -321,12 +321,12 @@ class ParseBigManifestTest : public testing::Test {
 
 static const std::string kExpectedClaimStrings[] = {
     R"(// Claims:)",
-    R"(says_hasTag("PS1", "NamedR.PS1#0.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "NamedR.PS1#0.out_handle.field1").)",
+    R"(says_hasTag("PS1", "NamedR.PS1.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "NamedR.PS1.out_handle.field1").)",
     R"(says_hasTag("PS1", "NamedR.PS1#1.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "NamedR.PS1#1.out_handle.field1").)",
-    R"(says_hasTag("PS2", "NamedR.PS2#2.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "NamedR.PS2#2.out_handle.field1").)",
-    R"(says_hasTag("PS1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1").)",
+    R"(says_hasTag("PS2", "NamedR.PS2.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "NamedR.PS2.out_handle.field1").)",
+    R"(says_hasTag("PS1", "GENERATED_RECIPE_NAME0.PS1.out_handle.field1", owner, "tag1") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS1.out_handle.field1").)",
+    R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2.out_handle.field1").)",
     R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1").)",
-    R"(says_hasTag("PS2", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", owner, "tag3") :- ownsAccessPath(owner, "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1").)",
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoClaimsTest) {
@@ -344,18 +344,18 @@ static constexpr absl::string_view kPattern =
 
 static std::string kExpectedCheckStrings[] = {
     R"(// Checks:)",
-    absl::Substitute(kPattern, "check_num_0", "NamedR.PS1#0.in_handle.field1",
+    absl::Substitute(kPattern, "check_num_0", "NamedR.PS1.in_handle.field1",
                      "tag2"),
     absl::Substitute(kPattern, "check_num_1", "NamedR.PS1#1.in_handle.field1",
                      "tag2"),
-    absl::Substitute(kPattern, "check_num_2", "NamedR.PS2#2.in_handle.field1",
+    absl::Substitute(kPattern, "check_num_2", "NamedR.PS2.in_handle.field1",
                      "tag4"),
     absl::Substitute(kPattern, "check_num_3",
-                     "GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "tag2"),
+                     "GENERATED_RECIPE_NAME0.PS1.in_handle.field1", "tag2"),
     absl::Substitute(kPattern, "check_num_4",
-                     "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "tag4"),
+                     "GENERATED_RECIPE_NAME0.PS2.in_handle.field1", "tag4"),
     absl::Substitute(kPattern, "check_num_5",
-                     "GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "tag4"),
+                     "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "tag4"),
 };
 
 TEST_F(ParseBigManifestTest, ManifestProtoChecksTest) {
@@ -370,14 +370,14 @@ static const std::string kExpectedEdgeStrings[] = {
     // Named recipe edges:
     // Edges connecting h1 to NamedR.PS1#0 for fields {field1, field2}.
     R"(// Edges:)",
-    R"(edge("NamedR.h1.field1", "NamedR.PS1#0.in_handle.field1").)",
-    R"(edge("NamedR.h1.field2", "NamedR.PS1#0.in_handle.field2").)",
+    R"(edge("NamedR.h1.field1", "NamedR.PS1.in_handle.field1").)",
+    R"(edge("NamedR.h1.field2", "NamedR.PS1.in_handle.field2").)",
 
     // Edges connecting h2 to NamedR.PS1#0 for field1
-    R"(edge("NamedR.PS1#0.out_handle.field1", "NamedR.h2.field1").)",
+    R"(edge("NamedR.PS1.out_handle.field1", "NamedR.h2.field1").)",
 
     // Intra-particle connection
-    R"(edge("NamedR.PS1#0.in_handle.field1", "NamedR.PS1#0.out_handle.field1").)",
+    R"(edge("NamedR.PS1.in_handle.field1", "NamedR.PS1.out_handle.field1").)",
 
     // Edges connecting h2 to NamedR.PS1#1 for field1.
     R"(edge("NamedR.h2.field1", "NamedR.PS1#1.in_handle.field1").)",
@@ -389,40 +389,40 @@ static const std::string kExpectedEdgeStrings[] = {
     R"(edge("NamedR.PS1#1.in_handle.field1", "NamedR.PS1#1.out_handle.field1").)",
 
     // Edges connecting h3 to NamedR.PS2#2 for field1
-    R"(edge("NamedR.h3.field1", "NamedR.PS2#2.in_handle.field1").)",
+    R"(edge("NamedR.h3.field1", "NamedR.PS2.in_handle.field1").)",
 
     // Edges connecting h4 to NamedR.Ps2#2 for field1
-    R"(edge("NamedR.PS2#2.out_handle.field1", "NamedR.h4.field1").)",
+    R"(edge("NamedR.PS2.out_handle.field1", "NamedR.h4.field1").)",
 
     // Intra-particle connection
-    R"(edge("NamedR.PS2#2.in_handle.field1", "NamedR.PS2#2.out_handle.field1").)",
+    R"(edge("NamedR.PS2.in_handle.field1", "NamedR.PS2.out_handle.field1").)",
 
     // Unnamed recipe edges:
-    R"(edge("GENERATED_RECIPE_NAME0.h1.field1", "GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1").)",
+    R"(edge("GENERATED_RECIPE_NAME0.h1.field1", "GENERATED_RECIPE_NAME0.PS1.in_handle.field1").)",
 
     // Edges connecting h2 to NamedR.PS1#0 for field1
-    R"(edge("GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1", "GENERATED_RECIPE_NAME0.h2.field1").)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS1.out_handle.field1", "GENERATED_RECIPE_NAME0.h2.field1").)",
 
     // Intra-particle connection
-    R"(edge("GENERATED_RECIPE_NAME0.PS1#0.in_handle.field1", "GENERATED_RECIPE_NAME0.PS1#0.out_handle.field1").)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS1.in_handle.field1", "GENERATED_RECIPE_NAME0.PS1.out_handle.field1").)",
 
     // Edges connecting h2 to NamedR.PS2#1 for field1.
-    R"(edge("GENERATED_RECIPE_NAME0.h2.field1", "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1").)",
+    R"(edge("GENERATED_RECIPE_NAME0.h2.field1", "GENERATED_RECIPE_NAME0.PS2.in_handle.field1").)",
 
     // Edges connecting h3 to NamedR.PS2#1 for field1
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "GENERATED_RECIPE_NAME0.h3.field1").)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS2.out_handle.field1", "GENERATED_RECIPE_NAME0.h3.field1").)",
 
     // Intra-particle connection
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1").)",
+    R"(edge("GENERATED_RECIPE_NAME0.PS2.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2.out_handle.field1").)",
 
-    // Edges connecting h3 to NamedR.PS2#2 for field1
-    R"(edge("GENERATED_RECIPE_NAME0.h3.field1", "GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1").)",
+    // Edges connecting h3 to NamedR.PS2 for field1
+    R"(edge("GENERATED_RECIPE_NAME0.h3.field1", "GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1").)",
 
-    // Edges connecting h4 to NamedR.PS2#2 for field1
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1", "GENERATED_RECIPE_NAME0.h4.field1").)",
+    // Edges connecting h4 to NamedR.PS2 for field1
+    R"(edge("GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1", "GENERATED_RECIPE_NAME0.h4.field1").)",
 
     // Intra-particle connection
-    R"(edge("GENERATED_RECIPE_NAME0.PS2#2.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#2.out_handle.field1").)"};
+    R"(edge("GENERATED_RECIPE_NAME0.PS2#1.in_handle.field1", "GENERATED_RECIPE_NAME0.PS2#1.out_handle.field1").)"};
 
 TEST_F(ParseBigManifestTest, ManifestProtoEdgesTest) {
   EXPECT_THAT(utils::make_range(std::find(datalog_strings_.begin(),

--- a/src/xform_to_datalog/testdata/ok_claim_propagates.dl
+++ b/src/xform_to_datalog/testdata/ok_claim_propagates.dl
@@ -29,18 +29,18 @@ saysWill(w, x, y) :- says_will(w, x, y).
 
 // Manifest
 // Claims:
-says_hasTag("P1", "R.P1#0.foo", owner, "userSelection") :- ownsAccessPath(owner, "R.P1#0.foo").
+says_hasTag("P1", "R.P1.foo", owner, "userSelection") :- ownsAccessPath(owner, "R.P1.foo").
 
 // Checks:
-isCheck("check_num_0", "R.P3#2.bar"). check("check_num_0", owner, "R.P3#2.bar") :-
-  ownsAccessPath(owner, "R.P3#2.bar"), mayHaveTag("R.P3#2.bar", owner, "userSelection").
+isCheck("check_num_0", "R.P3.bar"). check("check_num_0", owner, "R.P3.bar") :-
+  ownsAccessPath(owner, "R.P3.bar"), mayHaveTag("R.P3.bar", owner, "userSelection").
 
 // Edges:
-edge("R.P1#0.foo", "R.handle0").
-edge("R.handle0", "R.P2#1.bar").
-edge("R.P2#1.foo", "R.handle1").
-edge("R.P2#1.bar", "R.P2#1.foo").
-edge("R.handle1", "R.P3#2.bar").
+edge("R.P1.foo", "R.handle0").
+edge("R.handle0", "R.P2.bar").
+edge("R.P2.foo", "R.handle1").
+edge("R.P2.bar", "R.P2.foo").
+edge("R.handle1", "R.P3.bar").
 
 
 // Authorization Logic


### PR DESCRIPTION
This will make the names of particles in the access paths more predictable.