### PR TITLE
Add special rules for building internal edges for tag transforms.

### DIFF
--- a/src/analysis/souffle/operations.dl
+++ b/src/analysis/souffle/operations.dl
@@ -35,7 +35,34 @@
 // Operation universe.
 .decl isOperation(operation: Operation)
 
-isPrincipal(owner), isAccessPath(result) :- isOperation([owner, _, result, _, _]).
+// OperandList universe.
+.decl isOperandList(operandList: OperandList)
+
+// Operator universe.
+.decl isOperator(operator: Operator)
+
+// Attribute list universe.
+.decl isAttributeList(attributeList: AttributeList)
+
+// Fill the appropriate universes with the pieces of the operation.
+isPrincipal(owner), isOperator(operator), isAccessPath(result),
+isOperandList(operandList), isAttributeList(attributeList) :-
+isOperation([owner, operator, result, operandList, attributeList]).
+
+// Declare mappings from an operation to its fields.
+.decl operationHasResult(operation: Operation, result: AccessPath)
+.decl operationHasOwner(operation: Operation, owner: Principal)
+.decl operationHasOperator(operation: Operation, operator: Operator)
+.decl operationHasOperandList(operation: Operation, operandList: OperandList)
+.decl operationHasAttributeList(operation: Operation, attributeList: AttributeList)
+
+// Populate field association relations.
+operationHasResult(operation, result), operationHasOwner(operation, owner),
+operationHasOperator(operation, operator), operationHasOperandList(operation, operands),
+operationHasAttributeList(operation, attributes) :-
+  isPrincipal(owner), isOperator(operator), isAccessPath(result), isOperandList(operands),
+  isAttributeList(attributes), isOperation(operation),
+  operation = [owner, operator, result, operands, attributes].
 
 // BINARY_OPERATION is a convenience macro for the very-common-case of binary operations.
 #define BINARY_OPERATION(owner, operator, result, attrs, input1, input2) \
@@ -45,8 +72,8 @@ isOperation([owner, operator, result, [input1, [input2, nil]], attrs])
 // to get a mapping from operations to their operands.
 .decl operationHasOperandListSuffix(operation: Operation, partialList: OperandList)
 
-operationHasOperandListSuffix([owner, op, result, operandList, attrs], operandList) :-
-  isOperation([owner, op, result, operandList, attrs]).
+operationHasOperandListSuffix(operation, operandList) :-
+  operationHasOperandList(operation, operandList).
 operationHasOperandListSuffix(operation, tail) :-
   operationHasOperandListSuffix(operation, [_, tail]).
 
@@ -61,8 +88,8 @@ operandListLength([head, tail], tailLen + 1) :-
 // `operation`.
 .decl operationOperandListLength(operation: Operation, operandListLength: number)
 
-operationOperandListLength([owner, operator, result, operandList, attrs], len) :-
-  isOperation([owner, operator, result, operandList, attrs]),
+operationOperandListLength(operation, len) :-
+  isOperation(operation), operationHasOperandList(operation, operandList),
   operandListLength(operandList, len).
 
 // True when an `operation` has the given `operand` at the indicated `index` in
@@ -82,8 +109,8 @@ operationHasOperandAtIndex(operation, operand, opListLen - suffixListLen) :-
 // A helper relation that produces all partial attribute lists of an
 // `Operation`.
 .decl operationHasAttributeListSuffix(operation: Operation, attributes: AttributeList)
-operationHasAttributeListSuffix([owner, op, result, operandList, attrs], attrs) :-
-  isOperation([owner, op, result, operandList, attrs]).
+operationHasAttributeListSuffix(operation, attrs) :-
+  isOperation(operation), operationHasAttributeList(operation, attrs).
 operationHasAttributeListSuffix(op, tail) :- operationHasAttributeListSuffix(op, [_, tail]).
 
 // A mapping from an `Operation` to each individual `Attribute` on that

