### PR TITLE
Fix cargo warning, avoid discarded result and add error messages to unwrap

### DIFF
--- a/rust/tools/authorization-logic/src/main.rs
+++ b/rust/tools/authorization-logic/src/main.rs
@@ -25,7 +25,6 @@ mod souffle;
 mod utils;
 mod test;
 
-use std::env;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -63,7 +62,7 @@ fn main() {
     compilation_top_level::compile(&opt.input_filename,
                                    &opt.souffle_output_file,
                                    &opt.decl_skip);
-    if (!opt.skip_souffle) {
+    if !opt.skip_souffle {
         souffle::souffle_interface::run_souffle(
             &opt.souffle_output_file,
             &opt.output_queries_directory,

--- a/rust/tools/authorization-logic/src/souffle/lowering_ast_datalog.rs
+++ b/rust/tools/authorization-logic/src/souffle/lowering_ast_datalog.rs
@@ -235,7 +235,7 @@ impl LoweringToDatalogPass {
                 let gen = DLIRAssertion::DLIRCondAssertion {
                     lhs: gen_lhs,
                     rhs: [s_says_x_as_p, s_says_p_v]
-                        .into_iter()
+                        .iter()
                         .map(|pred| pred_to_dlir_rvalue(pred))
                         .collect(),
                 };
@@ -299,7 +299,7 @@ impl LoweringToDatalogPass {
                 );
                 // This is `p says fpf :- x says fpf, p says x canSay fpf`.
                 let rhs = [x_says_term, can_say_term]
-                    .into_iter()
+                    .iter()
                     .map(|pred| pred_to_dlir_rvalue(pred))
                     .collect();
                 let gen = DLIRAssertion::DLIRCondAssertion { lhs, rhs };
@@ -392,7 +392,7 @@ impl LoweringToDatalogPass {
         DLIRAssertion::DLIRCondAssertion {
             lhs: lhs,
             rhs: [main_fact, LoweringToDatalogPass::dummy_fact()]
-                .into_iter()
+                .iter()
                 .map(|pred| pred_to_dlir_rvalue(pred))
                 .collect()
         }

--- a/rust/tools/authorization-logic/src/souffle/souffle_interface.rs
+++ b/rust/tools/authorization-logic/src/souffle/souffle_interface.rs
@@ -71,7 +71,7 @@ pub fn ast_to_souffle_file(prog: &AstProgram, output_file_path: &str,
 pub fn run_souffle(input_file_path: &str, queries_outdir: &str) {
     let souffle_command = match std::env::var("SOUFFLE_BIN") {
         Ok(val) => val,
-        Err(e) => "souffle".to_string()
+        Err(_e) => "souffle".to_string()
     };
     Command::new(souffle_command)
         .arg(&input_file_path)

--- a/rust/tools/authorization-logic/src/test/test_num_compare.rs
+++ b/rust/tools/authorization-logic/src/test/test_num_compare.rs
@@ -16,10 +16,7 @@
 
 #[cfg(test)]
 pub mod test {
-    use crate::{
-        ast::*, compilation_top_level::*, souffle::souffle_interface::*,
-        test::test_queries::test::*,
-    };
+    use crate::test::test_queries::test::*;
 
     #[test]
     fn test_basic_number_comparisons() {

--- a/rust/tools/authorization-logic/src/test/test_queries.rs
+++ b/rust/tools/authorization-logic/src/test/test_queries.rs
@@ -19,7 +19,6 @@ pub mod test {
     use crate::souffle::souffle_interface::*;
     use std::process::Command;
     use crate::utils::*;
-    use crate::compilation_top_level::*;
 
     /// This struct gives the name of an authorization logic program in
     /// test_inputs, and a vector that relates the names of queries

--- a/rust/tools/authorization-logic/src/utils/utils.rs
+++ b/rust/tools/authorization-logic/src/utils/utils.rs
@@ -23,7 +23,7 @@ pub fn is_bazel_test() -> bool {
 // Otherwise, returns it unchanged.
 pub fn get_resolved_path(path: &str) -> String {
     if is_bazel_test() {
-        let tmp_dir = std::env::var("TEST_TMPDIR").unwrap();
+        let tmp_dir = std::env::var("TEST_TMPDIR").expect("Couldn't read env var TEST_TMPDIR");
         let path = format!("{}/{}", tmp_dir, path);
         path
     } else {
@@ -36,9 +36,10 @@ pub fn get_resolved_path(path: &str) -> String {
 #[cfg(test)]
 pub fn setup_bazeltest_data_paths(input_paths: Vec<&str>) {
     if !is_bazel_test() { return }
-    let tmp_dir = std::env::var("TEST_TMPDIR").unwrap();
-    let src_dir = std::env::var("TEST_SRCDIR").unwrap();
-    let workspace_dir = std::env::var("TEST_WORKSPACE").unwrap();
+    let tmp_dir = std::env::var("TEST_TMPDIR").expect("Couldn't read env var TEST_TMPDIR");
+    let src_dir = std::env::var("TEST_SRCDIR").expect("Couldn't read env var TEST_SRCDIR");
+    let workspace_dir = std::env::var("TEST_WORKSPACE")
+        .expect("Couldn't read env var TEST_WORKSPACE");
     for input_path in input_paths {
         let resolved_input_path = format!(
             "{}/{}/rust/tools/authorization-logic/{}",
@@ -59,11 +60,11 @@ pub fn setup_bazeltest_data_paths(input_paths: Vec<&str>) {
 #[cfg(test)]
 pub fn create_bazeltest_output_paths(output_paths: Vec<&str>) {
     if !is_bazel_test() { return }
-    let tmp_dir = std::env::var("TEST_TMPDIR").unwrap();
+    let tmp_dir = std::env::var("TEST_TMPDIR").expect("Couldn't read env var TEST_TMPDIR");
     for output_path in output_paths {
         let full_path = format!("{}/{}", tmp_dir, output_path);
         if !std::path::Path::new(&full_path).is_dir() {
-            std::fs::create_dir_all(&full_path);
+            std::fs::create_dir_all(&full_path).expect("Creating directories failed");
         }
     }
 }


### PR DESCRIPTION
Small changes to reduce unhelpful lint/warnings