### PR TITLE
Refactor relations on `Operation`s to allow more concise matching.

### DIFF
--- a/src/analysis/souffle/operations.dl
+++ b/src/analysis/souffle/operations.dl
@@ -35,7 +35,34 @@
 // Operation universe.
 .decl isOperation(operation: Operation)
 
-isPrincipal(owner), isAccessPath(result) :- isOperation([owner, _, result, _, _]).
+// OperandList universe.
+.decl isOperandList(operandList: OperandList)
+
+// Operator universe.
+.decl isOperator(operator: Operator)
+
+// Attribute list universe.
+.decl isAttributeList(attributeList: AttributeList)
+
+// Fill the appropriate universes with the pieces of the operation.
+isPrincipal(owner), isOperator(operator), isAccessPath(result),
+isOperandList(operandList), isAttributeList(attributeList) :-
+isOperation([owner, operator, result, operandList, attributeList]).
+
+// Declare mappings from an operation to its fields.
+.decl operationHasResult(operation: Operation, result: AccessPath)
+.decl operationHasOwner(operation: Operation, owner: Principal)
+.decl operationHasOperator(operation: Operation, operator: Operator)
+.decl operationHasOperandList(operation: Operation, operandList: OperandList)
+.decl operationHasAttributeList(operation: Operation, attributeList: AttributeList)
+
+// Populate field association relations.
+operationHasResult(operation, result), operationHasOwner(operation, owner),
+operationHasOperator(operation, operator), operationHasOperandList(operation, operands),
+operationHasAttributeList(operation, attributes) :-
+  isPrincipal(owner), isOperator(operator), isAccessPath(result), isOperandList(operands),
+  isAttributeList(attributes), isOperation(operation),
+  operation = [owner, operator, result, operands, attributes].
 
 // BINARY_OPERATION is a convenience macro for the very-common-case of binary operations.
 #define BINARY_OPERATION(owner, operator, result, attrs, input1, input2) \
@@ -45,8 +72,8 @@ isOperation([owner, operator, result, [input1, [input2, nil]], attrs])
 // to get a mapping from operations to their operands.
 .decl operationHasOperandListSuffix(operation: Operation, partialList: OperandList)
 
-operationHasOperandListSuffix([owner, op, result, operandList, attrs], operandList) :-
-  isOperation([owner, op, result, operandList, attrs]).
+operationHasOperandListSuffix(operation, operandList) :-
+  operationHasOperandList(operation, operandList).
 operationHasOperandListSuffix(operation, tail) :-
   operationHasOperandListSuffix(operation, [_, tail]).
 
@@ -61,8 +88,8 @@ operandListLength([head, tail], tailLen + 1) :-
 // `operation`.
 .decl operationOperandListLength(operation: Operation, operandListLength: number)
 
-operationOperandListLength([owner, operator, result, operandList, attrs], len) :-
-  isOperation([owner, operator, result, operandList, attrs]),
+operationOperandListLength(operation, len) :-
+  isOperation(operation), operationHasOperandList(operation, operandList),
   operandListLength(operandList, len).
 
 // True when an `operation` has the given `operand` at the indicated `index` in
@@ -82,8 +109,8 @@ operationHasOperandAtIndex(operation, operand, opListLen - suffixListLen) :-
 // A helper relation that produces all partial attribute lists of an
 // `Operation`.
 .decl operationHasAttributeListSuffix(operation: Operation, attributes: AttributeList)
-operationHasAttributeListSuffix([owner, op, result, operandList, attrs], attrs) :-
-  isOperation([owner, op, result, operandList, attrs]).
+operationHasAttributeListSuffix(operation, attrs) :-
+  isOperation(operation), operationHasAttributeList(operation, attrs).
 operationHasAttributeListSuffix(op, tail) :- operationHasAttributeListSuffix(op, [_, tail]).
 
 // A mapping from an `Operation` to each individual `Attribute` on that

--- a/src/analysis/souffle/tag_transforms.dl
+++ b/src/analysis/souffle/tag_transforms.dl
@@ -33,7 +33,7 @@
   [ precondition: SqlPolicyRulePrecondition, next: SqlPolicyRulePreconditionList ]
 
 .type SqlPolicyRuleResult =
-  AddIntegrityTag { tag: IntegrityTag } 
+  AddIntegrityTag { tag: IntegrityTag }
   | RemoveConfidentialityTag { tag: Tag }
   // Note: In the SQL verifier, rules can only add confidentiality tags on
   // named columns of global tables.
@@ -71,7 +71,7 @@ policyRulePreconditionListLength([head, tail], tailLen + 1) :-
   policyRulePreconditionListLength(tail, tailLen).
 
 .decl sqlPolicyRuleNameHasPreconditionAtIndex(
-  policyRuleName: symbol, policyRulePrecondition: SqlPolicyRulePrecondition, index: number) 
+  policyRuleName: symbol, policyRulePrecondition: SqlPolicyRulePrecondition, index: number)
 
 sqlPolicyRuleNameHasPreconditionAtIndex(name, precondition, suffixLen - 1) :-
   sqlPolicyRuleNameHasPreconditionListSuffix(name, [precondition, tail]),
