### PR TITLE
Add constructors for the SQL operations.

### DIFF
--- a/src/frontends/sql/ops/literal_op.cc
+++ b/src/frontends/sql/ops/literal_op.cc
@@ -26,17 +26,15 @@
 
 namespace raksha::frontends::sql {
 
-std::unique_ptr<LiteralOp> LiteralOp::Create(const ir::Block* parent_block,
-                                             const ir::IRContext& context,
-                                             absl::string_view literal) {
-  return std::make_unique<LiteralOp>(
-      parent_block, *CHECK_NOTNULL(SqlOp::GetOperator<LiteralOp>(context)),
-      ir::NamedAttributeMap(
-          {{std::string(kLiteralStringAttrName),
-            ir::Attribute::Create<ir::StringAttribute>(literal)}}),
-      ir::ValueList({}),
-      /*impl_module=*/nullptr);
-}
+LiteralOp::LiteralOp(const ir::Block* parent_block,
+                     const ir::IRContext& context, absl::string_view literal)
+    : SqlOp(parent_block,
+            *CHECK_NOTNULL(SqlOp::GetOperator<LiteralOp>(context)),
+            ir::NamedAttributeMap(
+                {{std::string(kLiteralStringAttrName),
+                  ir::Attribute::Create<ir::StringAttribute>(literal)}}),
+            ir::ValueList({}),
+            /*impl_module=*/nullptr) {}
 
 absl::string_view LiteralOp::GetLiteralString() const {
   auto find_result = attributes().find(kLiteralStringAttrName);

--- a/src/frontends/sql/ops/literal_op.h
+++ b/src/frontends/sql/ops/literal_op.h
@@ -29,16 +29,17 @@ class LiteralOp : public SqlOp {
   static constexpr absl::string_view kLiteralStringAttrName = "literal_string";
 
   // Constructs a LiteralOp.
+  LiteralOp(const ir::Block* parent_block, const ir::IRContext& context,
+            absl::string_view literal);
+
   static std::unique_ptr<LiteralOp> Create(const ir::Block* parent_block,
                                            const ir::IRContext& context,
-                                           absl::string_view literal);
+                                           absl::string_view literal) {
+    return std::make_unique<LiteralOp>(parent_block, context, literal);
+  }
 
   // Returns the literal string associated with the operation.
   absl::string_view GetLiteralString() const;
-
- private:
-  // Inherit constructors.
-  using SqlOp::SqlOp;
 };
 
 }  // namespace raksha::frontends::sql

--- a/src/frontends/sql/ops/literal_op_test.cc
+++ b/src/frontends/sql/ops/literal_op_test.cc
@@ -40,5 +40,19 @@ TEST(LiteralOpTest, FactoryMethodCreatesCorrectOperation) {
                   ir::Attribute::Create<ir::StringAttribute>("hello"))));
 }
 
+static const ir::IRContext kContext({ir::Operator(OpTraits<LiteralOp>::kName)},
+                                    {});
+static LiteralOp kGlobalLiteralOp(nullptr, kContext, "hello");
+
+TEST(LiteralOpTest, CtorCreatesCorrectOperation) {
+  EXPECT_EQ(kGlobalLiteralOp.op().name(), OpTraits<LiteralOp>::kName);
+  EXPECT_EQ(kGlobalLiteralOp.parent(), nullptr);
+  EXPECT_TRUE(kGlobalLiteralOp.inputs().empty());
+  EXPECT_THAT(kGlobalLiteralOp.attributes(),
+              testing::UnorderedElementsAre(testing::Pair(
+                  std::string(LiteralOp::kLiteralStringAttrName),
+                  ir::Attribute::Create<ir::StringAttribute>("hello"))));
+}
+
 }  // namespace
 }  // namespace raksha::frontends::sql

