### PR TITLE
Add a `raksha_cc_proto_library`, which will be used to simplify import.

### DIFF
--- a/build_defs/native.oss.bzl
+++ b/build_defs/native.oss.bzl
@@ -9,3 +9,22 @@ load("@rules_proto_grpc//cpp:defs.bzl", _cc_proto_library = "cpp_proto_library")
 
 cc_proto_library = _cc_proto_library
 proto_library = _proto_library
+
+def raksha_cc_proto_library(
+        name,
+        protos = [],
+        deps = [],
+        visibility = None):
+    """Used to paper over differences in interface between external and internal versions of cc_proto_library.
+
+    Args:
+        name: String; Name of the library
+        protos: List; labels of protos used to produce this library
+        deps: List; An alias for protos. This will be removed very shortly.
+        visibility: List; List of visibilities
+    """
+    _cc_proto_library(
+        name = name,
+        protos = protos + deps,
+        visibility = visibility,
+    )

--- a/build_defs/native.oss.bzl
+++ b/build_defs/native.oss.bzl
@@ -12,19 +12,17 @@ proto_library = _proto_library
 
 def raksha_cc_proto_library(
         name,
-        protos = [],
         deps = [],
         visibility = None):
     """Used to paper over differences in interface between external and internal versions of cc_proto_library.
 
     Args:
         name: String; Name of the library
-        protos: List; labels of protos used to produce this library
-        deps: List; An alias for protos. This will be removed very shortly.
+        deps: List; labels of protos used to produce this library
         visibility: List; List of visibilities
     """
     _cc_proto_library(
         name = name,
-        protos = protos + deps,
+        protos = deps,
         visibility = visibility,
     )

--- a/build_defs/native.oss.bzl
+++ b/build_defs/native.oss.bzl
@@ -13,16 +13,18 @@ proto_library = _proto_library
 def raksha_cc_proto_library(
         name,
         deps = [],
+        protos = [],
         visibility = None):
     """Used to paper over differences in interface between external and internal versions of cc_proto_library.
 
     Args:
         name: String; Name of the library
         deps: List; labels of protos used to produce this library
+        protos: List; Same as deps, will be removed shortly.
         visibility: List; List of visibilities
     """
     _cc_proto_library(
         name = name,
-        protos = deps,
+        protos = deps + protos,
         visibility = visibility,
     )

--- a/third_party/arcs/proto/BUILD
+++ b/third_party/arcs/proto/BUILD
@@ -1,7 +1,7 @@
 load(
     "//build_defs:native.oss.bzl",
-    "cc_proto_library",
     "proto_library",
+    "raksha_cc_proto_library",
 )
 
 licenses(["notice"])
@@ -34,7 +34,7 @@ proto_library(
     deps = [":annotation_proto"],
 )
 
-cc_proto_library(
+raksha_cc_proto_library(
     name = "manifest_cc_proto",
     protos = [
         ":annotation_proto",


### PR DESCRIPTION
The versions of `cc_proto_library` inside and outside of Google are
slightly incompatible in the attributes that they take. This commit adds
a new `raksha_cc_proto_library` which will have an internal and external
version to help ease the translation between the two versions. It is
intentionally not yet used everywhere it could be; we will finish setting up
the translation on the Google-internal side, as that's where most of the
work needs to occur.