### PR TITLE
Fix Bazel warning on unsafe function used to create temp dirs.

### DIFF
--- a/src/backends/policy_engine/souffle/utils_test.cc
+++ b/src/backends/policy_engine/souffle/utils_test.cc
@@ -29,8 +29,10 @@ namespace raksha::backends::policy_engine::souffle {
 namespace {
 
 TEST(WriteFactsToBadDirectory, WriteFactsToBadDirectory) {
-  absl::Status result = WriteFactsStringToFactsFile(
-      std::filesystem::path(std::tmpnam(nullptr)), "SomeRelation", "");
+  std::filesystem::path bad_path("nosuchpath");
+  ASSERT_FALSE(std::filesystem::exists(bad_path));
+
+  absl::Status result = WriteFactsStringToFactsFile(bad_path, "SomeRelation", "");
   EXPECT_FALSE(result.ok());
   EXPECT_TRUE(IsFailedPrecondition(result));
 }

--- a/src/common/utils/filesystem.cc
+++ b/src/common/utils/filesystem.cc
@@ -35,16 +35,14 @@ absl::StatusOr<std::filesystem::path> CreateTemporaryDirectory() {
         "Unable to access temporary file directory: %s", error_code.message()));
   }
 
-  const int BUFFER_SIZE = 1024;
-  char new_temp_path[BUFFER_SIZE];
-  snprintf(new_temp_path, BUFFER_SIZE, "%s/XXXXXX", temp_path.c_str());
-  if (::mkdtemp(new_temp_path) == nullptr) {
+  std::string target_dir = absl::StrFormat("%s/XXXXXX", temp_path);
+  if (::mkdtemp(target_dir.data()) == nullptr) {
     return absl::FailedPreconditionError(
-        absl::StrFormat("Unable to create directory `%s`: %s", new_temp_path,
+        absl::StrFormat("Unable to create target directory `%s`: %s", target_dir,
                         strerror(errno)));
   }
 
-  return new_temp_path;
+  return std::filesystem::path(target_dir);
 }
 
 }  // namespace raksha::common::utils


### PR DESCRIPTION
Replace use of `tmpnam` with `mkdtemp`. Example warning prior to this change:

  warning: the use of `tmpnam` is dangerous, better use `mkstemp`