### PR TITLE
Calculate positional indices of operands to operations.

### DIFF
--- a/src/analysis/souffle/operations.dl
+++ b/src/analysis/souffle/operations.dl
@@ -48,11 +48,32 @@ operationToPartialOperandLists([owner, op, result, operandList, attrs], operandL
 operationToPartialOperandLists(operation, tail) :-
   operationToPartialOperandLists(operation, [_, tail]).
 
-// Map full operations to operands.
-.decl operationToOperands(operation:Operation, operand: AccessPath)
+// `listLength` is the length of the `operandList`.
+.decl operandListLength(operandList: OperandList, listLength: number)
 
-operationToOperands(operation, operand) :-
-  isOperation(operation), operationToPartialOperandLists(operation, [operand, _]).
+operandListLength(nil, 0).
+operandListLength([head, tail], tailLen + 1) :-
+  operationToPartialOperandLists(_, [head, tail]), operandListLength(tail, tailLen).
+
+// `operandListLength` is the length of the `operandList` on the given
+// `operation`.
+.decl operationOperandListLength(operation: Operation, operandListLength: number)
+
+operationOperandListLength([owner, operator, result, operandList, attrs], len) :-
+  isOperation([owner, operator, result, operandList, attrs]),
+  operandListLength(operandList, len).
+
+// True when an `operation` has the given `operand` at the indicated `index` in
+// its `operandList`.
+.decl operationHasOperandAtIndex(operation: Operation, operand: AccessPath, index: number)
+
+// To find the index of an operand in an operation, find the sublist that it is
+// the head of in the operation, find the length of that list, and subtract it
+// from the overall length of the operand list in the operation.
+operationHasOperandAtIndex(operation, operand, opListLen - suffixListLen) :-
+  operationToPartialOperandLists(operation, [operand, tail]),
+  operandListLength([operand, tail], suffixListLen),
+  operationOperandListLength(operation, opListLen).
 
 // A helper relation that produces all partial attribute lists of an
 // `Operation`.

--- a/src/analysis/souffle/operations.dl
+++ b/src/analysis/souffle/operations.dl
@@ -41,19 +41,19 @@ isOperation([owner, operator, result, [input1, [input2, nil]], attrs])
 
 // Explode the operand lists so that we can extract the heads of each sublist
 // to get a mapping from operations to their operands.
-.decl operationToPartialOperandLists(operation: Operation, partialList: OperandList)
+.decl operationHasOperandListSuffix(operation: Operation, partialList: OperandList)
 
-operationToPartialOperandLists([owner, op, result, operandList, attrs], operandList) :-
+operationHasOperandListSuffix([owner, op, result, operandList, attrs], operandList) :-
   isOperation([owner, op, result, operandList, attrs]).
-operationToPartialOperandLists(operation, tail) :-
-  operationToPartialOperandLists(operation, [_, tail]).
+operationHasOperandListSuffix(operation, tail) :-
+  operationHasOperandListSuffix(operation, [_, tail]).
 
 // `listLength` is the length of the `operandList`.
 .decl operandListLength(operandList: OperandList, listLength: number)
 
 operandListLength(nil, 0).
 operandListLength([head, tail], tailLen + 1) :-
-  operationToPartialOperandLists(_, [head, tail]), operandListLength(tail, tailLen).
+  operationHasOperandListSuffix(_, [head, tail]), operandListLength(tail, tailLen).
 
 // `operandListLength` is the length of the `operandList` on the given
 // `operation`.
@@ -71,20 +71,20 @@ operationOperandListLength([owner, operator, result, operandList, attrs], len) :
 // the head of in the operation, find the length of that list, and subtract it
 // from the overall length of the operand list in the operation.
 operationHasOperandAtIndex(operation, operand, opListLen - suffixListLen) :-
-  operationToPartialOperandLists(operation, [operand, tail]),
+  operationHasOperandListSuffix(operation, [operand, tail]),
   operandListLength([operand, tail], suffixListLen),
   operationOperandListLength(operation, opListLen).
 
 // A helper relation that produces all partial attribute lists of an
 // `Operation`.
-.decl operationToPartialAttributeLists(operation: Operation, attributes: AttributeList)
-operationToPartialAttributeLists([owner, op, result, operandList, attrs], attrs) :-
+.decl operationHasAttributeListSuffix(operation: Operation, attributes: AttributeList)
+operationHasAttributeListSuffix([owner, op, result, operandList, attrs], attrs) :-
   isOperation([owner, op, result, operandList, attrs]).
-operationToPartialAttributeLists(op, tail) :- operationToPartialAttributeLists(op, [_, tail]).
+operationHasAttributeListSuffix(op, tail) :- operationHasAttributeListSuffix(op, [_, tail]).
 
 // A mapping from an `Operation` to each individual `Attribute` on that
 // `Operation`.
-.decl operationToAttribute(op: Operation, attr: Attribute)
-operationToAttribute(op, attr) :- operationToPartialAttributeLists(op, [attr, _]).
+.decl operationHasAttribute(op: Operation, attr: Attribute)
+operationHasAttribute(op, attr) :- operationHasAttributeListSuffix(op, [attr, _]).
 
 #endif // SRC_ANALYSIS_SOUFFLE_OPERATIONS_DL_

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -85,7 +85,7 @@
 //-----------------------------------------------------------------------------
 
 // Draw an edge from any operation's operand to its result.
-resolvedEdge(owner, src, tgt) :- operationToOperands([owner, _, tgt, _, _], src).
+resolvedEdge(owner, src, tgt) :- operationHasOperandAtIndex([owner, _, tgt, _, _], src,  _).
 
 // For all operations other than `=`, draw an edge from the special
 // "ArbitraryComputation" `AccessPath` to the result. This prevents default

--- a/src/analysis/souffle/tests/arcs_fact_tests/find_operations_by_attributes.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/find_operations_by_attributes.dl
@@ -50,7 +50,7 @@ isOperation(["owner", "op1", "result7", nil, [["attr3", PAYLOAD2], nil]]).
   result: AccessPath, attrName: AttributeName, payload: AttributePayload)
 
 resultToAttrNameAndPayload(result, attrName, payload) :-
