### PR TITLE
Add list of `Operator`s to IR TU message.

### DIFF
--- a/src/ir/proto/raksha_ir.proto
+++ b/src/ir/proto/raksha_ir.proto
@@ -61,6 +61,14 @@ message Operation {
   NamedValueMap results = 4;
 }
 
+// Information that applies to all `Operation`s performing a particular
+// `Operator`. Currently this only contains the operator's name, but may be
+// extended in the future to provide arity information, type constraints, and
+// other helpful information.
+message Operator {
+  string name = 1;
+}
+
 message AnyValue {}
 
 message OperationResultValue {
@@ -89,6 +97,9 @@ message IrTranslationUnit {
   Module top_level_module = 1;
   // The frontend that produced these IR messages.
   string frontend = 2;
+  // The list of `Operator`s used in this TU. Think of this as a list of
+  // `Operator` declarations.
+  repeated Operator operations = 3;
 }
 
 // A status indicating whether the analysis succeeded, failed, or encountered an

--- a/src/ir/proto/raksha_ir.proto
+++ b/src/ir/proto/raksha_ir.proto
@@ -99,7 +99,7 @@ message IrTranslationUnit {
   string frontend = 2;
   // The list of `Operator`s used in this TU. Think of this as a list of
   // `Operator` declarations.
-  repeated Operator operations = 3;
+  repeated Operator operators = 3;
 }
 
 // A status indicating whether the analysis succeeded, failed, or encountered an


### PR DESCRIPTION
This PR adds an `Operator` message and make the `IRTranslationUnit`
message contain a list of `Operator`s. We expect that eventually,
`Operator`s will contain more information than just the name they
currently contain, and thus it will make sense to have an IR TU
declare/define the list of `Operator`s that it will be using. In
addition, the `IRContext` object currently requires that `Operator`s be
added to the context before any `Operation` using that `Operator` is
built. Adding the list of possible `Operator`s to the TU allows those
`Operator`s to be populated before a decoder attempts to decode any
particular `Operation`.