### PR TITLE
Add a boolean conversion to `intrusive_ptr`.

### DIFF
--- a/src/common/utils/intrusive_ptr.h
+++ b/src/common/utils/intrusive_ptr.h
@@ -53,6 +53,9 @@ class intrusive_ptr {
 
   T* operator->() const { return ptr_; }
   T* get() const { return ptr_; }
+  explicit operator bool() const {
+    return ptr_ != nullptr;
+  }
 
  private:
   void Swap(intrusive_ptr<T>& other) {

--- a/src/common/utils/intrusive_ptr_test.cc
+++ b/src/common/utils/intrusive_ptr_test.cc
@@ -238,5 +238,13 @@ TEST(IntrusivePtrTest, ComparisionAgainstNullPtrs) {
   EXPECT_EQ(null, nullptr);
   EXPECT_EQ(nullptr, null);
 }
+
+TEST(IntrusivePtrBoolConversionTest, IntrusivePtrBoolConversionTest) {
+  RefCountedTypePtr ptr = make_intrusive_ptr<RefCountedType>();
+  EXPECT_TRUE(ptr);
+  RefCountedTypePtr null;
+  EXPECT_FALSE(null);
+}
+
 }  // namespace
 }  // namespace raksha


### PR DESCRIPTION
This change adds a boolean conversion to `intrusive_ptr`. While type
conversions are frowned upon by the Google style guide, boolean
conversions of this form are highly idiomatic for C++ smart pointers,
and are defined on both `std::unique_ptr` and `std::shared_ptr`. This
method allows more syntactically-fluid use of the `GetIf` function on
`Attribute`, as with it we can write code like so:

```
if (intrusive_ptr<Int64Attribute> int64_attr =
  attr.GetIf<Int64Attribute>()) {
...
}
```

with the conversion to `bool` allowing for the testing of the introduced
`int64_attr` local.