@@ -98,10 +98,6 @@ isTagTransformOperation(
 tagTransformHasRuleName(op, ruleName) :-
   isTagTransformOperation(op),
   operationHasAttribute(op, [TAG_TRANSFORM_RULE_NAME_ATTR, $StringAttributePayload(ruleName)]).
-
-.decl tagTransformHasResultAccessPath(tagTransform: Operation, resultPath: AccessPath)
-tagTransformHasResultAccessPath([owner, operator, result, operandList, attrs], result) :-
-  isTagTransformOperation([owner, operator, result, operandList, attrs]).
 
 // Associates the tagTransform operation with a tagPrecondition that must be
 // met for the transform to occur and the index of the corresponding policy
@@ -138,21 +134,21 @@ allTagTransformPreconditionsMet(tagTransform) :-
 
 removeTag(result, DEFAULT_SQL_OWNER, tag) :-
   isTagTransformOperation(op),
-  tagTransformHasResultAccessPath(op, result),
+  operationHasResult(op, result),
   tagTransformHasRuleName(op, ruleName),
   allTagTransformPreconditionsMet(op),
   sqlPolicyRuleNameHasResult(ruleName, $RemoveConfidentialityTag(tag)).
 
 hasTag(result, DEFAULT_SQL_OWNER, tag) :-
   isTagTransformOperation(op),
-  tagTransformHasResultAccessPath(op, result),
+  operationHasResult(op, result),
   tagTransformHasRuleName(op, ruleName),
   allTagTransformPreconditionsMet(op),
   sqlPolicyRuleNameHasResult(ruleName, $AddConfidentialityTag(tag)).
 
 mustHaveIntegrityTag(result, DEFAULT_SQL_OWNER, iTag) :-
   isTagTransformOperation(op),
-  tagTransformHasResultAccessPath(op, result),
+  operationHasResult(op, result),
   tagTransformHasRuleName(op, ruleName),
   allTagTransformPreconditionsMet(op),
   sqlPolicyRuleNameHasResult(ruleName, $AddIntegrityTag(iTag)).

--- a/src/analysis/souffle/tests/arcs_fact_tests/operation_field_unit_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/operation_field_unit_test.dl
@@ -29,9 +29,6 @@
   TEST_SINGLE_RESULT_FOR_OPERATION(test_name, (operation), operationHasOperandList, (operandList)). \
   TEST_SINGLE_RESULT_FOR_OPERATION(test_name, (operation), operationHasAttributeList, (attrList))
 
-#define MAKE_OPERATION(owner, operator, result, operandList, attrList) \
-  [owner, operator, result, operandList, attrList]
-
 #define CREATE_AND_TEST_OPERATION(test_name, owner, operator, result, operandList, attrList) \
   CREATE_AND_TEST_OPERATOR_INNER(test_name, ([owner, operator, result, (operandList), (attrList)]), owner, operator, result, (operandList), (attrList))
 

--- a/src/analysis/souffle/tests/arcs_fact_tests/operation_field_unit_test.dl
+++ b/src/analysis/souffle/tests/arcs_fact_tests/operation_field_unit_test.dl
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+#include "src/analysis/souffle/taint.dl"
+#include "src/analysis/souffle/fact_test_helper.dl"
+
+#define TEST_SINGLE_RESULT_FOR_OPERATION(test_name, operation, relation, expected) \
+  TEST_CASE(cat(test_name, cat("_", #relation))) :- \
+    count : { relation(operation, _) } = 1, relation(operation, expected)
+
+#define CREATE_AND_TEST_OPERATOR_INNER(test_name, operation, owner, operator, result, operandList, attrList) \
+  isOperation(operation). \
+  TEST_SINGLE_RESULT_FOR_OPERATION(test_name, (operation), operationHasOwner, owner). \
+  TEST_SINGLE_RESULT_FOR_OPERATION(test_name, (operation), operationHasOperator, operator). \
+  TEST_SINGLE_RESULT_FOR_OPERATION(test_name, (operation), operationHasResult, result). \
+  TEST_SINGLE_RESULT_FOR_OPERATION(test_name, (operation), operationHasOperandList, (operandList)). \
+  TEST_SINGLE_RESULT_FOR_OPERATION(test_name, (operation), operationHasAttributeList, (attrList))
+
+#define MAKE_OPERATION(owner, operator, result, operandList, attrList) \
+  [owner, operator, result, operandList, attrList]
+
+#define CREATE_AND_TEST_OPERATION(test_name, owner, operator, result, operandList, attrList) \
+  CREATE_AND_TEST_OPERATOR_INNER(test_name, ([owner, operator, result, (operandList), (attrList)]), owner, operator, result, (operandList), (attrList))
+
+#define OPERAND_LIST1 ["operand1", nil]
+#define ATTR_LIST1 [["attr1", $NumberAttributePayload(1)], nil]
+
+CREATE_AND_TEST_OPERATION("test1", "somePrincipal", "someOperator", "ap1", (OPERAND_LIST1), (ATTR_LIST1)).
+
+#define ATTR_LIST2 [["someAttr", $StringAttributePayload("hello")], [["anotherAttr", $NumberAttributePayload(2)], nil]]
+
+CREATE_AND_TEST_OPERATION("test2", "prin", "op", "ap2", nil, (ATTR_LIST2)).
+
+#define OPERAND_LIST2 ["input1", ["input2", nil]]
+CREATE_AND_TEST_OPERATION("test3", "owner", "op2", "ap3", (OPERAND_LIST2), nil).


### PR DESCRIPTION
This PR adds relations used to get particular fields of an `Operation`
so `Operation`s don't have to be fully deconstructed when a small number
of fields are required. Also updates some rules to use this mechanism
where it would make them more concise and eliminate some duplicate
rules.