### PR TITLE
Tweaks to datalog Attribute API to reduce verbosity.

### DIFF
--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor.cc
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor.cc
@@ -36,19 +36,17 @@ using DatalogOperandList = ir::datalog::OperandList;
 using DatalogIsOperationFact = ir::datalog::IsOperationFact;
 using DatalogAttribute = ir::datalog::Attribute;
 using DatalogAttributePayload = ir::datalog::AttributePayload;
-using DatalogStringAttributePayload = ir::datalog::StringAttributePayload;
-using DatalogNumberAttributePayload = ir::datalog::NumberAttributePayload;
 
 static DatalogAttributePayload GetPayloadForAttribute(ir::Attribute attr,
                                                       ir::SsaNames &ssa_names) {
   if (auto int_attr = attr.GetIf<ir::Int64Attribute>()) {
-    return DatalogNumberAttributePayload(DatalogNumber(int_attr->value()));
+    return DatalogAttribute::Number(int_attr->value());
   } else if (auto string_attr = attr.GetIf<ir::StringAttribute>()) {
-    return DatalogStringAttributePayload(DatalogSymbol(string_attr->value()));
+    return DatalogAttribute::String(string_attr->value());
   }
   LOG(FATAL) << "Unknown attribute kind.";
   // Unreachable, just to placate compiler.
-  return DatalogStringAttributePayload(DatalogSymbol(""));
+  return DatalogAttribute::String("");
 }
 
 void DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
