### PR TITLE
Add changes to make the IR parser build pass on winterrowd@'s machine.

### DIFF
--- a/src/parser/ir/BUILD
+++ b/src/parser/ir/BUILD
@@ -60,6 +60,7 @@ cc_library(
 cc_test(
     name = "ir_parser_test",
     srcs = ["ir_parser_test.cc"],
+    copts = ["-fexceptions"],
     deps = [
         ":ir_parser",
         "//src/common/testing:gtest",

--- a/src/parser/ir/BUILD
+++ b/src/parser/ir/BUILD
@@ -61,6 +61,7 @@ cc_test(
     name = "ir_parser_test",
     srcs = ["ir_parser_test.cc"],
     copts = ["-fexceptions"],
+    features = ["-use_header_modules"],
     deps = [
         ":ir_parser",
         "//src/common/testing:gtest",

--- a/src/parser/ir/ir_parser.cc
+++ b/src/parser/ir/ir_parser.cc
@@ -88,9 +88,7 @@ const Operation& IrProgramParser::ConstructOperation(
           : utils::MapIter<Value>(
                 operation_context.argumentList()->value(),
                 [this](IrParser::ValueContext* value_context) {
-                  if (auto* any_value_context =
-                          dynamic_cast<IrParser::AnyValueContext*>(
-                              value_context)) {
+                  if (dynamic_cast<IrParser::AnyValueContext*>(value_context)) {
                     return Value(value::Any());
                   }
                   auto* named_value_context =


### PR DESCRIPTION
My build was failing because the IR parser test did not have
`-fexceptions`, but the ANTLR-generated code wanted to throw exceptions
in some cases. I don't think I did anything to expose this. This may
just be another GCC/Clang difference showing up for me.