### PR TITLE
Make IRPrinter:PrintNamedMapOrder public

### DIFF
--- a/src/ir/ir_printer.h
+++ b/src/ir/ir_printer.h
@@ -106,11 +106,6 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     }
   }
 
- private:
-  std::string Indent() { return std::string(indent_ * 2, ' '); }
-  void IncreaseIndent() { ++indent_; }
-  void DecreaseIndent() { --indent_; }
-
   // Returns a pretty-printed map where entries are sorted by the key.
   template <class T, class F>
   static std::string PrintNamedMapInNameOrder(
@@ -128,6 +123,11 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
                           value_pretty_printer(map_to_print.at(name)));
         });
   }
+
+ private:
+  std::string Indent() { return std::string(indent_ * 2, ' '); }
+  void IncreaseIndent() { ++indent_; }
+  void DecreaseIndent() { --indent_; }
 
   IRPrinter(std::ostream& out) : out_(out), indent_(0) {}
 

--- a/src/ir/ir_printer_test.cc
+++ b/src/ir/ir_printer_test.cc
@@ -121,5 +121,17 @@ TEST_P(IRPrinterTest, PrettyPrintAttributesInSortedOrder) {
       "%0 = core.minus [access: private, name: addition](<<ANY>>, <<ANY>>)\n");
 }
 
+TEST(IRPrinterPrintNamedMapOrderTest, PrintsInSortedOrder) {
+  absl::flat_hash_map<std::string, int> values = {
+      {"zip", -1},
+      {"hello", 1},
+      {"world", 2},
+      {"number_42", 42},
+  };
+  EXPECT_THAT(IRPrinter::PrintNamedMapInNameOrder(
+                  values, [](int x) { return absl::StrFormat("%d", x); }),
+              "hello: 1, number_42: 42, world: 2, zip: -1");
+}
+
 }  // namespace
 }  // namespace raksha::ir


### PR DESCRIPTION
This is useful in some other PRs related to dot generation.