### PR TITLE
Add `fold` and `rfold` functions to our common utils.

### DIFF
--- a/src/common/utils/BUILD
+++ b/src/common/utils/BUILD
@@ -123,3 +123,19 @@ cc_test(
         "//src/common/testing:gtest",
     ],
 )
+
+cc_library(
+    name = "fold",
+    hdrs = ["fold.h"],
+    deps = [],
+)
+
+cc_test(
+    name = "fold_test",
+    srcs = ["fold_test.cc"],
+    deps = [
+        ":fold",
+        "//src/common/testing:gtest",
+        "@absl//absl/strings",
+    ],
+)

--- a/src/common/utils/fold.h
+++ b/src/common/utils/fold.h
@@ -32,6 +32,11 @@
 
 namespace raksha::common::utils {
 
+// An implementation of `fold` that takes as inputs an iterator to the beginning
+// of some range and an iterator to the end of that range. This just folds using
+// `fold_fn` from the beginning iterator to the end iterator with an initial
+// value of `accumulated`. Corresponds very directly to `std::accumulate` with a
+// custom `BinaryOperator`.
 template <class I, class A, class F>
 A fold_iter(I begin_iter, I end_iter, A accumulated, F fold_fn) {
   if (begin_iter == end_iter) return accumulated;
@@ -40,12 +45,16 @@ A fold_iter(I begin_iter, I end_iter, A accumulated, F fold_fn) {
                    fold_fn(std::move(accumulated), current_element), fold_fn);
 }
 
+// A left fold over the provided container using `fold_fn` with an initial value
+// of `init`.
 template <class C, class A, class F>
 A fold(const C &container, A &&init, F &&fold_fn) {
   return fold_iter(std::begin(container), std::end(container),
                    std::forward<A>(init), std::forward<F>(fold_fn));
 }
 
+// A right (or reverse) fold over the provided container using `fold_fn` with an
+// initial value of `init`.
 template <class C, class A, class F>
 A rfold(const C &container, A &&init, F &&fold_fn) {
   return fold_iter(std::rbegin(container), std::rend(container),

--- a/src/common/utils/fold.h
+++ b/src/common/utils/fold.h
@@ -1,0 +1,57 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#ifndef SRC_COMMON_UTILS_FOLD_H_
+#define SRC_COMMON_UTILS_FOLD_H_
+
+// This file contains a C++ implementation of the classic "fold" and
+// "right_fold" higher-order functions. This is somewhat redundant with
+// std::accumulate; unfortunately, std::accumulate requires its accumulator to
+// be copyable until C++20.
+//
+// Note that "right_fold" is named "rfold". This is a bit of a pun: if you come
+// from a functional languages background, the "r" naturally expands to "right",
+// while if you are fluent with C++ iterators, "r" naturally means "reverse".
+// In this context it actually means both: a right_fold achieved by using
+// reverse iterators on the provided container.
+
+#include <iterator>
+
+namespace raksha::common::utils {
+
+template <class I, class A, class F>
+A fold_iter(I begin_iter, I end_iter, A accumulated, F fold_fn) {
+  if (begin_iter == end_iter) return accumulated;
+  const auto &current_element = *begin_iter;
+  return fold_iter(++begin_iter, end_iter,
+                   fold_fn(std::move(accumulated), current_element), fold_fn);
+}
+
+template <class C, class A, class F>
+A fold(const C &container, A &&init, F &&fold_fn) {
+  return fold_iter(std::begin(container), std::end(container),
+                   std::forward<A>(init), std::forward<F>(fold_fn));
+}
+
+template <class C, class A, class F>
+A rfold(const C &container, A &&init, F &&fold_fn) {
+  return fold_iter(std::rbegin(container), std::rend(container),
+                   std::forward<A>(init), std::forward<F>(fold_fn));
+}
+
+}  // namespace raksha::common::utils
+
+#endif  // SRC_COMMON_UTILS_FOLD_H_

--- a/src/common/utils/fold.h
+++ b/src/common/utils/fold.h
@@ -38,27 +38,27 @@ namespace raksha::common::utils {
 // value of `accumulated`. Corresponds very directly to `std::accumulate` with a
 // custom `BinaryOperator`.
 template <class I, class A, class F>
-A fold_iter(I begin_iter, I end_iter, A accumulated, F fold_fn) {
+A fold(I begin_iter, I end_iter, A accumulated, F fold_fn) {
   if (begin_iter == end_iter) return accumulated;
   const auto &current_element = *begin_iter;
-  return fold_iter(++begin_iter, end_iter,
-                   fold_fn(std::move(accumulated), current_element), fold_fn);
+  return fold(++begin_iter, end_iter,
+              fold_fn(std::move(accumulated), current_element), fold_fn);
 }
 
 // A left fold over the provided container using `fold_fn` with an initial value
 // of `init`.
 template <class C, class A, class F>
 A fold(const C &container, A &&init, F &&fold_fn) {
-  return fold_iter(std::begin(container), std::end(container),
-                   std::forward<A>(init), std::forward<F>(fold_fn));
+  return fold(std::begin(container), std::end(container), std::forward<A>(init),
+              std::forward<F>(fold_fn));
 }
 
 // A right (or reverse) fold over the provided container using `fold_fn` with an
 // initial value of `init`.
 template <class C, class A, class F>
 A rfold(const C &container, A &&init, F &&fold_fn) {
-  return fold_iter(std::rbegin(container), std::rend(container),
-                   std::forward<A>(init), std::forward<F>(fold_fn));
+  return fold(std::rbegin(container), std::rend(container),
+              std::forward<A>(init), std::forward<F>(fold_fn));
 }
 
 }  // namespace raksha::common::utils

--- a/src/common/utils/fold_test.cc
+++ b/src/common/utils/fold_test.cc
@@ -73,23 +73,22 @@ class BoxFoldTest : public testing::TestWithParam<std::vector<std::string>> {};
 
 TEST_P(BoxFoldTest, BoxFoldTest) {
   const std::vector<std::string> &string_vec = GetParam();
-  auto box_fn = [](std::vector<std::unique_ptr<std::string>> boxed_so_far,
-                   const std::string &input) {
-    boxed_so_far.push_back(std::make_unique<std::string>(input));
-    return boxed_so_far;
-  };
   std::vector<std::unique_ptr<std::string>> boxed_strings =
-      fold(string_vec, std::vector<std::unique_ptr<std::string>>(), box_fn);
-  auto unbox_fn = [](std::vector<std::string> unboxed_so_far,
-                     const std::unique_ptr<std::string> &to_unbox) {
-    unboxed_so_far.push_back(*to_unbox);
-    return unboxed_so_far;
-  };
+      fold(string_vec, std::vector<std::unique_ptr<std::string>>(),
+           [](std::vector<std::unique_ptr<std::string>> boxed_so_far,
+              const std::string &input) {
+             boxed_so_far.push_back(std::make_unique<std::string>(input));
+             return boxed_so_far;
+           });
   std::vector<std::string> unboxed_strings =
-      fold(boxed_strings, std::vector<std::string>(), unbox_fn);
+      fold(boxed_strings, std::vector<std::string>(),
+           [](std::vector<std::string> unboxed_so_far,
+              const std::unique_ptr<std::string> &to_unbox) {
+             unboxed_so_far.push_back(*to_unbox);
+             return unboxed_so_far;
+           });
   EXPECT_THAT(unboxed_strings, testing::ElementsAreArray(string_vec));
 }
-
 
 INSTANTIATE_TEST_SUITE_P(BoxFoldTest, BoxFoldTest,
                          testing::ValuesIn(kSampleStringVecs));
@@ -108,7 +107,7 @@ TEST_P(RawPointerFoldTest, RawPointerFoldTest) {
   EXPECT_THAT(fold_iter(begin_ptr, end_ptr, 0, sum_fn), expected_result);
 }
 
-INSTANTIATE_TEST_SUITE_P(RawPointerFoldTest, RawPointerFoldTest, testing::ValuesIn(kIntVecsAndSum));
-
+INSTANTIATE_TEST_SUITE_P(RawPointerFoldTest, RawPointerFoldTest,
+                         testing::ValuesIn(kIntVecsAndSum));
 
 }  // namespace raksha::common::utils

--- a/src/common/utils/fold_test.cc
+++ b/src/common/utils/fold_test.cc
@@ -90,7 +90,25 @@ TEST_P(BoxFoldTest, BoxFoldTest) {
   EXPECT_THAT(unboxed_strings, testing::ElementsAreArray(string_vec));
 }
 
+
 INSTANTIATE_TEST_SUITE_P(BoxFoldTest, BoxFoldTest,
                          testing::ValuesIn(kSampleStringVecs));
+
+using RawPointerFoldTest = SumFoldTest;
+
+// Indirectly, the other tests actually do test `fold_iter`, as they delegate
+// to it. Here we show `fold_iter` doing something that they cannot: folding
+// over a pair of "iterators" that are actually just pointers to a contiguous
+// chunk of memory.
+TEST_P(RawPointerFoldTest, RawPointerFoldTest) {
+  const auto &[vec, expected_result] = GetParam();
+  const int *begin_ptr = vec.data();
+  const int *end_ptr = vec.data() + vec.size();
+  auto sum_fn = [](int sum_so_far, int num) { return sum_so_far + num; };
+  EXPECT_THAT(fold_iter(begin_ptr, end_ptr, 0, sum_fn), expected_result);
+}
+
+INSTANTIATE_TEST_SUITE_P(RawPointerFoldTest, RawPointerFoldTest, testing::ValuesIn(kIntVecsAndSum));
+
 
 }  // namespace raksha::common::utils

--- a/src/common/utils/fold_test.cc
+++ b/src/common/utils/fold_test.cc
@@ -1,0 +1,96 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#include "src/common/utils/fold.h"
+
+#include "absl/strings/str_join.h"
+#include "src/common/testing/gtest.h"
+
+namespace raksha::common::utils {
+
+struct IntVecAndSum {
+  std::vector<int> int_vec;
+  int sum;
+};
+
+class SumFoldTest : public testing::TestWithParam<IntVecAndSum> {};
+
+TEST_P(SumFoldTest, SumFoldTest) {
+  const auto &[vec, expected_result] = GetParam();
+  auto sum_fn = [](int sum_so_far, int num) { return sum_so_far + num; };
+  EXPECT_EQ(fold(vec, 0, sum_fn), expected_result);
+  EXPECT_EQ(rfold(vec, 0, sum_fn), expected_result);
+}
+
+static const IntVecAndSum kIntVecsAndSum[] = {
+    {.int_vec = {}, .sum = 0},
+    {.int_vec = {1}, .sum = 1},
+    {.int_vec = {1, 2, 3, 4}, .sum = 10},
+    {.int_vec = {-1, 5, 2, -8}, .sum = -2}};
+
+INSTANTIATE_TEST_SUITE_P(SumFoldTest, SumFoldTest,
+                         testing::ValuesIn(kIntVecsAndSum));
+
+class ConcatFoldTest : public testing::TestWithParam<std::vector<std::string>> {
+};
+
+TEST_P(ConcatFoldTest, ConcatFoldTest) {
+  const std::vector<std::string> &string_vec = GetParam();
+  auto concat_fn = [](std::string concat_so_far, const std::string &input) {
+    // Yes, this is bad form in general, but the quadraticness shouldn't matter
+    // for a test.
+    return concat_so_far + input;
+  };
+  EXPECT_EQ(fold(string_vec, std::string(""), concat_fn),
+            absl::StrJoin(string_vec, ""));
+  EXPECT_EQ(rfold(string_vec, std::string(""), concat_fn),
+            absl::StrJoin(string_vec.rbegin(), string_vec.rend(), ""));
+}
+
+static const std::vector<std::string> kSampleStringVecs[] = {
+    {}, {"x"}, {"hello", "world"}, {"a", "b", "c", "d", "e"}};
+
+INSTANTIATE_TEST_SUITE_P(ConcatFoldTest, ConcatFoldTest,
+                         testing::ValuesIn(kSampleStringVecs));
+
+// Box and unbox some strings via `fold`. This mainly tests that we can handle
+// an uncopyable accumulator (ie, the vector of unique pointers that we build
+// up) and an uncopyable input vector.
+class BoxFoldTest : public testing::TestWithParam<std::vector<std::string>> {};
+
+TEST_P(BoxFoldTest, BoxFoldTest) {
+  const std::vector<std::string> &string_vec = GetParam();
+  auto box_fn = [](std::vector<std::unique_ptr<std::string>> boxed_so_far,
+                   const std::string &input) {
+    boxed_so_far.push_back(std::make_unique<std::string>(input));
+    return boxed_so_far;
+  };
+  std::vector<std::unique_ptr<std::string>> boxed_strings =
+      fold(string_vec, std::vector<std::unique_ptr<std::string>>(), box_fn);
+  auto unbox_fn = [](std::vector<std::string> unboxed_so_far,
+                     const std::unique_ptr<std::string> &to_unbox) {
+    unboxed_so_far.push_back(*to_unbox);
+    return unboxed_so_far;
+  };
+  std::vector<std::string> unboxed_strings =
+      fold(boxed_strings, std::vector<std::string>(), unbox_fn);
+  EXPECT_THAT(unboxed_strings, testing::ElementsAreArray(string_vec));
+}
+
+INSTANTIATE_TEST_SUITE_P(BoxFoldTest, BoxFoldTest,
+                         testing::ValuesIn(kSampleStringVecs));
+
+}  // namespace raksha::common::utils

--- a/src/common/utils/fold_test.cc
+++ b/src/common/utils/fold_test.cc
@@ -110,16 +110,15 @@ INSTANTIATE_TEST_SUITE_P(BoxFoldTest, BoxFoldTest,
 
 using RawPointerFoldTest = SumFoldTest;
 
-// Indirectly, the other tests actually do test `fold_iter`, as they delegate
-// to it. Here we show `fold_iter` doing something that they cannot: folding
-// over a pair of "iterators" that are actually just pointers to a contiguous
-// chunk of memory.
+// Here we show the iterator-taking `fold` doing something that the
+// container-taking folds cannot: folding over a pair of "iterators" that are
+// actually just pointers to a contiguous chunk of memory.
 TEST_P(RawPointerFoldTest, RawPointerFoldTest) {
   const auto &[vec, expected_result] = GetParam();
   const int *begin_ptr = vec.data();
   const int *end_ptr = vec.data() + vec.size();
   auto sum_fn = [](int sum_so_far, int num) { return sum_so_far + num; };
-  EXPECT_THAT(fold_iter(begin_ptr, end_ptr, 0, sum_fn), expected_result);
+  EXPECT_THAT(fold(begin_ptr, end_ptr, 0, sum_fn), expected_result);
 }
 
 INSTANTIATE_TEST_SUITE_P(RawPointerFoldTest, RawPointerFoldTest,


### PR DESCRIPTION
C++ provides `std::accumulate`, which provides the classic higher-order
function `fold`. Unfortunately, `std::accumulate` copies its accumulator
until C++20, making it unsuitable for use with accumulators that have no
copy constructor. To work around this, this change adds a `fold` and an
`rfold` function, which can handle an uncopyable accumulator. If we
advance Raksha to C++20, we can just make these wrappers around
`std::accumulate`.