### PR TITLE
Revert "Update Bazel rules_foreign_cc from 0.4.0 to 0.8.0."

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,9 +41,9 @@ rules_proto_grpc_cpp_repos()
 #--------------------
 http_archive(
     name = "rules_foreign_cc",
-    sha256 = "6041f1374ff32ba711564374ad8e007aef77f71561a7ce784123b9b4b88614fc",
-    strip_prefix = "rules_foreign_cc-0.8.0",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.8.0.tar.gz",
+    sha256 = "e14a159c452a68a97a7c59fa458033cc91edb8224516295b047a95555140af5f",
+    strip_prefix = "rules_foreign_cc-0.4.0",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.4.0.tar.gz",
 )
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")


### PR DESCRIPTION
Reverts google-research/raksha#624. Hitting multiple issues on Mac after rules_foreign_cc is upgraded to 0.8.0.
```
./lib/msvc-nothrow.c:25:10: fatal error: 'windows.h' file not found
#include <windows.h>

./lib/findprog-in.c:137:25: error: implicit declaration of function 'eaccess' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                    if (eaccess (progpathname, X_OK) == 0)
                        ^
./lib/findprog-in.c:137:25: note: did you mean 'access'?
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:431:6: note: 'access' declared here
int      access(const char *, int);
         ^
./lib/findprog-in.c:211:21: error: implicit declaration of function 'eaccess' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                if (eaccess (progpathname, X_OK) == 0)
```