### PR TITLE
Check only source

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -34,6 +34,7 @@ SOURCE_FILES_PATTERNS=(
   ':!*.txt'
 
   # Exclude test files.
+  ':!*.auth'
   ':!*.authlogic'
   ':!*.raksha'
   ':!*.ir'

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -37,6 +37,7 @@ SOURCE_FILES_PATTERNS=(
   ':!*.authlogic'
   ':!*.raksha'
   ':!*.ir'
+  ':!**/testdata/**'
 
   # Exclude (generated) build and config files.
   ':(exclude,glob).*'

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -88,7 +88,7 @@ check_changed_files_for_missing_license() {
     # Initial commit: diff against an empty tree object
     against=$(git hash-object -t tree /dev/null)
   fi
-  for file in $(git diff --cached --name-only --diff-filter=ACMR -z $against | tr '\0' '\n'); do
+  for file in $(git diff --cached --name-only --diff-filter=ACMR -z $against -- $@ | tr '\0' '\n'); do
     check_file_for_missing_license $file
   done
 }
@@ -106,7 +106,7 @@ CMD=$1
 case $CMD in
   "" ) # Default pre-commit check.
     echo "Checking licenses in changed files..."
-    check_changed_files_for_missing_license
+    check_changed_files_for_missing_license ${SOURCE_FILES_PATTERNS[@]}
     ;;
   all ) # Used for manually checking 'all' files.
     echo "Checking licenses in all tracked files..."


### PR DESCRIPTION
A few changes to make the default license check ignore:

- `.auth` as well as `.authlogic` files (we're split between the two)
- `testdata` directories (as some of the data is either generated or compared with generated data)
- non-source files