### PR TITLE
Enable rebuilding of Docker images in CI and freeze bazel to 5.0.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get install default-jdk -y --no-install-recommends
 ENV JAVA_HOME /usr/lib/jvm/default-java
 
 # Set up baselisk.
+ENV USE_BAZEL_VERSION=5.0.0
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 \
     -O /usr/local/bin/bazelisk && chmod a+x /usr/local/bin/bazelisk
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,33 +5,31 @@ steps:
   args: ['pull', '${_DOCKER_IMAGE}']
   waitFor: ['-']
 
-# TODO(#292): We are hitting the rate limiter for Souffle installs.
-# Disable the rebuild of images for now.
-# # Build the new Docker image (caching from the pre-built one)
-# - id: 'build-image'
-#   waitFor: ['pull-image']
-#   name: 'gcr.io/cloud-builders/docker'
-#   args: [
-#     'build',
-#     '--network=cloudbuild',
-#     '--cache-from=${_DOCKER_IMAGE}',
-#     '--tag=${_DOCKER_IMAGE}',
-#     '.',
-#   ]
+# Build the new Docker image (caching from the pre-built one)
+- id: 'build-image'
+  waitFor: ['pull-image']
+  name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'build',
+    '--network=cloudbuild',
+    '--cache-from=${_DOCKER_IMAGE}',
+    '--tag=${_DOCKER_IMAGE}',
+    '.',
+  ]
 
-# # Push updated Docker image to Container Registry.
-# - id: 'push-image'
-#   waitFor: ['build-image']
-#   name: 'gcr.io/cloud-builders/docker'
-#   args: [
-#     'push',
-#     '${_DOCKER_IMAGE}',
-#   ]
+# Push updated Docker image to Container Registry.
+- id: 'push-image'
+  waitFor: ['build-image']
+  name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'push',
+    '${_DOCKER_IMAGE}',
+  ]
 
 # Run presubmit tests.
 - id: 'presubmit'
   secretEnv: ['GITHUB_COMMIT_STATUS_TOKEN']
-  waitFor: ['pull-image']
+  waitFor: ['build-image']
   name: '${_DOCKER_IMAGE}'
   entrypoint: 'bash'
   args: ['./gcb/presubmit.sh']


### PR DESCRIPTION
Also, fixes #292 