@@ -76,7 +74,7 @@ void DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
       [&ssa_names](DatalogAttributeList list_so_far,
                    std::pair<std::string, ir::Attribute> name_attr_pair) {
         return DatalogAttributeList(
-            DatalogAttribute(DatalogSymbol(std::move(name_attr_pair.first)),
+            DatalogAttribute(std::move(name_attr_pair.first),
                              GetPayloadForAttribute(
                                  std::move(name_attr_pair.second), ssa_names)),
             std::move(list_so_far));

--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor_test.cc
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor_test.cc
@@ -88,9 +88,8 @@ static const IrAndDatalogOperationPairs kIrAndDatalogOperations[] = {
          ir::datalog::Symbol("sql"), ir::datalog::Symbol("sql.ReadLiteral"),
          ir::datalog::Symbol("%0.out"), ir::datalog::OperandList(),
          ir::datalog::AttributeList(
-             ir::datalog::Attribute(ir::datalog::Symbol("literal"),
-                                    ir::datalog::StringAttributePayload(
-                                        ir::datalog::Symbol("number_5"))),
+             ir::datalog::Attribute("literal",
+                                    ir::datalog::Attribute::String("number_5")),
              ir::datalog::AttributeList()))},
     {.ir_operation = test_factory.CreateOperation(
          nullptr, kMergeOpOperator, ir::NamedAttributeMap({}),

--- a/src/ir/datalog/BUILD
+++ b/src/ir/datalog/BUILD
@@ -58,15 +58,33 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "attribute",
+    hdrs = ["attribute.h"],
+    deps = [
+        ":value",
+        "@absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "attribute_test",
+    srcs = ["attribute_test.cc"],
+    deps = [
+        ":attribute",
+        "//src/common/testing:gtest",
+    ],
+)
+
 # The interface to the Raksha analysis, as described by the C++ version of the
 # Datalog relations that are input/output relations.
 cc_library(
     name = "raksha_relation_interface",
     hdrs = [
-        "attribute.h",
         "operation.h",
     ],
     deps = [
+        ":attribute",
         ":input_relation_fact",
         ":value",
         "//src/common/logging",

--- a/src/ir/datalog/attribute.h
+++ b/src/ir/datalog/attribute.h
@@ -24,34 +24,41 @@
 
 namespace raksha::ir::datalog {
 
-inline constexpr absl::string_view kStringAttributePayloadName =
-    "StringAttributePayload";
-inline constexpr absl::string_view kNumberAttributePayloadName =
-    "NumberAttributePayload";
+using AttributePayload = Adt;
 
-class AttributePayload : public Adt {
+class Attribute
+    : public Record<Symbol /*attr_name*/, AttributePayload /*attr_payload*/> {
  public:
-  using Adt::Adt;
-};
+  explicit Attribute(absl::string_view name, AttributePayload payload)
+      : Record(Symbol(name), std::move(payload)) {}
 
-class StringAttributePayload : public AttributePayload {
- public:
-  StringAttributePayload(Symbol symbol)
-      : AttributePayload(kStringAttributePayloadName) {
-    arguments_.push_back(std::make_unique<Symbol>(symbol));
-  }
-};
+  class String : public AttributePayload {
+   public:
+    explicit String(Symbol symbol)
+        : AttributePayload(kStringAttributePayloadName) {
+      arguments_.push_back(std::make_unique<Symbol>(symbol));
+    }
 
-class NumberAttributePayload : public AttributePayload {
- public:
-  NumberAttributePayload(Number number)
-      : AttributePayload(kNumberAttributePayloadName) {
-    arguments_.push_back(std::make_unique<Number>(number));
-  }
-};
+    explicit String(absl::string_view symbol) : String(Symbol(symbol)) {}
+  };
 
-using Attribute =
-    Record<Symbol /*attr_name*/, AttributePayload /*attr_payload*/>;
+  class Number : public AttributePayload {
+   public:
+    explicit Number(datalog::Number number)
+        : AttributePayload(kNumberAttributePayloadName) {
+      // NOTE: unique_ptr<datalog::Number> and **not** unique_ptr<Number>!
+      arguments_.push_back(std::make_unique<datalog::Number>(number));
+    }
+
+    explicit Number(int64_t number) : Number(datalog::Number(number)) {}
+  };
+
+ private:
+  static constexpr absl::string_view kStringAttributePayloadName =
+      "StringAttributePayload";
+  static constexpr absl::string_view kNumberAttributePayloadName =
+      "NumberAttributePayload";
+};
 
 class AttributeList
     : public Record<Attribute /*attr*/, AttributeList /*next*/> {

--- a/src/ir/datalog/attribute.h
+++ b/src/ir/datalog/attribute.h
@@ -36,7 +36,7 @@ class Attribute
    public:
     explicit String(Symbol symbol)
         : AttributePayload(kStringAttributePayloadName) {
-      arguments_.push_back(std::make_unique<Symbol>(symbol));
+      arguments_.push_back(std::make_unique<Symbol>(std::move(symbol)));
     }
 
     explicit String(absl::string_view symbol) : String(Symbol(symbol)) {}
@@ -47,7 +47,8 @@ class Attribute
     explicit Number(datalog::Number number)
         : AttributePayload(kNumberAttributePayloadName) {
       // NOTE: unique_ptr<datalog::Number> and **not** unique_ptr<Number>!
-      arguments_.push_back(std::make_unique<datalog::Number>(number));
+      arguments_.push_back(
+          std::make_unique<datalog::Number>(std::move(number)));
     }
 
     explicit Number(int64_t number) : Number(datalog::Number(number)) {}

--- a/src/ir/datalog/attribute_test.cc
+++ b/src/ir/datalog/attribute_test.cc
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#include "src/ir/datalog/attribute.h"
+
+// #include "absl/strings/string_view.h"
+#include "attribute.h"
+#include "src/common/testing/gtest.h"
+
+namespace raksha::ir::datalog {
+
+using testing::Combine;
+using testing::TestWithParam;
+using testing::ValuesIn;
+
+TEST(AttributeTest, NumberPayloadConstruction) {
+  EXPECT_EQ(Attribute::Number(10).ToDatalogString(),
+            "$NumberAttributePayload{10}");
+  EXPECT_EQ(Attribute::Number(Number(42)).ToDatalogString(),
+            "$NumberAttributePayload{42}");
+}
+TEST(AttributeTest, StringPayloadConstruction) {
+  EXPECT_EQ(Attribute::String("hello world").ToDatalogString(),
+            R"($StringAttributePayload{"hello world"})");
+  EXPECT_EQ(Attribute::String(Symbol("42")).ToDatalogString(),
+            R"($StringAttributePayload{"42"})");
+}
+
+TEST(AttributeTest, AttributeConstructionTest) {
+  EXPECT_EQ(
+      Attribute("name", Attribute::String("hello world")).ToDatalogString(),
+      R"(["name", $StringAttributePayload{"hello world"}])");
+  EXPECT_EQ(Attribute("answer_for_everything", Attribute::Number(42))
+                .ToDatalogString(),
+            R"(["answer_for_everything", $NumberAttributePayload{42}])");
+}
+
+}  // namespace raksha::ir::datalog

--- a/src/ir/datalog/attribute_test.cc
+++ b/src/ir/datalog/attribute_test.cc
@@ -28,24 +28,24 @@ using testing::ValuesIn;
 
 TEST(AttributeTest, NumberPayloadConstruction) {
   EXPECT_EQ(Attribute::Number(10).ToDatalogString(),
-            "$NumberAttributePayload{10}");
+            "$NumberAttributePayload(10)");
   EXPECT_EQ(Attribute::Number(Number(42)).ToDatalogString(),
-            "$NumberAttributePayload{42}");
+            "$NumberAttributePayload(42)");
 }
 TEST(AttributeTest, StringPayloadConstruction) {
   EXPECT_EQ(Attribute::String("hello world").ToDatalogString(),
-            R"($StringAttributePayload{"hello world"})");
+            R"($StringAttributePayload("hello world"))");
   EXPECT_EQ(Attribute::String(Symbol("42")).ToDatalogString(),
-            R"($StringAttributePayload{"42"})");
+            R"($StringAttributePayload("42"))");
 }
 
 TEST(AttributeTest, AttributeConstructionTest) {
   EXPECT_EQ(
       Attribute("name", Attribute::String("hello world")).ToDatalogString(),
-      R"(["name", $StringAttributePayload{"hello world"}])");
+      R"(["name", $StringAttributePayload("hello world")])");
   EXPECT_EQ(Attribute("answer_for_everything", Attribute::Number(42))
                 .ToDatalogString(),
-            R"(["answer_for_everything", $NumberAttributePayload{42}])");
+            R"(["answer_for_everything", $NumberAttributePayload(42)])");
 }
 
 }  // namespace raksha::ir::datalog

--- a/src/ir/datalog/operation_test.cc
+++ b/src/ir/datalog/operation_test.cc
@@ -42,10 +42,8 @@ TEST_P(IsOperationFactTest, IsOperationFactTest) {
 
 static const IsOperationFact kSampleFact1 = IsOperationFact(Operation(
     Symbol("UserA"), Symbol("sql.Literal"), Symbol("out"), OperandList(),
-    AttributeList(
-        Attribute(Symbol("literal_value"),
-                  AttributePayload(StringAttributePayload(Symbol("number_5")))),
-        AttributeList())));
+    AttributeList(Attribute("literal_value", Attribute::String("number_5")),
+                  AttributeList())));
 
 static const IsOperationFact kSampleFact2 = IsOperationFact(Operation(
     Symbol("UserB"), Symbol("sql.MergeOp"), Symbol("out"),


### PR DESCRIPTION
This PR does some minor tweaks to reduce verbosity when defining attributes. This also adds a unit test.