### PR TITLE
Fix namespace in arcs/xform_to_datalog code

### DIFF
--- a/src/frontends/arcs/xform_to_datalog/authorization_logic.cc
+++ b/src/frontends/arcs/xform_to_datalog/authorization_logic.cc
@@ -40,7 +40,7 @@ extern "C" int generate_datalog_facts_from_authorization_logic(
 
 #endif
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 int GenerateDatalogFactsFromAuthorizationLogic(
     absl::string_view program, const std::filesystem::path& program_dir,
@@ -77,4 +77,4 @@ int GenerateDatalogFactsFromAuthorizationLogic(
 #endif
 }
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog

--- a/src/frontends/arcs/xform_to_datalog/authorization_logic.h
+++ b/src/frontends/arcs/xform_to_datalog/authorization_logic.h
@@ -20,7 +20,7 @@
 
 #include "absl/strings/string_view.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 int GenerateDatalogFactsFromAuthorizationLogic(
     absl::string_view program,

--- a/src/frontends/arcs/xform_to_datalog/authorization_logic_datalog_facts.cc
+++ b/src/frontends/arcs/xform_to_datalog/authorization_logic_datalog_facts.cc
@@ -26,7 +26,7 @@
 #include "src/common/logging/logging.h"
 #include "src/frontends/arcs/xform_to_datalog/authorization_logic.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 std::optional<AuthorizationLogicDatalogFacts>
 AuthorizationLogicDatalogFacts::create(const std::filesystem::path &program_dir,
@@ -82,4 +82,4 @@ AuthorizationLogicDatalogFacts::create(const std::filesystem::path &program_dir,
   return AuthorizationLogicDatalogFacts(datalog_program);
 }
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog

--- a/src/frontends/arcs/xform_to_datalog/authorization_logic_datalog_facts.h
+++ b/src/frontends/arcs/xform_to_datalog/authorization_logic_datalog_facts.h
@@ -22,7 +22,7 @@
 
 #include "absl/strings/string_view.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 class AuthorizationLogicDatalogFacts {
  public:
@@ -45,6 +45,6 @@ class AuthorizationLogicDatalogFacts {
   std::string datalog_facts_;
 };
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog
 
 #endif  // SRC_FRONTENDS_ARCS_XFORM_TO_DATALOG_AUTHORIZATION_LOGIC_DATALOG_FACTS_H_

--- a/src/frontends/arcs/xform_to_datalog/authorization_logic_datalog_facts_test.cc
+++ b/src/frontends/arcs/xform_to_datalog/authorization_logic_datalog_facts_test.cc
@@ -28,7 +28,7 @@
 
 namespace fs = std::filesystem;
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 // If authorization logic is disabled, just run a single, always-true dummy
 // test.
@@ -76,4 +76,4 @@ TEST(AuthorizationLogicDatalogFactsTest, InvalidFileReturnsNullOpt) {
 
 #endif
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog

--- a/src/frontends/arcs/xform_to_datalog/authorization_logic_test.cc
+++ b/src/frontends/arcs/xform_to_datalog/authorization_logic_test.cc
@@ -23,7 +23,7 @@
 #include "src/common/testing/gtest.h"
 #include "src/common/utils/test/utils.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 namespace fs = std::filesystem;
 
@@ -82,4 +82,4 @@ TEST(AuthorizationLogicTest, ErrorsInRustToolReturnsNonZeroValue) {
 
 #endif
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog

--- a/src/frontends/arcs/xform_to_datalog/datalog_facts.h
+++ b/src/frontends/arcs/xform_to_datalog/datalog_facts.h
@@ -28,7 +28,7 @@
 #include "src/frontends/arcs/xform_to_datalog/manifest_datalog_facts.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 // A utility class that is used to generate a datalog program by combining
 // datalog facts from different sources and adding the necessary headers.
@@ -88,6 +88,6 @@ saysWill(w, x, y) :- says_will(w, x, y).
 )";
 };
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog
 
 #endif  // SRC_FRONTENDS_ARCS_XFORM_TO_DATALOG_DATALOG_FACTS_H_

--- a/src/frontends/arcs/xform_to_datalog/datalog_facts_test.cc
+++ b/src/frontends/arcs/xform_to_datalog/datalog_facts_test.cc
@@ -21,7 +21,7 @@
 #include "src/frontends/arcs/xform_to_datalog/authorization_logic_datalog_facts.h"
 #include "src/frontends/arcs/xform_to_datalog/manifest_datalog_facts.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 // If authorization logic is disabled, just run a single, always-true dummy
 // test.
@@ -42,24 +42,21 @@ TEST_P(DatalogFactsTest, IncludesManifestFactsWithCorrectPrefixAndSuffix) {
   const auto &[manifest_datalog_facts, auth_logic_datalog_facts,
                expected_string] = GetParam();
   DatalogFacts datalog_facts(manifest_datalog_facts, auth_logic_datalog_facts);
-  arcs::DatalogPrintContext ctxt;
+  DatalogPrintContext ctxt;
   EXPECT_EQ(datalog_facts.ToDatalog(ctxt), expected_string);
 }
 
-static std::unique_ptr<arcs::ParticleSpec> particle_spec(
-    arcs::ParticleSpec::Create(
-        "particle",
-        /*checks=*/{},
-        /*tag_claims=*/
-        {arcs::TagClaim(
-            "particle",
-            arcs::AccessPath(
-                arcs::AccessPathRoot(arcs::HandleConnectionAccessPathRoot(
-                    "recipe", "particle", "out")),
-                ir::AccessPathSelectors()),
-            true, "tag")},
-        /*derives_from_claims=*/{},
-        /*edges=*/{}));
+static std::unique_ptr<ParticleSpec> particle_spec(ParticleSpec::Create(
+    "particle",
+    /*checks=*/{},
+    /*tag_claims=*/
+    {TagClaim("particle",
+              AccessPath(AccessPathRoot(HandleConnectionAccessPathRoot(
+                             "recipe", "particle", "out")),
+                         ir::AccessPathSelectors()),
+              true, "tag")},
+    /*derives_from_claims=*/{},
+    /*edges=*/{}));
 
 INSTANTIATE_TEST_SUITE_P(
     DatalogFactsTest, DatalogFactsTest,
@@ -177,4 +174,4 @@ says_isSomeType("prin1", "foo").
 
 #endif
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog

--- a/src/frontends/arcs/xform_to_datalog/generate_datalog_program.cc
+++ b/src/frontends/arcs/xform_to_datalog/generate_datalog_program.cc
@@ -42,9 +42,9 @@ ABSL_FLAG(bool, overwrite, false,
 constexpr char kUsageMessage[] =
     "This tool takes a manifest proto and generates a datalog program.";
 
-using ManifestDatalogFacts = raksha::xform_to_datalog::ManifestDatalogFacts;
+using ManifestDatalogFacts = raksha::frontends::arcs::xform_to_datalog::ManifestDatalogFacts;
 using AuthorizationLogicDatalogFacts =
-    raksha::xform_to_datalog::AuthorizationLogicDatalogFacts;
+    raksha::frontends::arcs::xform_to_datalog::AuthorizationLogicDatalogFacts;
 
 int main(int argc, char *argv[]) {
   google::InitGoogleLogging("generate_datalog_program");
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  auto datalog_facts = raksha::xform_to_datalog::DatalogFacts(
+  auto datalog_facts = raksha::frontends::arcs::xform_to_datalog::DatalogFacts(
       manifest_datalog_facts, *auth_logic_datalog_facts);
 
   std::ofstream datalog_file(

--- a/src/frontends/arcs/xform_to_datalog/manifest_datalog_facts.cc
+++ b/src/frontends/arcs/xform_to_datalog/manifest_datalog_facts.cc
@@ -22,7 +22,7 @@
 #include "src/ir/types/proto/type.h"
 #include "src/ir/types/type_factory.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 namespace arcs = frontends::arcs;
 namespace types = raksha::ir::types;
@@ -174,4 +174,4 @@ ManifestDatalogFacts ManifestDatalogFacts::CreateFromManifestProto(
   return ManifestDatalogFacts(std::move(particle_instances));
 }
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog

--- a/src/frontends/arcs/xform_to_datalog/manifest_datalog_facts.h
+++ b/src/frontends/arcs/xform_to_datalog/manifest_datalog_facts.h
@@ -29,7 +29,7 @@
 #include "src/ir/types/type_factory.h"
 #include "third_party/arcs/proto/manifest.pb.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 class ManifestDatalogFacts {
  public:
@@ -64,7 +64,7 @@ class ManifestDatalogFacts {
   static ManifestDatalogFacts CreateFromManifestProto(
       ir::types::TypeFactory &type_factory,
       const frontends::arcs::SystemSpec &system_spec,
-      const arcs::ManifestProto &manifest_proto);
+      const ::arcs::ManifestProto &manifest_proto);
 
   // A default constructor creates a sensible, legal state (no facts) and
   // allows a bit more flexibility in constructing objects within which
@@ -122,6 +122,6 @@ class ManifestDatalogFacts {
   std::vector<Particle> particle_instances_;
 };
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog
 
 #endif  // SRC_FRONTENDS_ARCS_XFORM_TO_DATALOG_MANIFEST_DATALOG_FACTS_H_

--- a/src/frontends/arcs/xform_to_datalog/manifest_datalog_facts_test.cc
+++ b/src/frontends/arcs/xform_to_datalog/manifest_datalog_facts_test.cc
@@ -25,7 +25,7 @@
 #include "src/frontends/arcs/proto/system_spec.h"
 #include "src/ir/types/primitive_type.h"
 
-namespace raksha::xform_to_datalog {
+namespace raksha::frontends::arcs::xform_to_datalog {
 
 namespace arcs = frontends::arcs;
 
@@ -436,4 +436,4 @@ TEST_F(ParseBigManifestTest, ManifestProtoEdgesTest) {
               testing::UnorderedElementsAreArray(kExpectedEdgeStrings));
 }
 
-}  // namespace raksha::xform_to_datalog
+}  // namespace raksha::frontends::arcs::xform_to_datalog


### PR DESCRIPTION
When manually merging #537 using copybara, we skipped the github CI tests. :( 