### PR TITLE
Use 'CopyConst' to Visitors over both const and non-const IR

### DIFF
--- a/rust/tools/authorization-logic/BUILD
+++ b/rust/tools/authorization-logic/BUILD
@@ -16,7 +16,7 @@
 #-------------------------------------------------------------------------------
 load("@rules_rust//rust:rust.bzl", "rust_binary", "rust_library", "rust_test")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//:__subpackages__"])
 
 licenses(["notice"])
 

--- a/rust/tools/authorization-logic/BUILD
+++ b/rust/tools/authorization-logic/BUILD
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 #-------------------------------------------------------------------------------
-package(default_visibility = ["//visibility:public"])
-
 load("@rules_rust//rust:rust.bzl", "rust_binary", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 

--- a/src/backends/policy_engine/souffle/BUILD
+++ b/src/backends/policy_engine/souffle/BUILD
@@ -79,6 +79,7 @@ cc_library(
         ":raksha_datalog_facts",
         "//src/common/logging",
         "//src/common/utils:fold",
+        "//src/common/utils:types",
         "//src/frontends/sql:decoder_context",
         "//src/ir:ir_traversing_visitor",
         "//src/ir:module",

--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor.cc
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor.cc
@@ -49,7 +49,7 @@ static DatalogAttributePayload GetPayloadForAttribute(ir::Attribute attr,
   return DatalogAttribute::String("");
 }
 
-void DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
+std::monostate DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
   const ir::Operator &op = operation.op();
   absl::string_view op_name = op.name();
 
@@ -88,6 +88,7 @@ void DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
       std::move(operand_list), std::move(attribute_list));
   datalog_facts_.AddIsOperationFact(
       DatalogIsOperationFact(std::move(datalog_operation)));
+  return {};
 }
 
 }  // namespace raksha::backends::policy_engine::souffle

--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor.cc
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor.cc
@@ -49,7 +49,7 @@ static DatalogAttributePayload GetPayloadForAttribute(ir::Attribute attr,
   return DatalogAttribute::String("");
 }
 
-void DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
+Unit DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
   const ir::Operator &op = operation.op();
   absl::string_view op_name = op.name();
 
@@ -88,6 +88,7 @@ void DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
       std::move(operand_list), std::move(attribute_list));
   datalog_facts_.AddIsOperationFact(
       DatalogIsOperationFact(std::move(datalog_operation)));
+  return Unit();
 }
 
 }  // namespace raksha::backends::policy_engine::souffle

--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor.cc
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor.cc
@@ -49,7 +49,7 @@ static DatalogAttributePayload GetPayloadForAttribute(ir::Attribute attr,
   return DatalogAttribute::String("");
 }
 
-std::monostate DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
+void DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) {
   const ir::Operator &op = operation.op();
   absl::string_view op_name = op.name();
 
@@ -88,7 +88,6 @@ std::monostate DatalogLoweringVisitor::PreVisit(const ir::Operation &operation) 
       std::move(operand_list), std::move(attribute_list));
   datalog_facts_.AddIsOperationFact(
       DatalogIsOperationFact(std::move(datalog_operation)));
-  return {};
 }
 
 }  // namespace raksha::backends::policy_engine::souffle

--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor.h
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor.h
@@ -18,6 +18,7 @@
 #define SRC_BACKENDS_POLICY_ENGINE_SOUFFLE_DATALOG_LOWERING_VISITOR_H_
 
 #include "src/backends/policy_engine/souffle/raksha_datalog_facts.h"
+#include "src/common/utils/types.h"
 #include "src/common/logging/logging.h"
 #include "src/ir/attributes/attribute.h"
 #include "src/ir/attributes/int_attribute.h"
@@ -36,7 +37,7 @@ class DatalogLoweringVisitor
   // need it yet, really, but we do need to output something.
   static constexpr absl::string_view kDefaultPrincipal = "sql";
 
-  void PreVisit(const ir::Operation &operation) override;
+  Unit PreVisit(const ir::Operation &operation) override;
 
   const RakshaDatalogFacts &datalog_facts() { return datalog_facts_; }
 

