### PR TITLE
 Use 'CopyConst' to Visitors over both const and non-const IR

### DIFF
--- a/src/common/utils/BUILD
+++ b/src/common/utils/BUILD
@@ -26,6 +26,15 @@ cc_library(
     deps = [],
 )
 
+cc_test(
+    name = "types_test",
+    srcs = ["types_test.cc"],
+    deps = [
+        ":types",
+        "//src/common/testing:gtest",
+    ],
+)
+
 cc_library(
     name = "intrusive_ptr",
     hdrs = ["intrusive_ptr.h"],

--- a/src/common/utils/intrusive_ptr.h
+++ b/src/common/utils/intrusive_ptr.h
@@ -20,7 +20,7 @@
 
 namespace raksha {
 
-// An implemntation of reference counted ptr where the reference count is
+// An implementation of reference counted ptr where the reference count is
 // embedded in the object itself (i.e., intrusive). This is mostly based on the
 // implementation of boost::intrusive_ptr.
 template <typename T>

--- a/src/common/utils/types.h
+++ b/src/common/utils/types.h
@@ -16,32 +16,15 @@
 #ifndef SRC_COMMON_UTILS_TYPES_H_
 #define SRC_COMMON_UTILS_TYPES_H_
 
+#include <type_traits>
 #include <variant>
 
 namespace raksha {
 // Type alias for monostate that sounds less scary.
 using Unit = std::monostate;
 
-// An implementation of a static, type-level, 'if'.
-// Useful for writing typesafe, code generically (especially for generic constness).
-// Based on SAT's laser (specifically 'misc_utils.h').
-template <bool Flag, typename T, typename F>
-struct SelectType {
-    using Result = T;
-};
-
-template <typename T, typename F>
-struct SelectType<true, T, F> {
-    using Result = T;
-};
-
-template <typename T, typename F>
-struct SelectType<false, T, F> {
-    using Result = F;
-};
-
 template <bool IsConst, typename T>
-using CopyConst = typename SelectType<IsConst, const T, T>::Result;
+using CopyConst = typename std::conditional_t<IsConst, std::add_const_t<T>, T>;
 
 }
 

--- a/src/common/utils/types.h
+++ b/src/common/utils/types.h
@@ -19,8 +19,30 @@
 #include <variant>
 
 namespace raksha {
-  // Type alias for monostate that sounds less scary.
-  using Unit = std::monostate;
+// Type alias for monostate that sounds less scary.
+using Unit = std::monostate;
+
+// An implementation of a static, type-level, 'if'.
+// Useful for writing typesafe, code generically (especially for generic constness).
+// Based on SAT's laser (specifically 'misc_utils.h').
+template <bool Flag, typename T, typename F>
+struct SelectType {
+    using Result = T;
+};
+
+template <typename T, typename F>
+struct SelectType<true, T, F> {
+    using Result = T;
+};
+
+template <typename T, typename F>
+struct SelectType<false, T, F> {
+    using Result = F;
+};
+
+template <bool IsConst, typename T>
+using CopyConst = typename SelectType<IsConst, const T, T>::Result;
+
 }
 
 #endif  // SRC_COMMON_UTILS_TYPES_H_

--- a/src/common/utils/types_test.cc
+++ b/src/common/utils/types_test.cc
@@ -23,20 +23,6 @@
 namespace raksha {
 namespace {
 
-TEST(TypesTest, SelectTypeTrue) {
-  SelectType<true, int, std::string>::Result a = 3;
-  ASSERT_EQ(typeid(&a), typeid(int *));
-  ASSERT_NE(typeid(&a), typeid(std::string *));
-  EXPECT_EQ(a, 3);
-}
-
-TEST(TypesTest, SelectTypeFalse) {
-  SelectType<false, int, std::string>::Result a = "Hi";
-  ASSERT_EQ(typeid(&a), typeid(std::string *));
-  ASSERT_NE(typeid(&a), typeid(int *));
-  EXPECT_EQ(a, "Hi");
-}
-
 TEST(TypesTest, CopyConstTypeTrue) {
   CopyConst<true, int> a = 3;
   ASSERT_EQ(typeid(&a), typeid(const int *));

--- a/src/common/utils/types_test.cc
+++ b/src/common/utils/types_test.cc
@@ -1,0 +1,57 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+#include "src/common/utils/types.h"
+
+#include <iostream>
+#include <string>
+
+#include "src/common/testing/gtest.h"
+
+namespace raksha {
+namespace {
+
+TEST(TypesTest, SelectTypeTrue) {
+  SelectType<true, int, std::string>::Result a = 3;
+  ASSERT_EQ(typeid(&a), typeid(int *));
+  ASSERT_NE(typeid(&a), typeid(std::string *));
+  EXPECT_EQ(a, 3);
+}
+
+TEST(TypesTest, SelectTypeFalse) {
+  SelectType<false, int, std::string>::Result a = "Hi";
+  ASSERT_EQ(typeid(&a), typeid(std::string *));
+  ASSERT_NE(typeid(&a), typeid(int *));
+  EXPECT_EQ(a, "Hi");
+}
+
+TEST(TypesTest, CopyConstTypeTrue) {
+  CopyConst<true, int> a = 3;
+  ASSERT_EQ(typeid(&a), typeid(const int *));
+  ASSERT_NE(typeid(&a), typeid(int *));
+  EXPECT_EQ(a, 3);
+}
+
+TEST(TypesTest, CopyConstTypeFalse) {
+  CopyConst<false, int> a = 4;
+  EXPECT_EQ(a, 4);
+  ASSERT_EQ(typeid(&a), typeid(int *));
+  ASSERT_NE(typeid(&a), typeid(const int *));
+  a++;
+  EXPECT_EQ(a, 5);
+}
+
+}  // namespace
+}  // namespace raksha

--- a/src/ir/ir_traversing_visitor.h
+++ b/src/ir/ir_traversing_visitor.h
@@ -26,8 +26,8 @@ namespace raksha::ir {
 // A visitor that also traverses the children of a node and allows performing
 // different actions before (PreVisit) and after (PostVisit) the children are
 // visited. Override any of the `PreVisit` and `PostVisit` methods as needed.
-template <typename Derived, typename Result = Unit>
-class IRTraversingVisitor : public IRVisitor<Derived, Result> {
+template <typename Derived, typename Result=Unit, bool IsConst=true>
+class IRTraversingVisitor : public IRVisitor<Derived, Result, IsConst> {
  private:
   template<class ValueType, class Enable = void>
   struct DefaultValueGetter {
@@ -53,56 +53,60 @@ class IRTraversingVisitor : public IRVisitor<Derived, Result> {
                             Result child_result) {
     return accumulator;
   }
-  // Invoked before all the children of `module` is visited.
-  virtual Result PreVisit(const Module& module) {
+
+  // Invoked before all the children of `module` are visited.
+  virtual Result PreVisit(CopyConst<IsConst, Module>& module) {
     return GetDefaultValue();
   }
-  // Invoked after all the children of `module` is visited.
-  virtual Result PostVisit(const Module& module, Result in_order_result) {
+  // Invoked after all the children of `module` are visited.
+  virtual Result PostVisit(CopyConst<IsConst, Module>& module, Result in_order_result) {
     return in_order_result;
   }
-  // Invoked before all the children of `block` is visited.
-  virtual Result PreVisit(const Block& block) {
+  // Invoked before all the children of `block` are visited.
+  virtual Result PreVisit(CopyConst<IsConst, Block>& block) {
     return GetDefaultValue();
   }
-  // Invoked after all the children of `block` is visited.
-  virtual Result PostVisit(const Block& block, Result in_order_result) {
+  // Invoked after all the children of `block` are visited.
+  virtual Result PostVisit(CopyConst<IsConst, Block>& block, Result in_order_result) {
     return in_order_result;
   }
-  // Invoked before all the children of `operation` is visited.
-  virtual Result PreVisit(const Operation& operation) {
+  // Invoked before all the children of `operation` are visited.
+  virtual Result PreVisit(CopyConst<IsConst, Operation>& operation) {
     return GetDefaultValue();
   }
-  // Invoked after all the children of `operation` is visited.
-  virtual Result PostVisit(const Operation& operation, Result in_order_result) {
+  // Invoked after all the children of `operation` are visited.
+  virtual Result PostVisit(CopyConst<IsConst, Operation>& operation,
+                           Result in_order_result) {
     return in_order_result;
   }
 
-  Result Visit(const Module& module) final override {
+  Result Visit(CopyConst<IsConst, Module>& module) final override {
     Result pre_visit_result = PreVisit(module);
     Result fold_result = common::utils::fold(
         module.blocks(), std::move(pre_visit_result),
-        [this](Result acc, const std::unique_ptr<Block>& block) {
+        [this](Result acc, CopyConst<IsConst, std::unique_ptr<Block>>& block) {
           return FoldResult(acc, block->Accept(*this));
         });
     return PostVisit(module, fold_result);
   }
 
-  Result Visit(const Block& block) final override {
+  Result Visit(CopyConst<IsConst, Block>& block) final override {
     Result pre_visit_result = PreVisit(block);
     Result fold_result = common::utils::fold(
         block.operations(), std::move(pre_visit_result),
-        [this](Result acc, const std::unique_ptr<Operation>& operation) {
+        [this](
+            Result acc,
+            CopyConst<IsConst, std::unique_ptr<Operation>>& operation) {
           return FoldResult(acc, operation->Accept(*this));
         });
     return PostVisit(block, fold_result);
   }
 
-  Result Visit(const Operation& operation) final override {
+  Result Visit(CopyConst<IsConst, Operation>& operation) final override {
     Result result = PreVisit(operation);
-    const Module* module = operation.impl_module();
+    auto* module = operation.impl_module();
     if (module != nullptr) {
-      result = FoldResult(std::move(result), module->Accept<Derived, Result>(*this));
+      result = FoldResult(result, module->Accept(*this));
     }
     return PostVisit(operation, result);
   }

--- a/src/ir/ir_traversing_visitor_test.cc
+++ b/src/ir/ir_traversing_visitor_test.cc
@@ -28,7 +28,10 @@ class WrappedInt {
  public:
   WrappedInt() = delete;
   WrappedInt(uint64_t val) : val_(val) {}
-
+  // Delete the copy constructor to ensure that only moves are used.
+  WrappedInt(const WrappedInt&) = delete;
+  // Have to explicitly enable moves.
+  WrappedInt(WrappedInt&&) = default;
   int64_t operator*() const { return val_; }
 
  private:

--- a/src/ir/ir_visitor.h
+++ b/src/ir/ir_visitor.h
@@ -26,13 +26,13 @@ class Operation;
 
 // An interface for the visitor class. We will also pass in the `Derived` class
 // as template argument if we want to support CRTP at a later point.
-template <typename Derived, typename Result = Unit>
+template <typename Derived, typename Result=Unit, bool IsConst=true>
 class IRVisitor {
  public:
   virtual ~IRVisitor() {}
-  virtual Result Visit(const Module& module) = 0;
-  virtual Result Visit(const Block& operation) = 0;
-  virtual Result Visit(const Operation& operation) = 0;
+  virtual Result Visit(CopyConst<IsConst, Module>& module) = 0;
+  virtual Result Visit(CopyConst<IsConst, Block>& operation) = 0;
+  virtual Result Visit(CopyConst<IsConst, Operation>& operation) = 0;
 };
 
 }  // namespace raksha::ir

--- a/src/ir/module.h
+++ b/src/ir/module.h
@@ -64,7 +64,12 @@ class Operation {
   std::string ToString(SsaNames& ssa_names) const;
 
   template <typename Derived, typename Result>
-  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, Result, false>& visitor) {
+    return visitor.Visit(*this);
+  }
+
+  template <typename Derived, typename Result>
+  Result Accept(IRVisitor<Derived, Result, true>& visitor) const {
     return visitor.Visit(*this);
   }
   void AddInput(const Value& value) { inputs_.push_back(value); }
@@ -107,7 +112,12 @@ class Block {
   const Module* parent_module() const { return parent_module_; }
 
   template <typename Derived, typename Result>
-  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, Result, false>& visitor) {
+    return visitor.Visit(*this);
+  }
+
+  template <typename Derived, typename Result>
+  Result Accept(IRVisitor<Derived, Result, true>& visitor) const {
     return visitor.Visit(*this);
   }
 
@@ -159,7 +169,12 @@ class Module {
   const BlockListType& blocks() const { return blocks_; }
 
   template <typename Derived, typename Result>
-  Result Accept(IRVisitor<Derived, Result>& visitor) const {
+  Result Accept(IRVisitor<Derived, Result, false>& visitor) {
+    return visitor.Visit(*this);
+  }
+
+  template <typename Derived, typename Result>
+  Result Accept(IRVisitor<Derived, Result, true>& visitor) const {
     return visitor.Visit(*this);
   }
 


### PR DESCRIPTION
Re-opening of #609 with the visitor change as a base for easier review.

Accidentally created #611 with the wrong base. Please disregard.