### PR TITLE
Fix `ir_printer.h` include that breaks external builds.

### DIFF
--- a/src/ir/block_builder_test.cc
+++ b/src/ir/block_builder_test.cc
@@ -20,7 +20,7 @@
 #include "src/common/testing/gtest.h"
 #include "src/ir/attributes/attribute.h"
 #include "src/ir/ir_context.h"
-#include  "third_party/raksha/src/ir/ir_printer.h"
+#include "src/ir/ir_printer.h"
 #include "src/ir/ssa_names.h"
 #include "src/ir/types/entity_type.h"
 #include "src/ir/types/type.h"


### PR DESCRIPTION
I see this at ToT here: https://github.com/google-research/raksha/blame/main/src/ir/block_builder_test.cc#L23

But it looks correct in https://github.com/google-research/raksha/pull/590/files#diff-4331b53480b9ef191adbc3c4fb8b7726a61ec9a4cea83663f0036c91e643f3a1 so I'm not sure what happened.