--- a/src/frontends/sql/ops/merge_op.h
+++ b/src/frontends/sql/ops/merge_op.h
@@ -37,10 +37,17 @@ class MergeOp : public SqlOp {
       "control_input_start_index";
 
   // Constructs a MergeOp.
+  MergeOp(const ir::Block* parent_block, const ir::IRContext& context,
+          ir::ValueList direct_inputs, ir::ValueList control_inputs);
+
   static std::unique_ptr<MergeOp> Create(const ir::Block* parent_block,
                                          const ir::IRContext& context,
                                          ir::ValueList direct_inputs,
-                                         ir::ValueList control_inputs);
+                                         ir::ValueList control_inputs) {
+    return std::make_unique<MergeOp>(parent_block, context,
+                                     std::move(direct_inputs),
+                                     std::move(control_inputs));
+  }
 
   // Returns an iterator range for the direct inputs.
   ir::ValueRange GetDirectInputs() const;
@@ -50,10 +57,6 @@ class MergeOp : public SqlOp {
 
   // Returns the index where the control inputs start.
   size_t GetControlInputStartIndex() const;
-
- private:
-  // Inherit constructors.
-  using SqlOp::SqlOp;
 };
 
 }  // namespace raksha::frontends::sql

--- a/src/frontends/sql/ops/merge_op_test.cc
+++ b/src/frontends/sql/ops/merge_op_test.cc
@@ -65,6 +65,27 @@ TEST_P(MergeOpTest, FactoryMethodCreatesCorrectOperation) {
                   ir::Attribute::Create<ir::Int64Attribute>(inputs.size()))));
 }
 
+TEST_P(MergeOpTest, CtorCreatesCorrectOperation) {
+  const auto& [inputs, controls] = GetParam();
+  // It is rare for the assignment to lose precision.
+  // Even if it does, the test will most certainly fail.
+  int64_t control_start_index = inputs.size();
+
+  MergeOp op(nullptr, context_, inputs, controls);
+  EXPECT_EQ(op.op().name(), OpTraits<MergeOp>::kName);
+  EXPECT_EQ(op.parent(), nullptr);
+  EXPECT_THAT(utils::make_range(op.inputs().begin(),
+                                op.inputs().begin() + control_start_index),
+              ElementsAreArray(inputs));
+  EXPECT_THAT(utils::make_range(op.inputs().begin() + control_start_index,
+                                op.inputs().end()),
+              ElementsAreArray(controls));
+  EXPECT_THAT(op.attributes(),
+              UnorderedElementsAre(Pair(
+                  std::string(MergeOp::kControlInputStartIndex),
+                  ir::Attribute::Create<ir::Int64Attribute>(inputs.size()))));
+}
+
 TEST_P(MergeOpTest, EnsureInputsAndEmptyInParamAreNotEmptySimultaneously) {
   const auto& [inputs, controls] = GetParam();
   // This will cause failures which is tested in a separate death test.

--- a/src/frontends/sql/ops/tag_transform_op.h
+++ b/src/frontends/sql/ops/tag_transform_op.h
@@ -30,10 +30,18 @@ class TagTransformOp : public SqlOp {
       "sql.tag_transform.rule_name";
 
   // Constructs a TagTransformOp.
-  static std::unique_ptr<TagTransformOp> Create(
+  TagTransformOp(
       const ir::Block* parent_block, const ir::IRContext& context,
       absl::string_view rule_name, ir::Value transformed_value,
       const std::vector<std::pair<std::string, ir::Value>>& preconditions);
+
+  static std::unique_ptr<TagTransformOp> Create(
+      const ir::Block* parent_block, const ir::IRContext& context,
+      absl::string_view rule_name, ir::Value transformed_value,
+      const std::vector<std::pair<std::string, ir::Value>>& preconditions) {
+    return std::make_unique<TagTransformOp>(parent_block, context, rule_name,
+                                            transformed_value, preconditions);
+  }
 
   // Returns the value that is being tranformed by this op.
   ir::Value GetTransformedValue() const;
@@ -42,10 +50,6 @@ class TagTransformOp : public SqlOp {
   absl::flat_hash_map<std::string, ir::Value> GetPreconditions() const;
 
   absl::string_view GetRuleName() const;
-
- private:
-  // Inherit constructors.
-  using SqlOp::SqlOp;
 };
 
 }  // namespace raksha::frontends::sql


### PR DESCRIPTION
This commit adds constructors to the SQL operations that allow these
operations to be built more easily at the static scope for tests. The
existing `Create` methods are defined in terms of these constructors.

Note for reviewers: see comment in MergeOp, would be interested in
feedback on how to make that better.