--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor.h
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor.h
@@ -31,7 +31,7 @@
 namespace raksha::backends::policy_engine::souffle {
 
 class DatalogLoweringVisitor
-    : public ir::IRTraversingVisitor<DatalogLoweringVisitor> {
+    : public ir::IRTraversingVisitor<DatalogLoweringVisitor, Unit, true> {
  public:
   // We currently don't have any owner information when outputting IR. We don't
   // need it yet, really, but we do need to output something.

--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor.h
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor.h
@@ -17,6 +17,7 @@
 #ifndef SRC_BACKENDS_POLICY_ENGINE_SOUFFLE_DATALOG_LOWERING_VISITOR_H_
 #define SRC_BACKENDS_POLICY_ENGINE_SOUFFLE_DATALOG_LOWERING_VISITOR_H_
 
+#include <variant>
 #include "src/backends/policy_engine/souffle/raksha_datalog_facts.h"
 #include "src/common/logging/logging.h"
 #include "src/ir/attributes/attribute.h"
@@ -30,13 +31,13 @@
 namespace raksha::backends::policy_engine::souffle {
 
 class DatalogLoweringVisitor
-    : public ir::IRTraversingVisitor<DatalogLoweringVisitor> {
+    : public ir::IRTraversingVisitor<DatalogLoweringVisitor, std::monostate> {
  public:
   // We currently don't have any owner information when outputting IR. We don't
   // need it yet, really, but we do need to output something.
   static constexpr absl::string_view kDefaultPrincipal = "sql";
 
-  void PreVisit(const ir::Operation &operation) override;
+  std::monostate PreVisit(const ir::Operation &operation) override;
 
   const RakshaDatalogFacts &datalog_facts() { return datalog_facts_; }
 

--- a/src/backends/policy_engine/souffle/datalog_lowering_visitor.h
+++ b/src/backends/policy_engine/souffle/datalog_lowering_visitor.h
@@ -17,7 +17,6 @@
 #ifndef SRC_BACKENDS_POLICY_ENGINE_SOUFFLE_DATALOG_LOWERING_VISITOR_H_
 #define SRC_BACKENDS_POLICY_ENGINE_SOUFFLE_DATALOG_LOWERING_VISITOR_H_
 
-#include <variant>
 #include "src/backends/policy_engine/souffle/raksha_datalog_facts.h"
 #include "src/common/logging/logging.h"
 #include "src/ir/attributes/attribute.h"
@@ -31,13 +30,13 @@
 namespace raksha::backends::policy_engine::souffle {
 
 class DatalogLoweringVisitor
-    : public ir::IRTraversingVisitor<DatalogLoweringVisitor, std::monostate> {
+    : public ir::IRTraversingVisitor<DatalogLoweringVisitor> {
  public:
   // We currently don't have any owner information when outputting IR. We don't
   // need it yet, really, but we do need to output something.
   static constexpr absl::string_view kDefaultPrincipal = "sql";
 
-  std::monostate PreVisit(const ir::Operation &operation) override;
+  void PreVisit(const ir::Operation &operation) override;
 
   const RakshaDatalogFacts &datalog_facts() { return datalog_facts_; }
 

--- a/src/common/utils/BUILD
+++ b/src/common/utils/BUILD
@@ -26,6 +26,15 @@ cc_library(
     deps = [],
 )
 
+cc_test(
+    name = "types_test",
+    srcs = ["types_test.cc"],
+    deps = [
+        ":types",
+        "//src/common/testing:gtest",
+    ],
+)
+
 cc_library(
     name = "intrusive_ptr",
     hdrs = ["intrusive_ptr.h"],

--- a/src/common/utils/BUILD
+++ b/src/common/utils/BUILD
@@ -21,6 +21,12 @@ package(
 )
 
 cc_library(
+    name = "types",
+    hdrs = ["types.h"],
+    deps = [],
+)
+
+cc_library(
     name = "intrusive_ptr",
     hdrs = ["intrusive_ptr.h"],
     deps = [

--- a/src/common/utils/intrusive_ptr.h
+++ b/src/common/utils/intrusive_ptr.h
@@ -20,7 +20,7 @@
 
 namespace raksha {
 
-// An implemntation of reference counted ptr where the reference count is
+// An implementation of reference counted ptr where the reference count is
 // embedded in the object itself (i.e., intrusive). This is mostly based on the
 // implementation of boost::intrusive_ptr.
 template <typename T>

--- a/src/common/utils/types.h
+++ b/src/common/utils/types.h
@@ -18,7 +18,9 @@
 
 #include <variant>
 
-// Type alias for monostate that sounds less scary.
-using Unit = std::monostate;
+namespace raksha {
+  // Type alias for monostate that sounds less scary.
+  using Unit = std::monostate;
+}
 
 #endif  // SRC_COMMON_UTILS_TYPES_H_

--- a/src/common/utils/types.h
+++ b/src/common/utils/types.h
@@ -1,0 +1,24 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#ifndef SRC_COMMON_UTILS_TYPES_H_
+#define SRC_COMMON_UTILS_TYPES_H_
+
+#include <variant>
+
+// Type alias for monostate that sounds less scary.
+using Unit = std::monostate;
+
+#endif  // SRC_COMMON_UTILS_TYPES_H_

--- a/src/common/utils/types.h
+++ b/src/common/utils/types.h
@@ -31,6 +31,11 @@ struct SelectType {
 };
 
 template <typename T, typename F>
+struct SelectType<true, T, F> {
+    using Result = T;
+};
+
+template <typename T, typename F>
 struct SelectType<false, T, F> {
     using Result = F;
 };

--- a/src/common/utils/types_test.cc
+++ b/src/common/utils/types_test.cc
@@ -13,31 +13,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-----------------------------------------------------------------------------
-#ifndef SRC_COMMON_UTILS_TYPES_H_
-#define SRC_COMMON_UTILS_TYPES_H_
+#include "src/common/utils/types.h"
 
-#include <variant>
+#include <iostream>
+#include <string>
+
+#include "src/common/testing/gtest.h"
 
 namespace raksha {
-// Type alias for monostate that sounds less scary.
-using Unit = std::monostate;
+namespace {
 
-// An implementation of a static, type-level, 'if'.
-// Useful for writing typesafe, code generically (especially for generic constness).
-// Based on SAT's laser (specifically 'misc_utils.h').
-template <bool Flag, typename T, typename F>
-struct SelectType {
-    using Result = T;
-};
-
-template <typename T, typename F>
-struct SelectType<false, T, F> {
-    using Result = F;
-};
-
-template <bool IsConst, typename T>
-using CopyConst = typename SelectType<IsConst, const T, T>::Result;
-
+TEST(TypesTest, SelectTypeTrue) {
+  SelectType<true, int, std::string>::Result a = 3;
+  EXPECT_EQ(a, 3);
 }
 
-#endif  // SRC_COMMON_UTILS_TYPES_H_
+TEST(TypesTest, SelectTypeFalse) {
+  SelectType<false, int, std::string>::Result a = "Hi";
+  EXPECT_EQ(a, "Hi");
+}
+
+TEST(TypesTest, CopyConstTypeTrue) {
+  CopyConst<true, int> a = 3;
+  // a++; // Should not compile.
+  EXPECT_EQ(a, 3);
+}
+
+TEST(TypesTest, CopyConstTypeFalse) {
+  CopyConst<false, int> a = 4;
+  a++;
+  EXPECT_EQ(a, 4);
+}
+
+}  // namespace
+}  // namespace raksha

--- a/src/common/utils/types_test.cc
+++ b/src/common/utils/types_test.cc
@@ -42,7 +42,7 @@ TEST(TypesTest, CopyConstTypeTrue) {
 TEST(TypesTest, CopyConstTypeFalse) {
   CopyConst<false, int> a = 4;
   a++;
-  EXPECT_EQ(a, 4);
+  EXPECT_EQ(a, 5);
 }
 
 }  // namespace

--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -118,7 +118,10 @@ cc_test(
 cc_library(
     name = "ir_traversing_visitor",
     hdrs = ["ir_traversing_visitor.h"],
-    deps = [":module"],
+    deps = [
+        ":module",
+        "//src/common/utils:types",
+    ],
 )
 
 cc_test(

--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -177,6 +177,7 @@ cc_library(
         ":operator",
         ":ssa_names",
         ":value",
+        "//src/common/utils:types",
         "//src/ir/attributes:attribute",
         "//src/ir/types",
         "@absl//absl/container:flat_hash_map",

--- a/src/ir/data_decl_test.cc
+++ b/src/ir/data_decl_test.cc
@@ -66,14 +66,14 @@ TEST_F(DataDeclCollectionTest, AddDeclReturnsAddedDecl) {
             "TestCount");
 }
 
-TEST_F(DataDeclCollectionTest, DuplicateAddDeclCausesFaiure) {
+TEST_F(DataDeclCollectionTest, DuplicateAddDeclCausesFailure) {
   collection_.AddDecl("count", type_factory_.MakePrimitiveType());
   EXPECT_DEATH(
       { collection_.AddDecl("count", type_factory_.MakePrimitiveType()); },
       "Adding a duplicate declaration for `count`.");
 }
 
-TEST_F(DataDeclCollectionTest, FindDeclReturnsExisingDecl) {
+TEST_F(DataDeclCollectionTest, FindDeclReturnsExistingDecl) {
   collection_.AddDecl(
       "city", DataDeclTest::MakeTestEntityType(type_factory_, "TestCity"));
 

--- a/src/ir/dot/dot_generator.cc
+++ b/src/ir/dot/dot_generator.cc
@@ -41,8 +41,8 @@ class DotGeneratorHelper : public IRTraversingVisitor<DotGeneratorHelper> {
     return visitor.GetDotGraph();
   }
 
-  std::monostate PreVisit(const Block& block) override;
-  std::monostate PreVisit(const Operation& operation) override;
+  void PreVisit(const Block& block) override;
+  void PreVisit(const Operation& operation) override;
 
  private:
   DotGeneratorHelper(DotGeneratorConfig config) : config_(std::move(config)) {}
@@ -239,7 +239,7 @@ std::string DotGeneratorHelper::GetDotGraph() {
   return absl::StrFormat(kDigraphFormat, blocks, operations, edges);
 }
 
-std::monostate DotGeneratorHelper::PreVisit(const Operation& operation) {
+void DotGeneratorHelper::PreVisit(const Operation& operation) {
   std::string node_name = GetNodeName(operation);
   AddOperationNode(node_name, operation);
   unsigned input_index = 0;
@@ -264,13 +264,11 @@ std::monostate DotGeneratorHelper::PreVisit(const Operation& operation) {
       AddEdge(GetNodeName(stored_value->storage()), input_name);
     }
   }
-  return {};
 }
 
-std::monostate DotGeneratorHelper::PreVisit(const Block& block) {
+void DotGeneratorHelper::PreVisit(const Block& block) {
   std::string block_name = GetNodeName(block);
   AddBlockNode(block_name, block);
-  return {};
 }
 
 std::string DotGenerator::ModuleAsDot(const Module& module,

--- a/src/ir/dot/dot_generator.cc
+++ b/src/ir/dot/dot_generator.cc
@@ -41,8 +41,8 @@ class DotGeneratorHelper : public IRTraversingVisitor<DotGeneratorHelper> {
     return visitor.GetDotGraph();
   }
 
-  void PreVisit(const Block& block) override;
-  void PreVisit(const Operation& operation) override;
+  Unit PreVisit(const Block& block) override;
+  Unit PreVisit(const Operation& operation) override;
 
  private:
   DotGeneratorHelper(DotGeneratorConfig config) : config_(std::move(config)) {}
@@ -239,7 +239,7 @@ std::string DotGeneratorHelper::GetDotGraph() {
   return absl::StrFormat(kDigraphFormat, blocks, operations, edges);
 }
 
-void DotGeneratorHelper::PreVisit(const Operation& operation) {
+Unit DotGeneratorHelper::PreVisit(const Operation& operation) {
   std::string node_name = GetNodeName(operation);
   AddOperationNode(node_name, operation);
   unsigned input_index = 0;
@@ -264,11 +264,13 @@ void DotGeneratorHelper::PreVisit(const Operation& operation) {
       AddEdge(GetNodeName(stored_value->storage()), input_name);
     }
   }
+  return Unit();
 }
 
-void DotGeneratorHelper::PreVisit(const Block& block) {
+Unit DotGeneratorHelper::PreVisit(const Block& block) {
   std::string block_name = GetNodeName(block);
   AddBlockNode(block_name, block);
+  return Unit();
 }
 
 std::string DotGenerator::ModuleAsDot(const Module& module,

--- a/src/ir/dot/dot_generator.cc
+++ b/src/ir/dot/dot_generator.cc
@@ -41,8 +41,8 @@ class DotGeneratorHelper : public IRTraversingVisitor<DotGeneratorHelper> {
     return visitor.GetDotGraph();
   }
 
-  void PreVisit(const Block& block) override;
-  void PreVisit(const Operation& operation) override;
+  std::monostate PreVisit(const Block& block) override;
+  std::monostate PreVisit(const Operation& operation) override;
 
  private:
   DotGeneratorHelper(DotGeneratorConfig config) : config_(std::move(config)) {}
@@ -239,7 +239,7 @@ std::string DotGeneratorHelper::GetDotGraph() {
   return absl::StrFormat(kDigraphFormat, blocks, operations, edges);
 }
 
-void DotGeneratorHelper::PreVisit(const Operation& operation) {
+std::monostate DotGeneratorHelper::PreVisit(const Operation& operation) {
   std::string node_name = GetNodeName(operation);
   AddOperationNode(node_name, operation);
   unsigned input_index = 0;
@@ -264,11 +264,13 @@ void DotGeneratorHelper::PreVisit(const Operation& operation) {
       AddEdge(GetNodeName(stored_value->storage()), input_name);
     }
   }
+  return {};
 }
 
-void DotGeneratorHelper::PreVisit(const Block& block) {
+std::monostate DotGeneratorHelper::PreVisit(const Block& block) {
   std::string block_name = GetNodeName(block);
   AddBlockNode(block_name, block);
+  return {};
 }
 
 std::string DotGenerator::ModuleAsDot(const Module& module,

--- a/src/ir/ir_printer.h
+++ b/src/ir/ir_printer.h
@@ -42,35 +42,39 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     return out.str();
   }
 
-  void PreVisit(const Module& module) override {
+  Unit PreVisit(const Module& module) override {
     out_ << Indent()
          << absl::StreamFormat("module m%d {\n",
                                ssa_names_.GetOrCreateID(module));
     IncreaseIndent();
+    return Unit();
   }
 
-  void PostVisit(const Module& module) override {
+  Unit PostVisit(const Module& module) override {
     DecreaseIndent();
     out_ << Indent()
          << absl::StreamFormat("}  // module m%d\n",
                                ssa_names_.GetOrCreateID(module));
+    return Unit();
   }
 
-  void PreVisit(const Block& block) override {
+  Unit PreVisit(const Block& block) override {
     out_ << Indent()
          << absl::StreamFormat("block b%d {\n",
                                ssa_names_.GetOrCreateID(block));
     IncreaseIndent();
+    return Unit();
   }
 
-  void PostVisit(const Block& block) override {
+  Unit PostVisit(const Block& block) override {
     DecreaseIndent();
     out_ << Indent()
          << absl::StreamFormat("}  // block b%d\n",
                                ssa_names_.GetOrCreateID(block));
+    return Unit();
   }
 
-  void PreVisit(const Operation& operation) override {
+  Unit PreVisit(const Operation& operation) override {
     constexpr absl::string_view kOperationFormat = "%%%d = %s [%s](%s)";
     SsaNames::ID this_ssa_name = ssa_names_.GetOrCreateID(operation);
 
@@ -97,13 +101,15 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     } else {
       out_ << "\n";
     }
+    return Unit();
   }
 
-  void PostVisit(const Operation& operation) override {
+  Unit PostVisit(const Operation& operation) override {
     if (operation.impl_module()) {
       DecreaseIndent();
       out_ << Indent() << "}\n";
     }
+    return Unit();
   }
 
   // Returns a pretty-printed map where entries are sorted by the key.

--- a/src/ir/ir_printer.h
+++ b/src/ir/ir_printer.h
@@ -16,7 +16,6 @@
 #ifndef SRC_IR_IR_PRINTER_H_
 #define SRC_IR_IR_PRINTER_H_
 
-#include <variant>
 #include <memory>
 
 #include "absl/strings/str_format.h"
@@ -43,37 +42,35 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     return out.str();
   }
 
-  std::monostate PreVisit(const Module& module) override {
+  void PreVisit(const Module& module) override {
     out_ << Indent()
          << absl::StreamFormat("module m%d {\n",
                                ssa_names_.GetOrCreateID(module));
     IncreaseIndent();
-    return {};
   }
 
-  void PostVisit(const Module& module, std::monostate&) override {
+  void PostVisit(const Module& module) override {
     DecreaseIndent();
     out_ << Indent()
          << absl::StreamFormat("}  // module m%d\n",
                                ssa_names_.GetOrCreateID(module));
   }
 
-  std::monostate PreVisit(const Block& block) override {
+  void PreVisit(const Block& block) override {
     out_ << Indent()
          << absl::StreamFormat("block b%d {\n",
                                ssa_names_.GetOrCreateID(block));
     IncreaseIndent();
-    return {};
   }
 
-  void PostVisit(const Block& block, std::monostate&) override {
+  void PostVisit(const Block& block) override {
     DecreaseIndent();
     out_ << Indent()
          << absl::StreamFormat("}  // block b%d\n",
                                ssa_names_.GetOrCreateID(block));
   }
 
-  std::monostate PreVisit(const Operation& operation) override {
+  void PreVisit(const Operation& operation) override {
     constexpr absl::string_view kOperationFormat = "%%%d = %s [%s](%s)";
     SsaNames::ID this_ssa_name = ssa_names_.GetOrCreateID(operation);
 
@@ -100,10 +97,9 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     } else {
       out_ << "\n";
     }
-    return {};
   }
 
-  void PostVisit(const Operation& operation, std::monostate&) override {
+  void PostVisit(const Operation& operation) override {
     if (operation.impl_module()) {
       DecreaseIndent();
       out_ << Indent() << "}\n";

--- a/src/ir/ir_printer.h
+++ b/src/ir/ir_printer.h
@@ -16,6 +16,7 @@
 #ifndef SRC_IR_IR_PRINTER_H_
 #define SRC_IR_IR_PRINTER_H_
 
+#include <variant>
 #include <memory>
 
 #include "absl/strings/str_format.h"
@@ -42,35 +43,37 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     return out.str();
   }
 
-  void PreVisit(const Module& module) override {
+  std::monostate PreVisit(const Module& module) override {
     out_ << Indent()
          << absl::StreamFormat("module m%d {\n",
                                ssa_names_.GetOrCreateID(module));
     IncreaseIndent();
+    return {};
   }
 
-  void PostVisit(const Module& module) override {
+  void PostVisit(const Module& module, std::monostate&) override {
     DecreaseIndent();
     out_ << Indent()
          << absl::StreamFormat("}  // module m%d\n",
                                ssa_names_.GetOrCreateID(module));
   }
 
-  void PreVisit(const Block& block) override {
+  std::monostate PreVisit(const Block& block) override {
     out_ << Indent()
          << absl::StreamFormat("block b%d {\n",
                                ssa_names_.GetOrCreateID(block));
     IncreaseIndent();
+    return {};
   }
 
-  void PostVisit(const Block& block) override {
+  void PostVisit(const Block& block, std::monostate&) override {
     DecreaseIndent();
     out_ << Indent()
          << absl::StreamFormat("}  // block b%d\n",
                                ssa_names_.GetOrCreateID(block));
   }
 
-  void PreVisit(const Operation& operation) override {
+  std::monostate PreVisit(const Operation& operation) override {
     constexpr absl::string_view kOperationFormat = "%%%d = %s [%s](%s)";
     SsaNames::ID this_ssa_name = ssa_names_.GetOrCreateID(operation);
 
@@ -97,9 +100,10 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     } else {
       out_ << "\n";
     }
+    return {};
   }
 
-  void PostVisit(const Operation& operation) override {
+  void PostVisit(const Operation& operation, std::monostate&) override {
     if (operation.impl_module()) {
       DecreaseIndent();
       out_ << Indent() << "}\n";

--- a/src/ir/ir_printer.h
+++ b/src/ir/ir_printer.h
@@ -50,12 +50,12 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     return Unit();
   }
 
-  Unit PostVisit(const Module& module) override {
+  Unit PostVisit(const Module& module, Unit result) override {
     DecreaseIndent();
     out_ << Indent()
          << absl::StreamFormat("}  // module m%d\n",
                                ssa_names_.GetOrCreateID(module));
-    return Unit();
+    return result;
   }
 
   Unit PreVisit(const Block& block) override {
@@ -66,12 +66,12 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     return Unit();
   }
 
-  Unit PostVisit(const Block& block) override {
+  Unit PostVisit(const Block& block, Unit result) override {
     DecreaseIndent();
     out_ << Indent()
          << absl::StreamFormat("}  // block b%d\n",
                                ssa_names_.GetOrCreateID(block));
-    return Unit();
+    return result;
   }
 
   Unit PreVisit(const Operation& operation) override {
@@ -104,12 +104,12 @@ class IRPrinter : public IRTraversingVisitor<IRPrinter> {
     return Unit();
   }
 
-  Unit PostVisit(const Operation& operation) override {
+  Unit PostVisit(const Operation& operation, Unit result) override {
     if (operation.impl_module()) {
       DecreaseIndent();
       out_ << Indent() << "}\n";
     }
-    return Unit();
+    return result;
   }
 
   // Returns a pretty-printed map where entries are sorted by the key.

--- a/src/ir/ir_traversing_visitor.h
+++ b/src/ir/ir_traversing_visitor.h
@@ -31,15 +31,11 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
   virtual ~IRTraversingVisitor() {}
 
   // Invoked before all the children of `module` is visited.
-  virtual void PreVisit(const Module& module) {}
-  virtual Result ReturningPreVisit(const Module& module) {
-    PreVisit(module);
+  virtual Result PreVisit(const Module& module) {
     return Result();
   }
   // Invoked after all the children of `module` is visited.
-  virtual void PostVisit(const Module& module) {}
   virtual Result PostVisit(const Module& module, Result result) {
-    PostVisit(module);
     return result;
   }
   virtual Result FoldResult(const Module& module, Result child_result,
@@ -47,15 +43,11 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
     return result;
   }
   // Invoked before all the children of `block` is visited.
-  virtual void PreVisit(const Block& block) {}
-  virtual Result ReturningPreVisit(const Block& block) {
-    PreVisit(block);
+  virtual Result PreVisit(const Block& block) {
     return Result();
   }
   // Invoked after all the children of `block` is visited.
-  virtual void PostVisit(const Block& block) {}
   virtual Result PostVisit(const Block& block, Result result) {
-    PostVisit(block);
     return result;
   }
   virtual Result FoldResult(const Block& block, Result child_result,
@@ -63,15 +55,11 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
     return result;
   }
   // Invoked before all the children of `operation` is visited.
-  virtual void PreVisit(const Operation& operation) {}
-  virtual Result ReturningPreVisit(const Operation& operation) {
-    PreVisit(operation);
+  virtual Result PreVisit(const Operation& operation) {
     return Result();
   }
   // Invoked after all the children of `operation` is visited.
-  virtual void PostVisit(const Operation& operation) {}
   virtual Result PostVisit(const Operation& operation, Result result) {
-    PostVisit(operation);
     return result;
   }
   virtual Result FoldResult(const Operation& operation, Result child_result,
@@ -80,7 +68,7 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
   }
 
   Result Visit(const Module& module) final override {
-    Result result = ReturningPreVisit(module);
+    Result result = PreVisit(module);
     for (const std::unique_ptr<Block>& block : module.blocks()) {
       result =
           FoldResult(*block, block->Accept<Derived, Result>(*this), std::move(result));
@@ -89,7 +77,7 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
   }
 
   Result Visit(const Block& block) final override {
-    Result result = ReturningPreVisit(block);
+    Result result = PreVisit(block);
     for (const std::unique_ptr<Operation>& operation : block.operations()) {
       result = FoldResult(*operation, operation->Accept<Derived, Result>(*this),
                           std::move(result));
@@ -98,7 +86,7 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
   }
 
   Result Visit(const Operation& operation) final override {
-    Result result = ReturningPreVisit(operation);
+    Result result = PreVisit(operation);
     const Module* module = operation.impl_module();
     if (module != nullptr) {
       result = FoldResult(operation, module->Accept<Derived, Result>(*this),

--- a/src/ir/ir_traversing_visitor.h
+++ b/src/ir/ir_traversing_visitor.h
@@ -31,23 +31,38 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
   virtual ~IRTraversingVisitor() {}
 
   // Invoked before all the children of `module` is visited.
-  virtual Result PreVisit(const Module& module) { return Result(); }
+  virtual void PreVisit(const Module& module) {}
+  virtual Result ReturningPreVisit(const Module& module) {
+    PreVisit(module);
+    return Result();
+  }
   // Invoked after all the children of `module` is visited.
-  virtual void PostVisit(const Module& module, Result& result) {}
+  virtual void PostVisit(const Module& module) {}
+  virtual void PostVisit(const Module& module, Result& result) { PostVisit(module); }
   virtual void FoldResult(const Module& module, Result child_result, Result& result) {}
   // Invoked before all the children of `block` is visited.
-  virtual Result PreVisit(const Block& block) { return Result(); }
+  virtual void PreVisit(const Block& block) {}
+  virtual Result ReturningPreVisit(const Block& block) {
+    PreVisit(block);
+    return Result();
+  }
   // Invoked after all the children of `block` is visited.
-  virtual void PostVisit(const Block& block, Result& result) {}
+  virtual void PostVisit(const Block& block) {}
+  virtual void PostVisit(const Block& block, Result& result) { PostVisit(block); }
   virtual void FoldResult(const Block& block, Result child_result, Result& result) {}
   // Invoked before all the children of `operation` is visited.
-  virtual Result PreVisit(const Operation& operation) { return Result(); }
+  virtual void PreVisit(const Operation& operation) {}
+  virtual Result ReturningPreVisit(const Operation& operation) {
+    PreVisit(operation);
+    return Result();
+  }
   // Invoked after all the children of `operation` is visited.
-  virtual void PostVisit(const Operation& operation, Result& result) {}
+  virtual void PostVisit(const Operation& operation) {}
+  virtual void PostVisit(const Operation& operation, Result& result) { PostVisit(operation); }
   virtual void FoldResult(const Operation& operation, Result child_result, Result& result) {}
 
   Result Visit(const Module& module) final override {
-    Result result = PreVisit(module);
+    Result result = ReturningPreVisit(module);
     for (const std::unique_ptr<Block>& block : module.blocks()) {
       FoldResult(*block, block->Accept<Derived, Result>(*this), result);
     }
@@ -56,7 +71,7 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
   }
 
   Result Visit(const Block& block) final override {
-    Result result = PreVisit(block);
+    Result result = ReturningPreVisit(block);
     for (const std::unique_ptr<Operation>& operation : block.operations()) {
       FoldResult(*operation, operation->Accept<Derived, Result>(*this), result);
     }
@@ -65,7 +80,7 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
   }
 
   Result Visit(const Operation& operation) final override {
-    Result result = PreVisit(operation);
+    Result result = ReturningPreVisit(operation);
     const Module* module = operation.impl_module();
     if (module != nullptr) {
       FoldResult(operation, module->Accept<Derived, Result>(*this), result);

--- a/src/ir/ir_traversing_visitor.h
+++ b/src/ir/ir_traversing_visitor.h
@@ -19,75 +19,76 @@
 #include "src/common/utils/types.h"
 #include "src/ir/ir_visitor.h"
 #include "src/ir/module.h"
+#include "src/common/utils/types.h"
 
 namespace raksha::ir {
 
 // A visitor that also traverses the children of a node and allows performing
 // different actions before (PreVisit) and after (PostVisit) the children are
 // visited. Override any of the `PreVisit` and `PostVisit` methods as needed.
-template <typename Derived, typename Result = Unit>
-class IRTraversingVisitor : public IRVisitor<Derived, Result> {
+template <typename Derived, bool IsConst=true, typename Result=std::monostate>
+class IRTraversingVisitor : public IRVisitor<Derived, IsConst, Result> {
  public:
   virtual ~IRTraversingVisitor() {}
 
   // Invoked before all the children of `module` is visited.
-  virtual Result PreVisit(const Module& module) {
+  virtual Result PreVisit(CopyConst<IsConst, Module>& module) {
     return Result();
   }
   // Invoked after all the children of `module` is visited.
-  virtual Result PostVisit(const Module& module, Result result) {
+  virtual Result PostVisit(CopyConst<IsConst, Module& module, Result result) {
     return result;
   }
-  virtual Result FoldResult(const Module& module, Result child_result,
+  virtual Result FoldResult(CopyConst<IsConst, Module& module, Result child_result,
                             Result result) {
     return result;
   }
   // Invoked before all the children of `block` is visited.
-  virtual Result PreVisit(const Block& block) {
+  virtual Result PreVisit(CopyConst<IsConst, Block& block) {
     return Result();
   }
   // Invoked after all the children of `block` is visited.
-  virtual Result PostVisit(const Block& block, Result result) {
+  virtual Result PostVisit(CopyConst<IsConst, Block& block, Result result) {
     return result;
   }
-  virtual Result FoldResult(const Block& block, Result child_result,
+  virtual Result FoldResult(CopyConst<IsConst, Block& block, Result child_result,
                             Result result) {
     return result;
   }
   // Invoked before all the children of `operation` is visited.
-  virtual Result PreVisit(const Operation& operation) {
+  virtual Result PreVisit(CopyConst<IsConst, Operation& operation) {
     return Result();
   }
   // Invoked after all the children of `operation` is visited.
-  virtual Result PostVisit(const Operation& operation, Result result) {
+  virtual Result PostVisit(CopyConst<IsConst, Operation& operation, Result result) {
     return result;
   }
-  virtual Result FoldResult(const Operation& operation, Result child_result,
+  virtual Result FoldResult(CopyConst<IsConst, Operation& operation, Result child_result,
                             Result result) {
     return result;
   }
 
-  Result Visit(const Module& module) final override {
+  Result Visit(CopyConst<IsConst, Module>& module) final override {
     Result result = PreVisit(module);
-    for (const std::unique_ptr<Block>& block : module.blocks()) {
+    for (CopyConst<IsConst, std::unique_ptr<Block>>& block : module.blocks()) {
       result =
           FoldResult(*block, block->Accept<Derived, Result>(*this), std::move(result));
     }
     return PostVisit(module, std::move(result));
   }
 
-  Result Visit(const Block& block) final override {
+  Result Visit(CopyConst<IsConst, Block>& block) final override {
     Result result = PreVisit(block);
-    for (const std::unique_ptr<Operation>& operation : block.operations()) {
+    for (CopyConst<IsConst, std::unique_ptr<Operation>& operation : block.operations()) {
       result = FoldResult(*operation, operation->Accept<Derived, Result>(*this),
                           std::move(result));
     }
     return PostVisit(block, std::move(result));
   }
 
-  Result Visit(const Operation& operation) final override {
+  Result Visit(CopyConst<IsConst, Operation>& operation) final override {
     Result result = PreVisit(operation);
-    const Module* module = operation.impl_module();
+    CopyConst<IsConst, Module* module = operation.impl_module();
     if (module != nullptr) {
       result = FoldResult(operation, module->Accept<Derived, Result>(*this),
                           std::move(result));

--- a/src/ir/ir_traversing_visitor.h
+++ b/src/ir/ir_traversing_visitor.h
@@ -26,8 +26,8 @@ namespace raksha::ir {
 // A visitor that also traverses the children of a node and allows performing
 // different actions before (PreVisit) and after (PostVisit) the children are
 // visited. Override any of the `PreVisit` and `PostVisit` methods as needed.
-template <typename Derived, bool IsConst=true, typename Result=std::monostate>
-class IRTraversingVisitor : public IRVisitor<Derived, IsConst, Result> {
+template <typename Derived, typename Result=std::monostate, bool IsConst=true>
+class IRTraversingVisitor : public IRVisitor<Derived, Result, IsConst> {
  public:
   virtual ~IRTraversingVisitor() {}
 
@@ -36,51 +36,51 @@ class IRTraversingVisitor : public IRVisitor<Derived, IsConst, Result> {
     return Result();
   }
   // Invoked after all the children of `module` is visited.
-  virtual Result PostVisit(CopyConst<IsConst, Module& module, Result result) {
+  virtual Result PostVisit(CopyConst<IsConst, Module>& module, Result result) {
     return result;
   }
-  virtual Result FoldResult(CopyConst<IsConst, Module& module, Result child_result,
+  virtual Result FoldResult(CopyConst<IsConst, Module>& module, Result child_result,
                             Result result) {
     return result;
   }
   // Invoked before all the children of `block` is visited.
-  virtual Result PreVisit(CopyConst<IsConst, Block& block) {
+  virtual Result PreVisit(CopyConst<IsConst, Block>& block) {
     return Result();
   }
   // Invoked after all the children of `block` is visited.
-  virtual Result PostVisit(CopyConst<IsConst, Block& block, Result result) {
+  virtual Result PostVisit(CopyConst<IsConst, Block>& block, Result result) {
     return result;
   }
-  virtual Result FoldResult(CopyConst<IsConst, Block& block, Result child_result,
+  virtual Result FoldResult(CopyConst<IsConst, Block>& block, Result child_result,
                             Result result) {
     return result;
   }
   // Invoked before all the children of `operation` is visited.
-  virtual Result PreVisit(CopyConst<IsConst, Operation& operation) {
+  virtual Result PreVisit(CopyConst<IsConst, Operation>& operation) {
     return Result();
   }
   // Invoked after all the children of `operation` is visited.
-  virtual Result PostVisit(CopyConst<IsConst, Operation& operation, Result result) {
+  virtual Result PostVisit(CopyConst<IsConst, Operation>& operation, Result result) {
     return result;
   }
-  virtual Result FoldResult(CopyConst<IsConst, Operation& operation, Result child_result,
+  virtual Result FoldResult(CopyConst<IsConst, Operation>& operation, Result child_result,
                             Result result) {
     return result;
   }
 
   Result Visit(CopyConst<IsConst, Module>& module) final override {
     Result result = PreVisit(module);
-    for (CopyConst<IsConst, std::unique_ptr<Block>>& block : module.blocks()) {
+    for (auto& block : module.blocks()) {
       result =
-          FoldResult(*block, block->Accept<Derived, Result>(*this), std::move(result));
+          FoldResult(*block, block->Accept(*this), std::move(result));
     }
     return PostVisit(module, std::move(result));
   }
 
   Result Visit(CopyConst<IsConst, Block>& block) final override {
     Result result = PreVisit(block);
-    for (CopyConst<IsConst, std::unique_ptr<Operation>& operation : block.operations()) {
-      result = FoldResult(*operation, operation->Accept<Derived, Result>(*this),
+    for (auto& operation : block.operations()) {
+      result = FoldResult(*operation, operation->Accept(*this),
                           std::move(result));
     }
     return PostVisit(block, std::move(result));
@@ -88,9 +88,9 @@ class IRTraversingVisitor : public IRVisitor<Derived, IsConst, Result> {
 
   Result Visit(CopyConst<IsConst, Operation>& operation) final override {
     Result result = PreVisit(operation);
-    CopyConst<IsConst, Module* module = operation.impl_module();
+    auto* module = operation.impl_module();
     if (module != nullptr) {
-      result = FoldResult(operation, module->Accept<Derived, Result>(*this),
+      result = FoldResult(operation, module->Accept(*this),
                           std::move(result));
     }
     return PostVisit(operation, std::move(result));

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -39,9 +39,9 @@ class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor> {
     if (pre_visits_) nodes_.push_back(std::addressof(module));
     return Unit();
   }
-  Unit PostVisit(const Module& module) override {
+  Unit PostVisit(const Module& module, Unit result) override {
     if (post_visits_) nodes_.push_back(std::addressof(module));
-    return Unit();
+    return result;
   }
 
   Unit PreVisit(const Block& block) override {
@@ -49,9 +49,9 @@ class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor> {
     return Unit();
   }
 
-  Unit PostVisit(const Block& block) override {
+  Unit PostVisit(const Block& block, Unit result) override {
     if (post_visits_) nodes_.push_back(std::addressof(block));
-    return Unit();
+    return result;
   }
 
   Unit PreVisit(const Operation& operation) override {
@@ -59,9 +59,9 @@ class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor> {
     return Unit();
   }
 
-  Unit PostVisit(const Operation& operation) override {
+  Unit PostVisit(const Operation& operation, Unit result) override {
     if (post_visits_) nodes_.push_back(std::addressof(operation));
-    return Unit();
+    return result;
   }
 
   const std::vector<const void*>& nodes() const { return nodes_; }
@@ -174,7 +174,7 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
         post_visits_(traversal_type == TraversalType::kPost ||
                      traversal_type == TraversalType::kBoth) {}
 
-  ResultType ReturningPreVisit(const Module& module) override {
+  ResultType PreVisit(const Module& module) override {
     ResultType result;
     if (pre_visits_) result.push_back((void*)std::addressof(module));
     return result;
@@ -188,7 +188,7 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
     return result;
   }
 
-  ResultType ReturningPreVisit(const Block& block) override {
+  ResultType PreVisit(const Block& block) override {
     ResultType result;
     if (pre_visits_) result.push_back((void*)std::addressof(block));
     return result;
@@ -203,7 +203,7 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
     return result;
   }
 
-  ResultType ReturningPreVisit(const Operation& operation) override {
+  ResultType PreVisit(const Operation& operation) override {
     ResultType result;
     if (pre_visits_) result.push_back((void*)std::addressof(operation));
     return result;

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -35,27 +35,33 @@ class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor> {
         post_visits_(traversal_type == TraversalType::kPost ||
                      traversal_type == TraversalType::kBoth) {}
 
-  void PreVisit(const Module& module) override {
+  Unit PreVisit(const Module& module) override {
     if (pre_visits_) nodes_.push_back(std::addressof(module));
+    return Unit();
   }
-  void PostVisit(const Module& module) override {
+  Unit PostVisit(const Module& module) override {
     if (post_visits_) nodes_.push_back(std::addressof(module));
+    return Unit();
   }
 
-  void PreVisit(const Block& block) override {
+  Unit PreVisit(const Block& block) override {
     if (pre_visits_) nodes_.push_back(std::addressof(block));
+    return Unit();
   }
 
-  void PostVisit(const Block& block) override {
+  Unit PostVisit(const Block& block) override {
     if (post_visits_) nodes_.push_back(std::addressof(block));
+    return Unit();
   }
 
-  void PreVisit(const Operation& operation) override {
+  Unit PreVisit(const Operation& operation) override {
     if (pre_visits_) nodes_.push_back(std::addressof(operation));
+    return Unit();
   }
 
-  void PostVisit(const Operation& operation) override {
+  Unit PostVisit(const Operation& operation) override {
     if (post_visits_) nodes_.push_back(std::addressof(operation));
+    return Unit();
   }
 
   const std::vector<const void*>& nodes() const { return nodes_; }

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -26,7 +26,7 @@ namespace {
 
 // Just a small test visitor that collects the nodes as they are visited to make
 // sure that  Pre and Post visits happened correctly.
-class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor, std::monostate> {
+class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor> {
  public:
   enum class TraversalType { PRE = 0x1, POST = 0x2, BOTH = 0x3 };
   CollectingVisitor(TraversalType traversal_type)
@@ -35,29 +35,26 @@ class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor, std::mon
         post_visits_(traversal_type == TraversalType::POST ||
                      traversal_type == TraversalType::BOTH) {}
 
-  std::monostate PreVisit(const Module& module) override {
+  void PreVisit(const Module& module) override {
     if (pre_visits_) nodes_.push_back(std::addressof(module));
-    return {};
   }
-  void PostVisit(const Module& module, std::monostate&) override {
+  void PostVisit(const Module& module) override {
     if (post_visits_) nodes_.push_back(std::addressof(module));
   }
 
-  std::monostate PreVisit(const Block& block) override {
+  void PreVisit(const Block& block) override {
     if (pre_visits_) nodes_.push_back(std::addressof(block));
-    return {};
   }
 
-  void PostVisit(const Block& block, std::monostate&) override {
+  void PostVisit(const Block& block) override {
     if (post_visits_) nodes_.push_back(std::addressof(block));
   }
 
-  std::monostate PreVisit(const Operation& operation) override {
+  void PreVisit(const Operation& operation) override {
     if (pre_visits_) nodes_.push_back(std::addressof(operation));
-    return {};
   }
 
-  void PostVisit(const Operation& operation, std::monostate&) override {
+  void PostVisit(const Operation& operation) override {
     if (post_visits_) nodes_.push_back(std::addressof(operation));
   }
 
@@ -171,7 +168,7 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
         post_visits_(traversal_type == TraversalType::POST ||
                      traversal_type == TraversalType::BOTH) {}
 
-  ResultType PreVisit(const Module& module) override {
+  ResultType ReturningPreVisit(const Module& module) override {
     ResultType result;
     if (pre_visits_) result.push_back((void*)std::addressof(module));
     return result;
@@ -183,7 +180,7 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
     if (post_visits_) result.push_back((void*)std::addressof(module));
   }
 
-  ResultType PreVisit(const Block& block) override {
+  ResultType ReturningPreVisit(const Block& block) override {
     ResultType result;
     if (pre_visits_) result.push_back((void*)std::addressof(block));
     return result;
@@ -196,7 +193,7 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
     if (post_visits_) result.push_back((void*)std::addressof(block));
   }
 
-  ResultType PreVisit(const Operation& operation) override {
+  ResultType ReturningPreVisit(const Operation& operation) override {
     ResultType result;
     if (pre_visits_) result.push_back((void*)std::addressof(operation));
     return result;

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -165,7 +165,7 @@ using ResultType=std::vector<void*>;
 // Another small test visitor that collects the nodes as they are visited to make
 // sure that  Pre and Post visits happened correctly.
 // Uses 'returns' rather than side effects.
-class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType> {
+class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType, true> {
  public:
   enum class TraversalType { kPre = 0x1, kPost = 0x2, kBoth = 0x3 };
   ReturningVisitor(TraversalType traversal_type)

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -173,11 +173,13 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
     if (pre_visits_) result.push_back((void*)std::addressof(module));
     return result;
   }
-  void FoldResult(const Module& module, ResultType child_result, ResultType& result) override {
+  ResultType FoldResult(const Module& module, ResultType child_result, ResultType result) override {
     result.insert( result.end(), child_result.begin(), child_result.end() );
+    return result;
   }
-  void PostVisit(const Module& module, ResultType& result) override {
+  ResultType PostVisit(const Module& module, ResultType result) override {
     if (post_visits_) result.push_back((void*)std::addressof(module));
+    return result;
   }
 
   ResultType ReturningPreVisit(const Block& block) override {
@@ -186,11 +188,13 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
     return result;
   }
 
-  void FoldResult(const Block& block, ResultType child_result, ResultType& result) override {
+  ResultType FoldResult(const Block& block, ResultType child_result, ResultType result) override {
     result.insert( result.end(), child_result.begin(), child_result.end() );
+    return result;
   }
-  void PostVisit(const Block& block, ResultType& result) override {
+  ResultType PostVisit(const Block& block, ResultType result) override {
     if (post_visits_) result.push_back((void*)std::addressof(block));
+    return result;
   }
 
   ResultType ReturningPreVisit(const Operation& operation) override {
@@ -199,11 +203,13 @@ class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType
     return result;
   }
 
-  void FoldResult(const Operation& operation, ResultType child_result, ResultType& result) override {
+  ResultType FoldResult(const Operation& operation, ResultType child_result, ResultType result) override {
     result.insert( result.end(), child_result.begin(), child_result.end() );
+    return result;
   }
-  void PostVisit(const Operation& operation, ResultType& result) override {
+  ResultType PostVisit(const Operation& operation, ResultType result) override {
     if (post_visits_) result.push_back((void*)std::addressof(operation));
+    return result;
   }
 
  private:

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -28,12 +28,12 @@ namespace {
 // sure that  Pre and Post visits happened correctly.
 class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor> {
  public:
-  enum class TraversalType { PRE = 0x1, POST = 0x2, BOTH = 0x3 };
+  enum class TraversalType { kPre = 0x1, kPost = 0x2, kBoth = 0x3 };
   CollectingVisitor(TraversalType traversal_type)
-      : pre_visits_(traversal_type == TraversalType::PRE ||
-                    traversal_type == TraversalType::BOTH),
-        post_visits_(traversal_type == TraversalType::POST ||
-                     traversal_type == TraversalType::BOTH) {}
+      : pre_visits_(traversal_type == TraversalType::kPre ||
+                    traversal_type == TraversalType::kBoth),
+        post_visits_(traversal_type == TraversalType::kPost ||
+                     traversal_type == TraversalType::kBoth) {}
 
   void PreVisit(const Module& module) override {
     if (pre_visits_) nodes_.push_back(std::addressof(module));
@@ -73,19 +73,19 @@ TEST(IRTraversingVisitorTest, TraversesModuleAsExpected) {
   const Block* block2 =
       std::addressof(global_module.AddBlock(std::make_unique<Block>()));
 
-  CollectingVisitor preorder_visitor(CollectingVisitor::TraversalType::PRE);
+  CollectingVisitor preorder_visitor(CollectingVisitor::TraversalType::kPre);
   global_module.Accept(preorder_visitor);
   EXPECT_THAT(
       preorder_visitor.nodes(),
       testing::ElementsAre(std::addressof(global_module), block1, block2));
 
-  CollectingVisitor postorder_visitor(CollectingVisitor::TraversalType::POST);
+  CollectingVisitor postorder_visitor(CollectingVisitor::TraversalType::kPost);
   global_module.Accept(postorder_visitor);
   EXPECT_THAT(
       postorder_visitor.nodes(),
       testing::ElementsAre(block1, block2, std::addressof(global_module)));
 
-  CollectingVisitor all_order_visitor(CollectingVisitor::TraversalType::BOTH);
+  CollectingVisitor all_order_visitor(CollectingVisitor::TraversalType::kBoth);
   global_module.Accept(all_order_visitor);
   EXPECT_THAT(
       all_order_visitor.nodes(),
@@ -103,19 +103,19 @@ TEST(IRTraversingVisitorTest, TraversesBlockAsExpected) {
       std::addressof(builder.AddOperation(*minus_op, {}, {}));
   auto block = builder.build();
 
-  CollectingVisitor preorder_visitor(CollectingVisitor::TraversalType::PRE);
+  CollectingVisitor preorder_visitor(CollectingVisitor::TraversalType::kPre);
   block->Accept(preorder_visitor);
   EXPECT_THAT(
       preorder_visitor.nodes(),
       testing::ElementsAre(block.get(), plus_op_instance, minus_op_instance));
 
-  CollectingVisitor postorder_visitor(CollectingVisitor::TraversalType::POST);
+  CollectingVisitor postorder_visitor(CollectingVisitor::TraversalType::kPost);
   block->Accept(postorder_visitor);
   EXPECT_THAT(
       postorder_visitor.nodes(),
       testing::ElementsAre(plus_op_instance, minus_op_instance, block.get()));
 
-  CollectingVisitor all_order_visitor(CollectingVisitor::TraversalType::BOTH);
+  CollectingVisitor all_order_visitor(CollectingVisitor::TraversalType::kBoth);
   block->Accept(all_order_visitor);
   EXPECT_THAT(
       all_order_visitor.nodes(),
@@ -132,19 +132,19 @@ TEST(IRTraversingVisitorTest, TraversesOperationAsExpected) {
                              std::make_unique<Module>());
   auto plus_op_module = plus_op_instance.impl_module();
 
-  CollectingVisitor preorder_visitor(CollectingVisitor::TraversalType::PRE);
+  CollectingVisitor preorder_visitor(CollectingVisitor::TraversalType::kPre);
   plus_op_instance.Accept(preorder_visitor);
   EXPECT_THAT(
       preorder_visitor.nodes(),
       testing::ElementsAre(std::addressof(plus_op_instance), plus_op_module));
 
-  CollectingVisitor postorder_visitor(CollectingVisitor::TraversalType::POST);
+  CollectingVisitor postorder_visitor(CollectingVisitor::TraversalType::kPost);
   plus_op_instance.Accept(postorder_visitor);
   EXPECT_THAT(
       postorder_visitor.nodes(),
       testing::ElementsAre(plus_op_module, std::addressof(plus_op_instance)));
 
-  CollectingVisitor all_order_visitor(CollectingVisitor::TraversalType::BOTH);
+  CollectingVisitor all_order_visitor(CollectingVisitor::TraversalType::kBoth);
   plus_op_instance.Accept(all_order_visitor);
   EXPECT_THAT(
       all_order_visitor.nodes(),
@@ -218,19 +218,19 @@ TEST(IRTraversingVisitorTest, TraversesModuleAsExpectedUsingReturns) {
   const Block* block2 =
       std::addressof(global_module.AddBlock(std::make_unique<Block>()));
 
-  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::PRE);
+  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::kPre);
   ResultType nodes1 = global_module.Accept<ReturningVisitor, ResultType>(preorder_visitor);
   EXPECT_THAT(
       nodes1,
       testing::ElementsAre(std::addressof(global_module), block1, block2));
 
-  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::POST);
+  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::kPost);
   ResultType nodes2 = global_module.Accept(postorder_visitor);
   EXPECT_THAT(
       nodes2,
       testing::ElementsAre(block1, block2, std::addressof(global_module)));
 
-  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::BOTH);
+  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::kBoth);
   ResultType nodes3 = global_module.Accept(all_order_visitor);
   EXPECT_THAT(
       nodes3,
@@ -248,19 +248,19 @@ TEST(IRTraversingVisitorTest, TraversesBlockAsExpectedUsingReturns) {
       std::addressof(builder.AddOperation(*minus_op, {}, {}));
   auto block = builder.build();
 
-  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::PRE);
+  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::kPre);
   ResultType nodes1 = block->Accept<ReturningVisitor, ResultType>(preorder_visitor);
   EXPECT_THAT(
       nodes1,
       testing::ElementsAre(block.get(), plus_op_instance, minus_op_instance));
 
-  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::POST);
+  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::kPost);
   ResultType nodes2 = block->Accept(postorder_visitor);
   EXPECT_THAT(
       nodes2,
       testing::ElementsAre(plus_op_instance, minus_op_instance, block.get()));
 
-  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::BOTH);
+  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::kBoth);
   ResultType nodes3 = block->Accept(all_order_visitor);
   EXPECT_THAT(
       nodes3,
@@ -277,19 +277,19 @@ TEST(IRTraversingVisitorTest, TraversesOperationAsExpectedUsingReturns) {
                              std::make_unique<Module>());
   auto plus_op_module = plus_op_instance.impl_module();
 
-  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::PRE);
+  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::kPre);
   ResultType nodes1 = plus_op_instance.Accept(preorder_visitor);
   EXPECT_THAT(
       nodes1,
       testing::ElementsAre(std::addressof(plus_op_instance), plus_op_module));
 
-  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::POST);
+  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::kPost);
   ResultType nodes2 = plus_op_instance.Accept(postorder_visitor);
   EXPECT_THAT(
       nodes2,
       testing::ElementsAre(plus_op_module, std::addressof(plus_op_instance)));
 
-  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::BOTH);
+  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::kBoth);
   ResultType nodes3 = plus_op_instance.Accept(all_order_visitor);
   EXPECT_THAT(
       nodes3,

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -161,12 +161,12 @@ using ResultType=std::vector<void*>;
 // Uses 'returns' rather than side effects.
 class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType> {
  public:
-  enum class TraversalType { PRE = 0x1, POST = 0x2, BOTH = 0x3 };
+  enum class TraversalType { kPre = 0x1, kPost = 0x2, kBoth = 0x3 };
   ReturningVisitor(TraversalType traversal_type)
-      : pre_visits_(traversal_type == TraversalType::PRE ||
-                    traversal_type == TraversalType::BOTH),
-        post_visits_(traversal_type == TraversalType::POST ||
-                     traversal_type == TraversalType::BOTH) {}
+      : pre_visits_(traversal_type == TraversalType::kPre ||
+                    traversal_type == TraversalType::kBoth),
+        post_visits_(traversal_type == TraversalType::kPost ||
+                     traversal_type == TraversalType::kBoth) {}
 
   ResultType ReturningPreVisit(const Module& module) override {
     ResultType result;

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -26,7 +26,7 @@ namespace {
 
 // Just a small test visitor that collects the nodes as they are visited to make
 // sure that  Pre and Post visits happened correctly.
-class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor> {
+class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor, std::monostate> {
  public:
   enum class TraversalType { PRE = 0x1, POST = 0x2, BOTH = 0x3 };
   CollectingVisitor(TraversalType traversal_type)
@@ -35,26 +35,29 @@ class CollectingVisitor : public IRTraversingVisitor<CollectingVisitor> {
         post_visits_(traversal_type == TraversalType::POST ||
                      traversal_type == TraversalType::BOTH) {}
 
-  void PreVisit(const Module& module) override {
+  std::monostate PreVisit(const Module& module) override {
     if (pre_visits_) nodes_.push_back(std::addressof(module));
+    return {};
   }
-  void PostVisit(const Module& module) override {
+  void PostVisit(const Module& module, std::monostate&) override {
     if (post_visits_) nodes_.push_back(std::addressof(module));
   }
 
-  void PreVisit(const Block& block) override {
+  std::monostate PreVisit(const Block& block) override {
     if (pre_visits_) nodes_.push_back(std::addressof(block));
+    return {};
   }
 
-  void PostVisit(const Block& block) override {
+  void PostVisit(const Block& block, std::monostate&) override {
     if (post_visits_) nodes_.push_back(std::addressof(block));
   }
 
-  void PreVisit(const Operation& operation) override {
+  std::monostate PreVisit(const Operation& operation) override {
     if (pre_visits_) nodes_.push_back(std::addressof(operation));
+    return {};
   }
 
-  void PostVisit(const Operation& operation) override {
+  void PostVisit(const Operation& operation, std::monostate&) override {
     if (post_visits_) nodes_.push_back(std::addressof(operation));
   }
 
@@ -148,6 +151,151 @@ TEST(IRTraversingVisitorTest, TraversesOperationAsExpected) {
   plus_op_instance.Accept(all_order_visitor);
   EXPECT_THAT(
       all_order_visitor.nodes(),
+      testing::ElementsAre(std::addressof(plus_op_instance), plus_op_module,
+                           plus_op_module, std::addressof(plus_op_instance)));
+}
+}  // namespace
+
+namespace {
+using ResultType=std::vector<void*>;
+
+// Another small test visitor that collects the nodes as they are visited to make
+// sure that  Pre and Post visits happened correctly.
+// Uses 'returns' rather than side effects.
+class ReturningVisitor : public IRTraversingVisitor<ReturningVisitor, ResultType> {
+ public:
+  enum class TraversalType { PRE = 0x1, POST = 0x2, BOTH = 0x3 };
+  ReturningVisitor(TraversalType traversal_type)
+      : pre_visits_(traversal_type == TraversalType::PRE ||
+                    traversal_type == TraversalType::BOTH),
+        post_visits_(traversal_type == TraversalType::POST ||
+                     traversal_type == TraversalType::BOTH) {}
+
+  ResultType PreVisit(const Module& module) override {
+    ResultType result;
+    if (pre_visits_) result.push_back((void*)std::addressof(module));
+    return result;
+  }
+  void FoldResult(const Module& module, ResultType child_result, ResultType& result) override {
+    result.insert( result.end(), child_result.begin(), child_result.end() );
+  }
+  void PostVisit(const Module& module, ResultType& result) override {
+    if (post_visits_) result.push_back((void*)std::addressof(module));
+  }
+
+  ResultType PreVisit(const Block& block) override {
+    ResultType result;
+    if (pre_visits_) result.push_back((void*)std::addressof(block));
+    return result;
+  }
+
+  void FoldResult(const Block& block, ResultType child_result, ResultType& result) override {
+    result.insert( result.end(), child_result.begin(), child_result.end() );
+  }
+  void PostVisit(const Block& block, ResultType& result) override {
+    if (post_visits_) result.push_back((void*)std::addressof(block));
+  }
+
+  ResultType PreVisit(const Operation& operation) override {
+    ResultType result;
+    if (pre_visits_) result.push_back((void*)std::addressof(operation));
+    return result;
+  }
+
+  void FoldResult(const Operation& operation, ResultType child_result, ResultType& result) override {
+    result.insert( result.end(), child_result.begin(), child_result.end() );
+  }
+  void PostVisit(const Operation& operation, ResultType& result) override {
+    if (post_visits_) result.push_back((void*)std::addressof(operation));
+  }
+
+ private:
+  const bool pre_visits_;
+  const bool post_visits_;
+};
+
+TEST(IRTraversingVisitorTest, TraversesModuleAsExpectedUsingReturns) {
+  Module global_module;
+  const Block* block1 =
+      std::addressof(global_module.AddBlock(std::make_unique<Block>()));
+  const Block* block2 =
+      std::addressof(global_module.AddBlock(std::make_unique<Block>()));
+
+  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::PRE);
+  ResultType nodes1 = global_module.Accept<ReturningVisitor, ResultType>(preorder_visitor);
+  EXPECT_THAT(
+      nodes1,
+      testing::ElementsAre(std::addressof(global_module), block1, block2));
+
+  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::POST);
+  ResultType nodes2 = global_module.Accept(postorder_visitor);
+  EXPECT_THAT(
+      nodes2,
+      testing::ElementsAre(block1, block2, std::addressof(global_module)));
+
+  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::BOTH);
+  ResultType nodes3 = global_module.Accept(all_order_visitor);
+  EXPECT_THAT(
+      nodes3,
+      testing::ElementsAre(std::addressof(global_module), block1, block1,
+                           block2, block2, std::addressof(global_module)));
+}
+
+TEST(IRTraversingVisitorTest, TraversesBlockAsExpectedUsingReturns) {
+  auto plus_op = std::make_unique<Operator>("core.plus");
+  auto minus_op = std::make_unique<Operator>("core.minus");
+  BlockBuilder builder;
+  const Operation* plus_op_instance =
+      std::addressof(builder.AddOperation(*plus_op, {}, {}));
+  const Operation* minus_op_instance =
+      std::addressof(builder.AddOperation(*minus_op, {}, {}));
+  auto block = builder.build();
+
+  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::PRE);
+  ResultType nodes1 = block->Accept<ReturningVisitor, ResultType>(preorder_visitor);
+  EXPECT_THAT(
+      nodes1,
+      testing::ElementsAre(block.get(), plus_op_instance, minus_op_instance));
+
+  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::POST);
+  ResultType nodes2 = block->Accept(postorder_visitor);
+  EXPECT_THAT(
+      nodes2,
+      testing::ElementsAre(plus_op_instance, minus_op_instance, block.get()));
+
+  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::BOTH);
+  ResultType nodes3 = block->Accept(all_order_visitor);
+  EXPECT_THAT(
+      nodes3,
+      testing::ElementsAre(block.get(), plus_op_instance, plus_op_instance,
+                           minus_op_instance, minus_op_instance, block.get()));
+}
+
+TEST(IRTraversingVisitorTest, TraversesOperationAsExpectedUsingReturns) {
+  auto plus_op = std::make_unique<Operator>("core.plus");
+  auto minus_op = std::make_unique<Operator>("core.minus");
+  BlockBuilder builder;
+
+  Operation plus_op_instance(nullptr, *plus_op, {}, {},
+                             std::make_unique<Module>());
+  auto plus_op_module = plus_op_instance.impl_module();
+
+  ReturningVisitor preorder_visitor(ReturningVisitor::TraversalType::PRE);
+  ResultType nodes1 = plus_op_instance.Accept(preorder_visitor);
+  EXPECT_THAT(
+      nodes1,
+      testing::ElementsAre(std::addressof(plus_op_instance), plus_op_module));
+
+  ReturningVisitor postorder_visitor(ReturningVisitor::TraversalType::POST);
+  ResultType nodes2 = plus_op_instance.Accept(postorder_visitor);
+  EXPECT_THAT(
+      nodes2,
+      testing::ElementsAre(plus_op_module, std::addressof(plus_op_instance)));
+
+  ReturningVisitor all_order_visitor(ReturningVisitor::TraversalType::BOTH);
+  ResultType nodes3 = plus_op_instance.Accept(all_order_visitor);
+  EXPECT_THAT(
+      nodes3,
       testing::ElementsAre(std::addressof(plus_op_instance), plus_op_module,
                            plus_op_module, std::addressof(plus_op_instance)));
 }

--- a/src/ir/ir_visitor.h
+++ b/src/ir/ir_visitor.h
@@ -16,6 +16,8 @@
 #ifndef SRC_IR_IR_VISITOR_H_
 #define SRC_IR_IR_VISITOR_H_
 
+#include "src/common/utils/types.h"
+
 namespace raksha::ir {
 
 class Module;
@@ -24,13 +26,13 @@ class Operation;
 
 // An interface for the visitor class. We will also pass in the `Derived` class
 // as template argument if we want to support CRTP at a later point.
-template <typename Derived, typename Result=void>
+template <typename Derived, bool IsConst=true, typename Result=void>
 class IRVisitor {
  public:
   virtual ~IRVisitor() {}
-  virtual Result Visit(const Module& module) = 0;
-  virtual Result Visit(const Block& operation) = 0;
-  virtual Result Visit(const Operation& operation) = 0;
+  virtual Result Visit(CopyConst<IsConst, Module>& module) = 0;
+  virtual Result Visit(CopyConst<IsConst, Block>& operation) = 0;
+  virtual Result Visit(CopyConst<IsConst, Operation>& operation) = 0;
 };
 
 }  // namespace raksha::ir

--- a/src/ir/ir_visitor.h
+++ b/src/ir/ir_visitor.h
@@ -26,7 +26,7 @@ class Operation;
 
 // An interface for the visitor class. We will also pass in the `Derived` class
 // as template argument if we want to support CRTP at a later point.
-template <typename Derived, bool IsConst=true, typename Result=void>
+template <typename Derived, typename Result=void, bool IsConst=true>
 class IRVisitor {
  public:
   virtual ~IRVisitor() {}

--- a/src/ir/ir_visitor.h
+++ b/src/ir/ir_visitor.h
@@ -24,13 +24,13 @@ class Operation;
 
 // An interface for the visitor class. We will also pass in the `Derived` class
 // as template argument if we want to support CRTP at a later point.
-template <typename Derived>
+template <typename Derived, typename Result=void>
 class IRVisitor {
  public:
   virtual ~IRVisitor() {}
-  virtual void Visit(const Module& module) = 0;
-  virtual void Visit(const Block& operation) = 0;
-  virtual void Visit(const Operation& operation) = 0;
+  virtual Result Visit(const Module& module) = 0;
+  virtual Result Visit(const Block& operation) = 0;
+  virtual Result Visit(const Operation& operation) = 0;
 };
 
 }  // namespace raksha::ir

--- a/src/ir/module.h
+++ b/src/ir/module.h
@@ -58,12 +58,12 @@ class Operation {
   std::string ToString(SsaNames& ssa_names) const;
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, false, Result>& visitor) {
+  Result Accept(IRVisitor<Derived, Result, true>& visitor) const {
     return visitor.Visit(*this);
   }
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, true, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, Result, false>& visitor) {
     return visitor.Visit(*this);
   }
 
@@ -101,12 +101,12 @@ class Block {
   const Module* parent_module() const { return parent_module_; }
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, false, Result>& visitor) {
+  Result Accept(IRVisitor<Derived, Result, true>& visitor) const {
     return visitor.Visit(*this);
   }
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, true, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, Result, false>& visitor) {
     return visitor.Visit(*this);
   }
 
@@ -158,12 +158,12 @@ class Module {
   const BlockListType& blocks() const { return blocks_; }
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, false, Result>& visitor) {
+  Result Accept(IRVisitor<Derived, Result, true>& visitor) const {
     return visitor.Visit(*this);
   }
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, true, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, Result, false>& visitor) {
     return visitor.Visit(*this);
   }
 

--- a/src/ir/module.h
+++ b/src/ir/module.h
@@ -58,7 +58,12 @@ class Operation {
   std::string ToString(SsaNames& ssa_names) const;
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, false, Result>& visitor) {
+    return visitor.Visit(*this);
+  }
+
+  template <typename Derived, typename Result=void>
+  Result Accept(IRVisitor<Derived, true, Result>& visitor) const {
     return visitor.Visit(*this);
   }
 
@@ -96,7 +101,12 @@ class Block {
   const Module* parent_module() const { return parent_module_; }
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, false, Result>& visitor) {
+    return visitor.Visit(*this);
+  }
+
+  template <typename Derived, typename Result=void>
+  Result Accept(IRVisitor<Derived, true, Result>& visitor) const {
     return visitor.Visit(*this);
   }
 
@@ -148,7 +158,12 @@ class Module {
   const BlockListType& blocks() const { return blocks_; }
 
   template <typename Derived, typename Result=void>
-  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, false, Result>& visitor) {
+    return visitor.Visit(*this);
+  }
+
+  template <typename Derived, typename Result=void>
+  Result Accept(IRVisitor<Derived, true, Result>& visitor) const {
     return visitor.Visit(*this);
   }
 

--- a/src/ir/module.h
+++ b/src/ir/module.h
@@ -57,9 +57,9 @@ class Operation {
 
   std::string ToString(SsaNames& ssa_names) const;
 
-  template <typename Derived>
-  void Accept(IRVisitor<Derived>& visitor) const {
-    visitor.Visit(*this);
+  template <typename Derived, typename Result=void>
+  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+    return visitor.Visit(*this);
   }
 
  private:
@@ -95,9 +95,9 @@ class Block {
   const NamedValueMap& results() const { return results_; }
   const Module* parent_module() const { return parent_module_; }
 
-  template <typename Derived>
-  void Accept(IRVisitor<Derived>& visitor) const {
-    visitor.Visit(*this);
+  template <typename Derived, typename Result=void>
+  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+    return visitor.Visit(*this);
   }
 
   friend class BlockBuilder;
@@ -147,9 +147,9 @@ class Module {
 
   const BlockListType& blocks() const { return blocks_; }
 
-  template <typename Derived>
-  void Accept(IRVisitor<Derived>& visitor) const {
-    visitor.Visit(*this);
+  template <typename Derived, typename Result=void>
+  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+    return visitor.Visit(*this);
   }
 
  private:

--- a/src/ir/storage.h
+++ b/src/ir/storage.h
@@ -38,7 +38,7 @@ class Storage {
   const types::Type& type() const { return type_; }
 
   std::string ToString() const {
-    // TODD(#335): When types have a ToString use that to print types.
+    // TODO(#335): When types have a ToString use that to print types.
     return absl::StrFormat("store:%s:type", name_);
   }
 

--- a/src/ir/value.h
+++ b/src/ir/value.h
@@ -17,6 +17,7 @@
 #define SRC_IR_VALUE_H_
 
 #include <vector>
+#include <variant>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_format.h"


### PR DESCRIPTION
This draft is based on https://github.com/google-research/raksha/pull/598
I'm sending it out as a preview of future work we could do.

Needs:
- Tests for non-const IR traversal (i.e. traversal while performing mutations)
- Static checks for CopyConst and SelectType (there's tests but these are pretty limited).
- Comments