-  operationToAttribute([_, _, result, _, _], [attrName, payload]).
+  operationHasAttribute([_, _, result, _, _], [attrName, payload]).
 
 .decl expectedResultToAttrNameAndPayload(
   result: AccessPath, attrName: AttributeName, payload: AttributePayload)

--- a/src/analysis/souffle/tests/arcs_fact_tests/operand_index_unit_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/operand_index_unit_test.dl
@@ -1,0 +1,38 @@
+#include "src/analysis/souffle/taint.dl"
+#include "src/analysis/souffle/fact_test_helper.dl"
+
+#define NO_OPERAND_OP ["someOwner", "op1", "result", nil, nil]
+
+isAccessPath("someOwner").
+isAccessPath("result").
+
+isOperation(NO_OPERAND_OP).
+
+TEST_CASE("no_indexed_operands_for_no_operand_operation") :-
+  count : { operationHasOperandAtIndex(NO_OPERAND_OP, _, _) } = 0.
+
+#define ONE_OPERAND_OP ["owner", "op2", "result2", ["path1", nil], nil]
+
+isAccessPath("result2").
+isAccessPath("path1").
+
+isOperation(ONE_OPERAND_OP).
+
+TEST_CASE("single_indexed_operand_is_path1") :-
+  operationHasOperandAtIndex(ONE_OPERAND_OP, "path1", 0),
+  count : { operationHasOperandAtIndex(ONE_OPERAND_OP, _, _) } = 1.
+
+#define MULTI_OPERAND_OP \
+  ["owner2", "op3", "result3", ["path2", ["path3", ["path2", nil] ] ], nil ]
+
+isAccessPath("path2").
+isAccessPath("path3").
+isAccessPath("result3").
+
+isOperation(MULTI_OPERAND_OP).
+
+TEST_CASE("multi_operand_op_has_correct_indexed_operands") :-
+  operationHasOperandAtIndex(MULTI_OPERAND_OP, "path2", 0),
+  operationHasOperandAtIndex(MULTI_OPERAND_OP, "path3", 1),
+  operationHasOperandAtIndex(MULTI_OPERAND_OP, "path2", 2),
+  count : { operationHasOperandAtIndex(MULTI_OPERAND_OP, _, _) } = 3.


### PR DESCRIPTION
Because lists in Souffle are just recursive linked-list structs, it is
not very natural to look up elements by index. For the tag transform
operation from the SQL verifier, however, we need to do exactly that.
This commit introduces `operationHasOperandAtIndex`, which enriches the
old `operationToOperands` relation by adding the position the operand
holds in the operation's `operandList`.