### PR TITLE
Add ctor to `IRContext` allowing creating with initial contents.

### DIFF
--- a/src/ir/block_builder_test.cc
+++ b/src/ir/block_builder_test.cc
@@ -29,12 +29,16 @@ namespace {
 
 class BlockBuilderTest : public testing::Test {
  public:
-  BlockBuilderTest() {
-    context_.RegisterOperator(std::make_unique<Operator>("core.plus"));
-    context_.RegisterOperator(std::make_unique<Operator>("core.minus"));
-    context_.RegisterOperator(std::make_unique<Operator>("core.merge"));
-    context_.RegisterOperator(std::make_unique<Operator>("core.choose"));
-  }
+  BlockBuilderTest()
+      : type_factory_(),
+        context_(
+            {
+                Operator("core.plus"),
+                Operator("core.minus"),
+                Operator("core.merge"),
+                Operator("core.choose"),
+            },
+            {}) {}
 
   types::Type MakeTestEntityType(absl::string_view schema_name) {
     const types::Schema& schema =

--- a/src/ir/ir_context.h
+++ b/src/ir/ir_context.h
@@ -33,6 +33,19 @@ class IRContext {
   IRContext(const IRContext &) = delete;
   IRContext &operator=(const IRContext &) = delete;
 
+  // Create a context with some number of operators and storages pre-seeded.
+  IRContext(std::vector<ir::Operator> operators,
+            std::vector<ir::Storage> storages) {
+    for (auto iter = std::make_move_iterator(operators.begin());
+         iter != std::make_move_iterator(operators.end()); ++iter) {
+      RegisterOperator(std::make_unique<Operator>(*iter));
+    }
+    for (auto iter = std::make_move_iterator(storages.begin());
+         iter != std::make_move_iterator(storages.end()); ++iter) {
+      RegisterStorage(std::make_unique<Storage>(*iter));
+    }
+  }
+
   types::TypeFactory &type_factory() { return type_factory_; }
 
   // Register an operator and return the stored operator instances.

--- a/src/ir/ir_context.h
+++ b/src/ir/ir_context.h
@@ -36,13 +36,11 @@ class IRContext {
   // Create a context with some number of operators and storages pre-seeded.
   IRContext(std::vector<ir::Operator> operators,
             std::vector<ir::Storage> storages) {
-    for (auto iter = std::make_move_iterator(operators.begin());
-         iter != std::make_move_iterator(operators.end()); ++iter) {
-      RegisterOperator(std::make_unique<Operator>(*iter));
+    for (ir::Operator &op : operators) {
+      RegisterOperator(std::make_unique<Operator>(std::move(op)));
     }
-    for (auto iter = std::make_move_iterator(storages.begin());
-         iter != std::make_move_iterator(storages.end()); ++iter) {
-      RegisterStorage(std::make_unique<Storage>(*iter));
+    for (Storage &storage : storages) {
+      RegisterStorage(std::make_unique<Storage>(std::move(storage)));
     }
   }
 

--- a/src/ir/storage.h
+++ b/src/ir/storage.h
@@ -27,9 +27,12 @@ class Storage {
   Storage(absl::string_view name, types::Type type)
       : name_(name), type_(std::move(type)) {}
 
-  // Disable copy (and move) semantics.
+  // Disable copy semantics.
   Storage(const Storage&) = delete;
   Storage& operator=(const Storage&) = delete;
+
+  Storage(Storage&&) = default;
+  Storage& operator=(Storage&&) = default;
 
   absl::string_view name() const { return name_; }
   const types::Type& type() const { return type_; }


### PR DESCRIPTION
Prior to this commit, all `Operator`s and `Storage`s only got into an
`IRContext` by being passed into their respective `Register` function.
While this makes sense for many circumstances, it makes it harder to
write certain tests, as objects that need an `IRContext` cannot be
constructed in the static scope without global mutable state. In
addition, it could make sense to have an `IRContext` with a known,
initial set of `Operator`s and `Storage`s: if we know an exact set of
allowed `Operation`s in advance, why not just build the `IRContext` with
them in there from the start?

This commit adds a constructor to `IRContext` that takes a `std::vector`
of initial `Operation`s and `Storage`s to seed the `IRContext` with. The
constructor then just calls `Register` for each of those items. This
commit also uses this new constructor in a test where it can make the
test more concise.