### PR TITLE
Allow additional annotations to be added for operations in dot output.

### DIFF
--- a/src/ir/dot/BUILD
+++ b/src/ir/dot/BUILD
@@ -25,7 +25,10 @@ cc_library(
     srcs = [
         "dot_generator.cc",
     ],
-    hdrs = ["dot_generator.h"],
+    hdrs = [
+        "dot_generator.h",
+        "dot_generator_config.h",
+    ],
     deps = [
         "//src/ir:ir_printer",
         "//src/ir:ir_traversing_visitor",

--- a/src/ir/dot/dot_generator.cc
+++ b/src/ir/dot/dot_generator.cc
@@ -124,6 +124,17 @@ void DotGeneratorHelper::AddResult(const Operation& op,
   }
 }
 
+namespace {
+
+// Safe initialization of static empty btree set.
+const absl::btree_set<std::string>& GetEmptyStringBtreeSet() {
+  static const absl::btree_set<std::string>* empty_set =
+      new absl::btree_set<std::string>();
+  return *empty_set;
+}
+
+}  // namespace
+
 std::string DotGeneratorHelper::GetDotNode(const Operation& op) {
   // Generates a dot representation of an operation as a node. Suppose that the
   // operation has `m` inputs and `n`results, the generated node will be
@@ -139,7 +150,6 @@ std::string DotGeneratorHelper::GetDotNode(const Operation& op) {
   //
   // The `Ix` and `Rx` are ports that we can connect edges to.
   // (cf. https://www.graphviz.org/doc/info/shapes.html#record)
-  static absl::btree_set<std::string> empty_results_set;
   std::string node_name = GetNodeName(op);
   std::string input_ports = absl::StrJoin(
       op.inputs(), "|", [i = 0](std::string* out, const Value& v) mutable {
@@ -149,7 +159,7 @@ std::string DotGeneratorHelper::GetDotNode(const Operation& op) {
       });
   auto find_result = operation_results_.find(node_name);
   const absl::btree_set<std::string>& results =
-      (find_result == operation_results_.end()) ? empty_results_set
+      (find_result == operation_results_.end()) ? GetEmptyStringBtreeSet()
                                                 : find_result->second;
   std::string output_ports =
       results.empty()

--- a/src/ir/dot/dot_generator_config.h
+++ b/src/ir/dot/dot_generator_config.h
@@ -13,23 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //----------------------------------------------------------------------------
-#ifndef SRC_IR_DOT_DOT_GENERATOR_H_
-#define SRC_IR_DOT_DOT_GENERATOR_H_
+#ifndef SRC_IR_DOT_DOT_GENERATOR_CONFIG_H_
+#define SRC_IR_DOT_DOT_GENERATOR_CONFIG_H_
 
 #include <functional>
+#include <string>
+#include <vector>
 
-#include "src/ir/dot/dot_generator_config.h"
+#include "absl/container/btree_set.h"
 #include "src/ir/module.h"
 
 namespace raksha::ir::dot {
 
-class DotGenerator {
- public:
-  std::string ModuleAsDot(
-      const Module& module,
-      DotGeneratorConfig config = DotGeneratorConfig::GetDefault()) const;
+struct DotGeneratorConfig {
+  std::function<std::string(const Operation&,
+                            const absl::btree_set<std::string>&)>
+      operation_labeler;
+
+  // Default config.
+  static DotGeneratorConfig GetDefault() {
+    return {.operation_labeler =
+                [](const Operation& op,
+                   const absl::btree_set<std::string>& results) { return ""; }};
+  }
 };
 
 }  // namespace raksha::ir::dot
 
-#endif  // SRC_IR_DOT_DOT_GENERATOR_H_
+#endif  // SRC_IR_DOT_DOT_GENERATOR_CONFIG_H_

--- a/src/ir/dot/dot_generator_test.cc
+++ b/src/ir/dot/dot_generator_test.cc
@@ -238,10 +238,13 @@ TEST_F(DotGeneratorTest, AddsEdgeFromOperationResultToInputs) {
 }
 
 TEST_F(DotGeneratorTest, AddsAdditionalLabelToOperationNodes) {
+  // Create a config for additional annotations to operation nodes. The format
+  // of the annotation is `numResults(<op-name>): <num-results>`.
   DotGeneratorConfig config = {
       .operation_labeler = [](const Operation& op,
                               const absl::btree_set<std::string>& results) {
-        return absl::StrFormat("%s-%d", op.op().name(), results.size());
+        return absl::StrFormat("numResults(%s): %d", op.op().name(),
+                               results.size());
       }};
   // module m0 {
   //   block b0 {
@@ -264,9 +267,11 @@ TEST_F(DotGeneratorTest, AddsAdditionalLabelToOperationNodes) {
           // block b0
           "B0",
           // %0 = core.pair []()
-          R"(B0_0[label="{{}|core.pair|core.pair-2|{<first>first|<second>second}}"])",
+          // Check `|numResults(core.pair): 2` is added.
+          R"(B0_0[label="{{}|core.pair|numResults(core.pair): 2|{<first>first|<second>second}}"])",
           // %1 = core.plus [](%0.first, %1.second)
-          R"(B0_1[label="{{<I0>I0|<I1>I1}|core.plus|core.plus-0|{<out>out}}"])"));
+          // Check `|numResults(core.plus): 0` is added.
+          R"(B0_1[label="{{<I0>I0|<I1>I1}|core.plus|numResults(core.plus): 0|{<out>out}}"])"));
 }
 
 }  // namespace


### PR DESCRIPTION
The `DotGeneratorConfig` is narrowly focussed so that we have something to build on. We might have to rethink this when we have more experience with what we want.