### PR TITLE
Separate `.input`/`.output` directives from regular datalog.

### DIFF
--- a/build_defs/test_helpers.bzl
+++ b/build_defs/test_helpers.bzl
@@ -130,11 +130,12 @@ def run_taint_exec_compare_check_results(
         outs = ["checkAndResult", "expectedCheckAndResult"],
         srcs = input_files,
         testonly = True,
-        cmd = ("$(location //src/analysis/souffle:taint_exec_test) --output=$(RULEDIR) {fact_dirs} && " +
+        cmd = ("$(location //src/analysis/souffle:tag_check_and_expectation_test) " +
+               "--output=$(RULEDIR) {fact_dirs} && " +
                "cp $(RULEDIR)/checkAndResult.csv $(location :checkAndResult) && " +
                "cp $(RULEDIR)/expectedCheckAndResult.csv $(location :expectedCheckAndResult)")
             .format(fact_dirs = " ".join(facts_dir_opts)),
-        tools = ["//src/analysis/souffle:taint_exec_test"],
+        tools = ["//src/analysis/souffle:tag_check_and_expectation_test"],
         visibility = visibility,
     )
 

--- a/src/analysis/souffle/BUILD
+++ b/src/analysis/souffle/BUILD
@@ -44,8 +44,8 @@ gen_souffle_cxx_code(
 )
 
 gen_souffle_cxx_code(
-    name = "taint_cxx_for_test",
-    src = "taint.dl",
+    name = "tag_check_and_expectation_for_test",
+    src = "tag_check_and_expectation_interface.dl",
     for_test = True,
     included_dl_scripts = [
         "attributes.dl",
@@ -54,18 +54,19 @@ gen_souffle_cxx_code(
         "dataflow_graph.dl",
         "operations.dl",
         "tags.dl",
+        "taint.dl",
     ],
+)
+
+souffle_cc_binary(
+    name = "tag_check_and_expectation_test",
+    testonly = True,
+    src = ":tag_check_and_expectation_for_test",
 )
 
 souffle_cc_library(
     name = "taint_dl",
     src = ":taint_cxx",
-)
-
-souffle_cc_binary(
-    name = "taint_exec_test",
-    testonly = True,
-    src = ":taint_cxx_for_test",
 )
 
 exports_files([

--- a/src/analysis/souffle/authorization_logic.dl
+++ b/src/analysis/souffle/authorization_logic.dl
@@ -46,7 +46,6 @@
 
 // The `speaker` says that `path` definitely has `tag` taint.
 .decl says_hasTag(speaker: Principal, path: AccessPath, owner: Principal, tag: Tag)
-.input says_hasTag(delimiter=";")
 
 //-----------------------------------------------------------------------------
 // Rules

--- a/src/analysis/souffle/check_predicate.dl
+++ b/src/analysis/souffle/check_predicate.dl
@@ -33,7 +33,6 @@
 
 // A check of some predicate on tags.
 .decl checkP(name: symbol, pred: CheckPredicate)
-.input checkP(delimiter=";")
 
 // Deconstruct all top-level check predicates to get subpredicates here.
 .decl checkSubExprs(pred: CheckPredicate)
@@ -58,7 +57,6 @@ predicateEval($CP_Implies(ant, cons), (lnot antResult) lor (antResult land consR
   predicateEval(cons, consResult).
 
 .decl checkAndResult(name: symbol, result: symbol)
-.output checkAndResult(delimiter=";")
 
 checkAndResult(name, "PASS") :- checkP(name, pred), predicateEval(pred, result), result != 0.
 
@@ -78,7 +76,6 @@ checkP(name, pred) :- checkAndExpectation(name, pred, _).
 // Produce a list of expected checkAndResults based upon the checks and
 // checkAndExpectations given to a test.
 .decl expectedCheckAndResult(name: symbol, result: symbol)
-.output expectedCheckAndResult(delimiter=";")
 
 // For checks listed in checkAndExpectation, grab the expectation directly from checkAndExpectation.
 expectedCheckAndResult(name, result) :- checkAndExpectation(name, _, result).

--- a/src/analysis/souffle/dataflow_graph.dl
+++ b/src/analysis/souffle/dataflow_graph.dl
@@ -36,11 +36,15 @@
 // A data flow edge. An edge is just a synonym for the `=` operator with `src`
 // as the one operand and `tgt` as the result.
 .decl edge(src: AccessPath, tgt: AccessPath)
-.input edge(delimiter=";")
 
 // Use the previous relations to map an edge to a generated access path
 // representing its midpoint.
 .decl edgeToMidpointAccessPath(src: AccessPath, tgt: AccessPath, midpoint: AccessPath)
+
+// Manifests can produce base facts of this form, where usually the principal
+// is a particle (and this fact is entered by a code reviewer with no knowledge
+// of the taint analysis).
+.decl claimNotEdge(principal: Principal, src: AccessPath, dst: AccessPath)
 
 // An "resolvedEdge" is an internal concept. When the user requests an edge with an
 // edge fact, we will expand that into resolvedEdges in one of two ways:

--- a/src/analysis/souffle/tag_check_and_expectation_interface.dl
+++ b/src/analysis/souffle/tag_check_and_expectation_interface.dl
@@ -1,0 +1,33 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#ifndef SRC_ANALYSIS_SOUFFLE_TAG_CHECK_AND_EXPECTATION_INTERFACE
+#define SRC_ANALYSIS_SOUFFLE_TAG_CHECK_AND_EXPECTATION_INTERFACE
+
+#include "src/analysis/souffle/taint.dl"
+
+// An interface used primarily for testing. Makes the analysis take as input
+// checks with expectations and `says_hasTag` facts, possibly with edges
+// connecting paths together. Outputs the `checkAndResult` and
+// `expectedCheckAndResult` relations.
+.input says_hasTag(delimiter=";")
+.input checkAndExpectation(delimiter=";")
+.input checkP(delimiter=";")
+.input edge(delimiter=";")
+.output checkAndResult(delimiter=";")
+.output expectedCheckAndResult(delimiter=";")
+
+#endif

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -54,11 +54,6 @@
 .decl says_isTag(prin: Principal, tag: Tag)
 .decl says_isPrincipal(prin1: Principal, prin2: Principal)
 
-// Manifests can produce base facts of this form, where usually the principal
-// is a particle (and this fact is entered by a code reviewer with no knowledge
-// of the taint analysis).
-.decl claimNotEdge(principal: Principal, src: AccessPath, dst: AccessPath)
-
 // Indicates that an integrity tag is directly applied to an AccessPath. This
 // rule should only be populated with base facts with no derivation to prevent
 // us from getting tangled up in stratification issues. Propagation will happen

--- a/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates_predicate_test/expected_results.csv
+++ b/src/analysis/souffle/tests/arcs_fact_tests/ok_claim_propagates_predicate_test/expected_results.csv
@@ -1,1 +1,0 @@
-userSelectionPresentOnP1;PASS


### PR DESCRIPTION
Souffle allows indicating that certain relations are `.input` or
`.output`. The analysis will expect facts to be provided at startup to
`.input` relations and shall output facts to the `.output` relations.

Before this commit, the `.input` and `.output` directives were scattered
through the regular Datalog files. This is a bad move, as the same
analysis datalog may input and output different facts when run in
different ways. For instance, the `.input` and `.output` relations
previously specified in the datalog files were geared towards unit
tests, but were inappropriate for regular runs of the analysis.

This commit collects those `.input` and `.output` relations into a new
`tag_check_and_expectation_interface.dl` file, which indicates the
interface to the analysis for this kind of unit test. This is a pattern
I'd like to establish going forward, where each binary or library that we
produce based upon our Souffle datalog shall correspond to a separate
interface file, indicating the input and output realtions used by that
binary.