### PR TITLE
Make `DecodeExpressionArena` have a no-context overload.

### DIFF
--- a/src/frontends/sql/decode.cc
+++ b/src/frontends/sql/decode.cc
@@ -110,8 +110,8 @@ static Value DecodeExpression(const Expression &expr,
 
 // Decode every `Expression` contained within the arena and return the top
 // level `ir::Value` for that arena.
-Value DecodeExpressionArena(
-    const ExpressionArena &expr_arena, DecoderContext &decoder_context) {
+Value DecodeExpressionArena(const ExpressionArena &expr_arena,
+                            DecoderContext &decoder_context) {
   std::optional<Value> top_level_value = std::nullopt;
   for (const IdExpressionPair &id_expr_pair :
        expr_arena.id_expression_pairs()) {
@@ -129,6 +129,5 @@ Value DecodeExpressionArena(const ExpressionArena &expr_arena) {
   DecoderContext decoder_context(ir_context);
   return DecodeExpressionArena(expr_arena, decoder_context);
 }
-
 
 }  // namespace raksha::frontends::sql

--- a/src/frontends/sql/decode.cc
+++ b/src/frontends/sql/decode.cc
@@ -108,9 +108,10 @@ static Value DecodeExpression(const Expression &expr,
   CHECK(false) << "Unreachable!";
 }
 
-// Decode every `Expression`
-Value DecodeExpressionArena(const ExpressionArena &expr_arena,
-                            DecoderContext &decoder_context) {
+// Decode every `Expression` contained within the arena and return the top
+// level `ir::Value` for that arena.
+Value DecodeExpressionArena(
+    const ExpressionArena &expr_arena, DecoderContext &decoder_context) {
   std::optional<Value> top_level_value = std::nullopt;
   for (const IdExpressionPair &id_expr_pair :
        expr_arena.id_expression_pairs()) {
@@ -122,5 +123,12 @@ Value DecodeExpressionArena(const ExpressionArena &expr_arena,
                                         "be provided in the ExpressionArena.";
   return *top_level_value;
 }
+
+Value DecodeExpressionArena(const ExpressionArena &expr_arena) {
+  ir::IRContext ir_context;
+  DecoderContext decoder_context(ir_context);
+  return DecodeExpressionArena(expr_arena, decoder_context);
+}
+
 
 }  // namespace raksha::frontends::sql

--- a/src/frontends/sql/decode.h
+++ b/src/frontends/sql/decode.h
@@ -31,6 +31,10 @@ namespace raksha::frontends::sql {
 ir::Value DecodeExpressionArena(const ExpressionArena &expr,
                                 DecoderContext &decoder_context);
 
+// A simple no-context variant for decoding the expression arena which creates
+// a fresh context and calls the above.
+ir::Value DecodeExpressionArena(const ExpressionArena &expr);
+
 }  // namespace raksha::frontends::sql
 
 #endif  // SRC_FRONTENDS_SQL_DECODE_H_

--- a/src/frontends/sql/decode_expr_death_test.cc
+++ b/src/frontends/sql/decode_expr_death_test.cc
@@ -18,7 +18,6 @@
 #include "absl/strings/string_view.h"
 #include "src/common/testing/gtest.h"
 #include "src/frontends/sql/decode.h"
-#include "src/frontends/sql/decoder_context.h"
 #include "src/frontends/sql/sql_ir.pb.h"
 #include "src/frontends/sql/testing/utils.h"
 
@@ -26,7 +25,6 @@ namespace raksha::frontends::sql {
 
 namespace {
 
-using ir::IRContext;
 using ::testing::TestWithParam;
 using ::testing::ValuesIn;
 
@@ -37,8 +35,6 @@ struct TextprotoDeathMessagePair {
 
 class DecodeExprDeathTest : public TestWithParam<TextprotoDeathMessagePair> {
  protected:
-  DecodeExprDeathTest() : ir_context_(), decoder_context_(ir_context_) {}
-
   ExpressionArena GetExprArena() {
     ExpressionArena exprArena;
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
@@ -49,13 +45,11 @@ class DecodeExprDeathTest : public TestWithParam<TextprotoDeathMessagePair> {
     return exprArena;
   }
 
-  IRContext ir_context_;
-  DecoderContext decoder_context_;
 };
 
 TEST_P(DecodeExprDeathTest, DecodeExprDeathTest) {
   ExpressionArena exprArena = GetExprArena();
-  EXPECT_DEATH({ DecodeExpressionArena(exprArena, decoder_context_); },
+  EXPECT_DEATH({ DecodeExpressionArena(exprArena); },
                GetParam().death_message);
 }
 

--- a/src/frontends/sql/decode_expr_death_test.cc
+++ b/src/frontends/sql/decode_expr_death_test.cc
@@ -14,8 +14,8 @@
 // limitations under the License.
 //----------------------------------------------------------------------------
 
-#include "google/protobuf/text_format.h"
 #include "absl/strings/string_view.h"
+#include "google/protobuf/text_format.h"
 #include "src/common/testing/gtest.h"
 #include "src/frontends/sql/decode.h"
 #include "src/frontends/sql/sql_ir.pb.h"
@@ -44,13 +44,11 @@ class DecodeExprDeathTest : public TestWithParam<TextprotoDeathMessagePair> {
         << "Could not decode exprArena";
     return exprArena;
   }
-
 };
 
 TEST_P(DecodeExprDeathTest, DecodeExprDeathTest) {
   ExpressionArena exprArena = GetExprArena();
-  EXPECT_DEATH({ DecodeExpressionArena(exprArena); },
-               GetParam().death_message);
+  EXPECT_DEATH({ DecodeExpressionArena(exprArena); }, GetParam().death_message);
 }
 
 const TextprotoDeathMessagePair kTextprotoDeathMessagePairs[] = {


### PR DESCRIPTION
`DecodeExpressionArena`, up til now, has taken a `DecoderContext` as one
of its arguments. You could imagine this being very useful for fancy
scenarios, such as having multiple pieces of a large program containing
a SQL query relying on a common context. However, it is a bit annoying
for the simple case we would like to solve right now, in which we want
to decode the IR for a single SQL query for the SQL verifier
integration. For this case, it is easier to not pass a context, which
should cause a fresh context to be constructed and used for decoding.
This commit adds an overload with that behavior.