### PR TITLE
Create a new `refct_ptr`, an intrusive_ptr that brings its own counter.

### DIFF
--- a/src/common/utils/BUILD
+++ b/src/common/utils/BUILD
@@ -80,6 +80,25 @@ cc_test(
 )
 
 cc_library(
+    name = "refct_ptr",
+    hdrs = ["refct_ptr.h"],
+    deps = [
+        ":intrusive_ptr",
+        ":ref_counted",
+    ],
+)
+
+cc_test(
+    name = "refct_ptr_test",
+    srcs = ["refct_ptr_test.cc"],
+    deps = [
+        ":refct_ptr",
+        "//src/common/testing:gtest",
+        "@absl//absl/strings",
+    ],
+)
+
+cc_library(
     name = "overloaded",
     hdrs = ["overloaded.h"],
     deps = [],

--- a/src/common/utils/refct_ptr.h
+++ b/src/common/utils/refct_ptr.h
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#ifndef SRC_COMMON_UTILS_REFCT_PTR_H_
+#define SRC_COMMON_UTILS_REFCT_PTR_H_
+
+#include "src/common/utils/intrusive_ptr.h"
+#include "src/common/utils/ref_counted.h"
+
+namespace raksha::common::utils {
+
+template <class T>
+class WithRefCount : public RefCounted<WithRefCount<T>> {
+ public:
+  template <class... Args>
+  WithRefCount(Args&&... args)
+      : RefCounted<WithRefCount<T>>(), payload_(std::forward<Args>(args)...) {}
+
+  T& payload() { return payload_; }
+  const T& payload() const { return payload_; }
+
+ private:
+  T payload_;
+};
+
+// An intrusive_ptr that only intrudes on the `WithRefCount` object it
+// introduces. As such, it's not really "intrusive" from the point of view of
+// the client and deserves a new name.
+template <class T>
+class refct_ptr {
+ public:
+  refct_ptr() : ptr_() {}
+  refct_ptr(intrusive_ptr<WithRefCount<T>> ptr) : ptr_(std::move(ptr)) {}
+
+  T& operator*() { return (*ptr_).payload(); }
+
+  const T& operator*() const { return (*ptr_).payload(); }
+
+  T* operator->() { return &(*ptr_).payload(); }
+
+  const T* operator->() const { return &(*ptr_).payload(); }
+
+  explicit operator bool() const { return bool(ptr_); }
+
+  intrusive_ptr<WithRefCount<T>> get_intrusive_ptr() const { return ptr_; }
+
+ private:
+  intrusive_ptr<WithRefCount<T>> ptr_;
+};
+
+template <class T, class... Args>
+refct_ptr<T> make_refct_ptr(Args&&... args) {
+  return intrusive_ptr<WithRefCount<T>>(
+      new WithRefCount<T>(std::forward<Args>(args)...));
+}
+
+}  // namespace raksha::common::utils
+
+#endif  // SRC_COMMON_UTILS_REFCT_PTR_H_

--- a/src/common/utils/refct_ptr_test.cc
+++ b/src/common/utils/refct_ptr_test.cc
@@ -1,0 +1,82 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#include "src/common/utils/refct_ptr.h"
+
+#include "absl/strings/string_view.h"
+#include "src/common/testing/gtest.h"
+
+namespace raksha::common::utils {
+
+TEST(NullRefctPtr, NullRefctPtr) {
+  refct_ptr<int> null_refct_ptr;
+  auto inner_intrusive_ptr = null_refct_ptr.get_intrusive_ptr();
+  EXPECT_TRUE(inner_intrusive_ptr == nullptr);
+  EXPECT_FALSE(null_refct_ptr);
+}
+
+class TestIntRefctPtr : public testing::TestWithParam<int> {};
+
+TEST_P(TestIntRefctPtr, TestIntRefctPtr) {
+  int param = GetParam();
+  refct_ptr<int> int_ptr = make_refct_ptr<int>(param);
+  EXPECT_EQ(*int_ptr, param);
+  EXPECT_TRUE(int_ptr);
+  const refct_ptr<int> const_int_ptr = int_ptr;
+  EXPECT_EQ(*const_int_ptr, param);
+  EXPECT_EQ(int_ptr.get_intrusive_ptr(), const_int_ptr.get_intrusive_ptr());
+  EXPECT_TRUE(const_int_ptr);
+}
+
+static int kSampleInts[] = {0, -1, 100, -5};
+
+INSTANTIATE_TEST_SUITE_P(TestIntRefctPtr, TestIntRefctPtr,
+                         testing::ValuesIn(kSampleInts));
+
+class IntStringPair {
+ public:
+  IntStringPair(int i, absl::string_view s) : int_(i), string_(s) {}
+
+  int get_int() const { return int_; }
+  absl::string_view get_string() const { return string_; }
+
+ private:
+  int int_;
+  std::string string_;
+};
+
+class TestIntStringPairPtr
+    : public testing::TestWithParam<std::tuple<int, absl::string_view>> {};
+
+TEST_P(TestIntStringPairPtr, TestIntStringPairPtr) {
+  auto [i, s] = GetParam();
+  refct_ptr<IntStringPair> ptr = make_refct_ptr<IntStringPair>(i, s);
+  EXPECT_EQ(ptr->get_int(), i);
+  EXPECT_EQ(ptr->get_string(), s);
+  EXPECT_TRUE(ptr);
+  const refct_ptr<IntStringPair> const_ptr = ptr;
+  EXPECT_EQ(const_ptr->get_int(), i);
+  EXPECT_EQ(const_ptr->get_string(), s);
+  EXPECT_TRUE(const_ptr);
+}
+
+static absl::string_view kSampleStrings[] = {"", "abc", "def", "foo", "!!!"};
+
+INSTANTIATE_TEST_SUITE_P(TestIntStringPairPtr, TestIntStringPairPtr,
+                         testing::Combine(testing::ValuesIn(kSampleInts),
+                                          testing::ValuesIn(kSampleStrings)));
+
+}  // namespace raksha::common::utils


### PR DESCRIPTION
The `intrusive_ptr` smart pointer expects its pointed-to type to have
a counter upon it. This means that the pointed-to object needs to derive
from `RefCounted` or duplicate its interface to allow `intrusive_ptr` to
count correctly. But what if you want a shared smart pointer and you
don't want to worry about inheriting from a counter object?

That is what the new `refct_ptr` tries to do. Rather than requiring its
payload to bring its own counter, at time of allocation, it composes
that payload with a `WithRefCount` object that provides the `RefCounted`
superclass. This allows `refct_ptr` to point to any object with few
additional restrictions at the cost of an extra `uint64_t` in size on
the pointed-to payload.