--- a/src/analysis/souffle/operations.dl
+++ b/src/analysis/souffle/operations.dl
@@ -118,4 +118,8 @@ operationHasAttributeListSuffix(op, tail) :- operationHasAttributeListSuffix(op,
 .decl operationHasAttribute(op: Operation, attr: Attribute)
 operationHasAttribute(op, attr) :- operationHasAttributeListSuffix(op, [attr, _]).
 
+// Indicates that this operator has special internal edges defined and should
+// not be subject to the default rules.
+.decl hasSpecialInternalEdges(operator: Operator)
+
 #endif // SRC_ANALYSIS_SOUFFLE_OPERATIONS_DL_

--- a/src/analysis/souffle/operations.dl
+++ b/src/analysis/souffle/operations.dl
@@ -120,6 +120,6 @@ operationHasAttribute(op, attr) :- operationHasAttributeListSuffix(op, [attr, _]
 
 // Indicates that this operator has special internal edges defined and should
 // not be subject to the default rules.
-.decl hasSpecialInternalEdges(operator: Operator)
+.decl hasSpecialEdgeRules(operator: Operator)
 
 #endif // SRC_ANALYSIS_SOUFFLE_OPERATIONS_DL_

--- a/src/analysis/souffle/tag_transforms.dl
+++ b/src/analysis/souffle/tag_transforms.dl
@@ -31,7 +31,7 @@
 // rule should check for integrity tags preconditions. In addition, any tag
 // transform should propagate any integrity tags from its transformed input to
 // the output.
-hasSpecialInternalEdges(TAG_TRANSFORM_OPERATOR).
+hasSpecialEdgeRules(TAG_TRANSFORM_OPERATOR).
 
 // A precondition produced in the SQL verifier. The `preconditionName`
 // corresponds to the user-provided name in the SQL pattern in the original

--- a/src/analysis/souffle/tag_transforms.dl
+++ b/src/analysis/souffle/tag_transforms.dl
@@ -25,6 +25,14 @@
 #define TAG_TRANSFORM_OPERATOR "sql.tag_transform"
 #define TAG_TRANSFORM_RULE_NAME_ATTR "rule_name"
 
+// Tag transforms are very special in their propagation of tags: their
+// precondition inputs do not propagate confidentiality tags, as they aren't
+// part of the "real" dataflow. They are only used to indicate where a policy
+// rule should check for integrity tags preconditions. In addition, any tag
+// transform should propagate any integrity tags from its transformed input to
+// the output.
+hasSpecialInternalEdges(TAG_TRANSFORM_OPERATOR).
+
 // A precondition produced in the SQL verifier. The `preconditionName`
 // corresponds to the user-provided name in the SQL pattern in the original
 // policy rule.
@@ -90,6 +98,14 @@ isIntegrityTag(tag) :- sqlPolicyRuleNameHasResult(_, $AddIntegrityTag(tag)).
 isTagTransformOperation(
   [DEFAULT_SQL_OWNER, TAG_TRANSFORM_OPERATOR, result, operandList, attributes]) :-
   isOperation([DEFAULT_SQL_OWNER, TAG_TRANSFORM_OPERATOR, result, operandList, attributes]).
+
+// A TagTransform operator propagates confidentiality tags and integrity tags
+// only from its direct input (its 0th input) to its output. It faithfully
+// propagates all integrity tags. This can be expressed by drawing a single
+// edge from the input to the output.
+resolvedEdge(DEFAULT_SQL_OWNER, xformedInput, xformedOutput) :-
+  isTagTransformOperation(operation), operationHasOperandAtIndex(operation, xformedInput, 0),
+  operationHasResult(operation, xformedOutput).
 
 .type TagPrecondition = [ path: AccessPath, itag: IntegrityTag ]
 

--- a/src/analysis/souffle/tag_transforms.dl
+++ b/src/analysis/souffle/tag_transforms.dl
@@ -33,7 +33,7 @@
   [ precondition: SqlPolicyRulePrecondition, next: SqlPolicyRulePreconditionList ]
 
 .type SqlPolicyRuleResult =
-  AddIntegrityTag { tag: IntegrityTag } 
+  AddIntegrityTag { tag: IntegrityTag }
   | RemoveConfidentialityTag { tag: Tag }
   // Note: In the SQL verifier, rules can only add confidentiality tags on
   // named columns of global tables.
@@ -71,7 +71,7 @@ policyRulePreconditionListLength([head, tail], tailLen + 1) :-
   policyRulePreconditionListLength(tail, tailLen).
 
 .decl sqlPolicyRuleNameHasPreconditionAtIndex(
-  policyRuleName: symbol, policyRulePrecondition: SqlPolicyRulePrecondition, index: number) 
+  policyRuleName: symbol, policyRulePrecondition: SqlPolicyRulePrecondition, index: number)
 
 sqlPolicyRuleNameHasPreconditionAtIndex(name, precondition, suffixLen - 1) :-
   sqlPolicyRuleNameHasPreconditionListSuffix(name, [precondition, tail]),
@@ -98,10 +98,6 @@ isTagTransformOperation(
 tagTransformHasRuleName(op, ruleName) :-
   isTagTransformOperation(op),
   operationHasAttribute(op, [TAG_TRANSFORM_RULE_NAME_ATTR, $StringAttributePayload(ruleName)]).
-
-.decl tagTransformHasResultAccessPath(tagTransform: Operation, resultPath: AccessPath)
-tagTransformHasResultAccessPath([owner, operator, result, operandList, attrs], result) :-
-  isTagTransformOperation([owner, operator, result, operandList, attrs]).
 
 // Associates the tagTransform operation with a tagPrecondition that must be
 // met for the transform to occur and the index of the corresponding policy
@@ -138,21 +134,21 @@ allTagTransformPreconditionsMet(tagTransform) :-
 
 removeTag(result, DEFAULT_SQL_OWNER, tag) :-
   isTagTransformOperation(op),
-  tagTransformHasResultAccessPath(op, result),
+  operationHasResult(op, result),
   tagTransformHasRuleName(op, ruleName),
   allTagTransformPreconditionsMet(op),
   sqlPolicyRuleNameHasResult(ruleName, $RemoveConfidentialityTag(tag)).
 
 hasTag(result, DEFAULT_SQL_OWNER, tag) :-
   isTagTransformOperation(op),
-  tagTransformHasResultAccessPath(op, result),
+  operationHasResult(op, result),
   tagTransformHasRuleName(op, ruleName),
   allTagTransformPreconditionsMet(op),
   sqlPolicyRuleNameHasResult(ruleName, $AddConfidentialityTag(tag)).
 
 mustHaveIntegrityTag(result, DEFAULT_SQL_OWNER, iTag) :-
   isTagTransformOperation(op),
-  tagTransformHasResultAccessPath(op, result),
+  operationHasResult(op, result),
   tagTransformHasRuleName(op, ruleName),
   allTagTransformPreconditionsMet(op),
   sqlPolicyRuleNameHasResult(ruleName, $AddIntegrityTag(iTag)).

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -80,14 +80,16 @@
 //-----------------------------------------------------------------------------
 
 // Draw an edge from any operation's operand to its result.
-resolvedEdge(owner, src, tgt) :- operationHasOperandAtIndex([owner, _, tgt, _, _], src,  _).
+resolvedEdge(owner, src, tgt) :-
+  operationHasOperandAtIndex([owner, operator, tgt, _, _], src,  _),
+  !hasSpecialInternalEdges(operator).
 
 // For all operations other than `=`, draw an edge from the special
 // "ArbitraryComputation" `AccessPath` to the result. This prevents default
 // propagation of `IntegrityTag`s through the operation.
 isAccessPath("ArbitraryComputation").
 resolvedEdge(owner, "ArbitraryComputation", tgt) :-
-  isOperation([owner, operator, tgt, _, _]), operator != "=".
+  isOperation([owner, operator, tgt, _, _]), !hasSpecialInternalEdges(operator).
 
 ownsAccessPath(principal, path) :- says_ownsAccessPath(principal, principal, path).
 ownsAccessPath(principal, tgt) :-

--- a/src/analysis/souffle/taint.dl
+++ b/src/analysis/souffle/taint.dl
@@ -82,14 +82,14 @@
 // Draw an edge from any operation's operand to its result.
 resolvedEdge(owner, src, tgt) :-
   operationHasOperandAtIndex([owner, operator, tgt, _, _], src,  _),
-  !hasSpecialInternalEdges(operator).
+  !hasSpecialEdgeRules(operator).
 
 // For all operations other than `=`, draw an edge from the special
 // "ArbitraryComputation" `AccessPath` to the result. This prevents default
 // propagation of `IntegrityTag`s through the operation.
 isAccessPath("ArbitraryComputation").
 resolvedEdge(owner, "ArbitraryComputation", tgt) :-
-  isOperation([owner, operator, tgt, _, _]), !hasSpecialInternalEdges(operator).
+  isOperation([owner, operator, tgt, _, _]), !hasSpecialEdgeRules(operator).
 
 ownsAccessPath(principal, path) :- says_ownsAccessPath(principal, principal, path).
 ownsAccessPath(principal, tgt) :-

--- a/src/analysis/souffle/tests/sql_verifier_dl_unit_tests/tag_transform_default_propagation/BUILD
+++ b/src/analysis/souffle/tests/sql_verifier_dl_unit_tests/tag_transform_default_propagation/BUILD
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------------------------
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------------------------
+load(
+    "//build_defs:test_helpers.bzl",
+    "run_taint_exec_compare_check_results",
+)
+
+package(
+    features = ["layering_check"],
+    licenses = ["notice"],
+)
+
+run_taint_exec_compare_check_results(
+    name = "check_pred_unit_test",
+    input_files = glob(["*.facts"]),
+    test_bin = ["//src/analysis/souffle:sql_verifier_tag_unit_test_test"],
+)

--- a/src/analysis/souffle/tests/sql_verifier_dl_unit_tests/tag_transform_default_propagation/checkP.facts
+++ b/src/analysis/souffle/tests/sql_verifier_dl_unit_tests/tag_transform_default_propagation/checkP.facts
@@ -1,0 +1,4 @@
+default_propagate_conf_tag;$CP_TagPresence("default_propagate_conf_tag","sql",$CTag("tag"))
+default_propagate_integ_tag;$CP_TagPresence("default_propagate_integ_tag","sql",$ITag("itag"))
+no_propagate_conf_tag_through_precond;$CP_Not($CP_TagPresence("no_propagate_conf_tag_through_precond","sql",$CTag("tag")))
+no_propagate_integ_tag_through_precond;$CP_Not($CP_TagPresence("no_propagate_integ_tag_through_precond","sql",$ITag("itag")))

--- a/src/analysis/souffle/tests/sql_verifier_dl_unit_tests/tag_transform_default_propagation/isOperation.facts
+++ b/src/analysis/souffle/tests/sql_verifier_dl_unit_tests/tag_transform_default_propagation/isOperation.facts
@@ -1,0 +1,7 @@
+["sql", "arbitrary", "path1", nil, nil]
+["sql", "sql.tag_transform", "has_tag", ["path1", nil], [["rule_name", $StringAttributePayload("add_tag_rule")], nil]]
+["sql", "sql.tag_transform", "has_integrity_tag", ["path1", nil], [["rule_name", $StringAttributePayload("add_itag_rule")], nil]]
+["sql", "sql.tag_transform", "default_propagate_conf_tag", ["has_tag", nil], [["rule_name", $StringAttributePayload("dummy")], nil]]
+["sql", "sql.tag_transform", "default_propagate_integ_tag", ["has_integrity_tag", nil], [["rule_name", $StringAttributePayload("dummy")], nil]]
+["sql", "sql.tag_transform", "no_propagate_conf_tag_through_precond", ["arbitrary", ["has_tag", nil]], [["rule_name", $StringAttributePayload("dummy")], [["precond1", $NumberAttributePayload(1)], nil]]]
+["sql", "sql.tag_transform", "no_propagate_integ_tag_through_precond", ["arbitrary", ["has_integrity_tag", nil]], [["rule_name", $StringAttributePayload("dummy")], [["precond1", $NumberAttributePayload(1)], nil]]]

--- a/src/analysis/souffle/tests/sql_verifier_dl_unit_tests/tag_transform_default_propagation/isSqlPolicyRule.facts
+++ b/src/analysis/souffle/tests/sql_verifier_dl_unit_tests/tag_transform_default_propagation/isSqlPolicyRule.facts
@@ -1,0 +1,4 @@
+["add_tag_rule", $AddConfidentialityTag("tag"), nil]
+["add_itag_rule", $AddIntegrityTag("itag"), nil]
+["dummy", $RemoveConfidentialityTag("dummy"), nil]
+["dummy_with_precondition", $RemoveConfidentialityTag("dummy"), [["precond1", "dummyITag"], nil]]


### PR DESCRIPTION
Tag transforms have special propagation rules. They do not perform data
transformations on the operation that they wrap, and thus propagate all
integrity tags from the wrapped operation to their result. Further, they
do not propagate integrity tags nor confidentiality tags from their
precondition inputs. This commit introduces a new mechanism for flagging
an operator as having special internal edges so does not have default
internal edges drawn and uses that mechanism to realize this special
behavior of the tag transform operation.