### PR TITLE
Add --proto to check_policy_compliance

### DIFF
--- a/src/backends/policy_engine/souffle/BUILD
+++ b/src/backends/policy_engine/souffle/BUILD
@@ -69,6 +69,7 @@ cc_binary(
         "//src/backends/policy_engine:policy",
         "//src/backends/policy_engine:sql_policy_rule_policy",
         "//src/common/logging",
+        "//src/ir:proto_to_ir",
         "//src/parser/ir:ir_parser",
         "@absl//absl/flags:flag",
         "@absl//absl/flags:parse",
@@ -83,6 +84,7 @@ sh_test(
     args = [
         "$(location :check_policy_compliance)",
         "pass",
+        "ir",
         "$(location //src/backends/policy_engine/souffle/testdata:simple.ir)",
         "$(location //src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt)",
         "datalog_simple_policy_verifier_pass_datalog_cxx",
@@ -100,6 +102,7 @@ sh_test(
     args = [
         "$(location :check_policy_compliance)",
         "fail",
+        "ir",
         "$(location //src/backends/policy_engine/souffle/testdata:simple.ir)",
         "$(location //src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt)",
         "datalog_simple_policy_verifier_fail_datalog_cxx",
@@ -117,6 +120,7 @@ sh_test(
     args = [
         "$(location :check_policy_compliance)",
         "pass",
+        "ir",
         "$(location //src/backends/policy_engine/souffle/testdata:simple_passing_sql.ir)",
         "$(location //src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt)",
     ],
@@ -128,17 +132,48 @@ sh_test(
 )
 
 sh_test(
+    name = "check_policy_compliance_proto_pass_test",
+    srcs = ["check_policy_compliance_test.sh"],
+    args = [
+        "$(location :check_policy_compliance)",
+        "pass",
+        "proto",
+        "$(location //src/backends/policy_engine/souffle/testdata:simple_passing_sql.json)",
+        "$(location //src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt)",
+    ],
+    data = [
+        ":check_policy_compliance",
+        "//src/backends/policy_engine/souffle/testdata:simple_passing_sql.json",
+        "//src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt",
+    ],
+)
+
+sh_test(
     name = "check_policy_compliance_fail_test",
     srcs = ["check_policy_compliance_test.sh"],
     args = [
         "$(location :check_policy_compliance)",
         "fail",
+        "ir",
         "$(location //src/backends/policy_engine/souffle/testdata:simple_failing_sql.ir)",
         "$(location //src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt)",
     ],
     data = [
         ":check_policy_compliance",
         "//src/backends/policy_engine/souffle/testdata:simple_failing_sql.ir",
+        "//src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt",
+    ],
+)
+
+sh_test(
+    name = "check_policy_compliance_badargs_test",
+    srcs = ["check_policy_compliance_errors.sh"],
+    args = [
+        "$(location :check_policy_compliance)",
+        "$(location //src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt)",
+    ],
+    data = [
+        ":check_policy_compliance",
         "//src/backends/policy_engine/souffle/testdata:sql_policy_rules.txt",
     ],
 )

--- a/src/backends/policy_engine/souffle/check_policy_compliance.cc
+++ b/src/backends/policy_engine/souffle/check_policy_compliance.cc
@@ -29,12 +29,14 @@
 #include "src/backends/policy_engine/souffle/souffle_policy_checker.h"
 #include "src/backends/policy_engine/sql_policy_rule_policy.h"
 #include "src/common/logging/logging.h"
+#include "src/ir/proto_to_ir.h"
 #include "src/parser/ir/ir_parser.h"
 
-ABSL_FLAG(std::string, ir, "", "the IR file");
-ABSL_FLAG(std::optional<std::string>, sql_policy_rules, "",
+ABSL_FLAG(std::optional<std::string>, ir, std::nullopt, "the IR file");
+ABSL_FLAG(std::optional<std::string>, sql_policy_rules, std::nullopt,
           "file containing the SQL policy rules");
-ABSL_FLAG(std::optional<std::string>, policy_engine, "",
+ABSL_FLAG(std::optional<std::string>, proto, std::nullopt, "the proto file");
+ABSL_FLAG(std::optional<std::string>, policy_engine, std::nullopt,
           "name of the policy engine");
 
 constexpr char kUsageMessage[] =
@@ -61,6 +63,52 @@ absl::StatusOr<std::string> ReadFileContents(std::filesystem::path file_path) {
   return string_stream.str();
 }
 
+enum class ReturnCode : uint8_t { PASS = 0, FAIL = 1 , ERROR = 2};
+
+int UnwrapExitCode(ReturnCode code) { return static_cast<int>(code); }
+
+struct IrGraphComponents {
+  std::unique_ptr<raksha::ir::Module> ir_module;
+  std::unique_ptr<raksha::ir::SsaNames> ir_ssa_names;
+  std::unique_ptr<raksha::ir::IRContext> ir_context;
+};
+
+absl::StatusOr<IrGraphComponents> GetIrGraphComponentsFromIrPath(
+    absl::string_view ir_path) {
+  raksha::ir::IrProgramParser ir_parser;
+  absl::StatusOr<std::string> ir_string = ReadFileContents(ir_path);
+  if (ir_string.ok()) {
+    auto [context, module, ssa_names] = ir_parser.ParseProgram(*ir_string);
+    return IrGraphComponents{.ir_module = std::move(module),
+                             .ir_ssa_names = std::move(ssa_names),
+                             .ir_context = std::move(context)};
+  } else {
+    return ir_string.status();
+  }
+}
+
+absl::StatusOr<IrGraphComponents> GetIrGraphComponentsFromProtoPath(
+    absl::string_view proto_path) {
+  absl::StatusOr<std::string> proto_string = ReadFileContents(proto_path);
+  if (proto_string.ok()) {
+    std::unique_ptr<raksha::ir::IRContext> context =
+        std::make_unique<raksha::ir::IRContext>(); /*...*/
+    absl::StatusOr<raksha::ir::ProtoToIR::Result> ir_result =
+        raksha::ir::ProtoToIR::Convert(*context, *proto_string);
+    if (ir_result.ok()) {
+      return IrGraphComponents{
+          .ir_module = std::move(ir_result.value().module),
+          .ir_ssa_names = std::move(ir_result.value().ssa_names),
+          .ir_context = std::move(context)};
+    } else {
+      return ir_result.status();
+    }
+  } else {
+    LOG(ERROR) << "Error reading proto file: " << proto_string.status();
+    return proto_string.status();
+  }
+}
+
 }  // namespace
 
 using raksha::backends::policy_engine::AuthLogicPolicy;
@@ -72,36 +120,48 @@ int main(int argc, char* argv[]) {
   google::InitGoogleLogging("check_policy_compliance");
   absl::SetProgramUsageMessage(kUsageMessage);
   absl::ParseCommandLine(argc, argv);
-  // Parse the given IR file.
-  absl::StatusOr<std::string> ir_string =
-      ReadFileContents(absl::GetFlag(FLAGS_ir));
-  if (!ir_string.ok()) {
-    LOG(ERROR) << "Error reading IR file: " << ir_string.status();
-    return 2;
-  }
 
   // Read the sql policy rules file.
   absl::StatusOr<std::string> sql_policy_rules =
       ReadFileContents(absl::GetFlag(FLAGS_sql_policy_rules).value());
-  if (absl::GetFlag(FLAGS_sql_policy_rules).has_value() &&
-      !sql_policy_rules.ok()) {
+  if (absl::GetFlag(FLAGS_sql_policy_rules).has_value() && !sql_policy_rules.ok()) {
     LOG(ERROR) << "Error reading sql policy rules file: "
                << sql_policy_rules.status();
-    return 2;
+    return UnwrapExitCode(ReturnCode::ERROR);
+  }
+
+  const std::optional<std::string> ir_path = absl::GetFlag(FLAGS_ir);
+  const std::optional<std::string> proto_path = absl::GetFlag(FLAGS_proto);
+
+  if (ir_path.has_value() == proto_path.has_value()) {
+    if (ir_path.has_value()) {
+      LOG(ERROR) << "Both --ir and --proto cannot be used simultaneously.";
+    } else {
+      LOG(ERROR) << "One of --ir or --proto must be specified.";
+    }
+
+    return UnwrapExitCode(ReturnCode::ERROR);
+  }
+
+  // Parse either an IR file or a Proto file
+  const absl::StatusOr<IrGraphComponents> components =
+      ir_path.has_value() ? GetIrGraphComponentsFromIrPath(*ir_path)
+                          : GetIrGraphComponentsFromProtoPath(*proto_path);
+  if (!components.ok()) {
+    LOG(ERROR) << "Error during parsing graph " << components.status();
+    return UnwrapExitCode(ReturnCode::ERROR);
   }
 
   // Invoke policy checker and return result.
-  IrProgramParser irParser;
   bool policyCheckSucceeded = false;
-  auto [context, module, ssa_names] = irParser.ParseProgram(*ir_string);
   if (absl::GetFlag(FLAGS_policy_engine).has_value()) {
     AuthLogicPolicy policy(absl::GetFlag(FLAGS_policy_engine).value());
     policyCheckSucceeded =
-        SoufflePolicyChecker().IsModulePolicyCompliant(*module, policy);
+        SoufflePolicyChecker().IsModulePolicyCompliant(*components.value().ir_module, policy);
   } else if (absl::GetFlag(FLAGS_sql_policy_rules).has_value()) {
     SqlPolicyRulePolicy policy(*sql_policy_rules);
     policyCheckSucceeded =
-        SoufflePolicyChecker().IsModulePolicyCompliant(*module, policy);
+        SoufflePolicyChecker().IsModulePolicyCompliant(*components.value().ir_module, policy);
   } else {
     LOG(ERROR) << "Both sql_policy_rules and authorzation logic generated "
                   "datalog policy engine are undefined";
@@ -110,9 +170,9 @@ int main(int argc, char* argv[]) {
 
   if (policyCheckSucceeded) {
     LOG(ERROR) << "Policy check succeeded!";
-    return 0;
+    return UnwrapExitCode(ReturnCode::PASS);
   } else {
     LOG(ERROR) << "Policy check failed!";
-    return 1;
+    return UnwrapExitCode(ReturnCode::FAIL);
   }
 }

--- a/src/backends/policy_engine/souffle/check_policy_compliance_errors.sh
+++ b/src/backends/policy_engine/souffle/check_policy_compliance_errors.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#-------------------------------------------------------------------------------
+
+
+CMD_ARG=$1
+SQL_POLICY_RULES_FILE_ARG=$2
+
+# A simple script to test the `check_policy_compliance` command line tool.
+ROOT_DIR=${TEST_SRCDIR}/${TEST_WORKSPACE}
+CMD=${ROOT_DIR}/${CMD_ARG}
+SQL_POLICY_RULES_FILE=${ROOT_DIR}/${SQL_POLICY_RULES_FILE_ARG}
+ERROR_EXIT_CODE=2
+
+$CMD --ir=$FILE --proto=$FILE --sql_policy_rules=$SQL_POLICY_RULES_FILE
+CMD_RESULT=$?
+if [ ${CMD_RESULT} -eq ${ERROR_EXIT_CODE} ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/src/backends/policy_engine/souffle/check_policy_compliance_test.sh
+++ b/src/backends/policy_engine/souffle/check_policy_compliance_test.sh
@@ -22,19 +22,23 @@ FAIL_RESULT="fail"
 function printUsageAndExit() {
   echo "Usage: "
   echo "  check_policy_compliance_test.sh \ "
-  echo "     <cmd> ${PASS_RESULT}|${FAIL_RESULT} <ir_file> <sql_policy_rules_file> <policy_engine>"
+  echo "     <cmd> ${PASS_RESULT}|${FAIL_RESULT} <ir|proto> <file> <sql_policy_rules_file> <policy_engine>"
   exit 1
 }
 
-if [ $# -ne 5 || $# -ne 4]; then
+MAX_NUM_ARGS=6
+MIN_NUM_ARGS=5
+
+if [ $# -ne ${MAX_NUM_ARGS} || $# -ne ${MIN_NUM_ARGS}]; then
   printUsageAndExit
 fi
 
 CMD_ARG=$1
 EXPECTATION_ARG=$2
-IR_FILE_ARG=$3
-SQL_POLICY_RULES_FILE_ARG=$4
-POLICY_ENGINE=$5
+TYPE_ARG=$3
+FILE_ARG=$4
+SQL_POLICY_RULES_FILE_ARG=$5
+POLICY_ENGINE=$6
 
 if
   [ "${EXPECTATION_ARG}" != "${PASS_RESULT}" ] &&
@@ -45,9 +49,10 @@ fi
 # A simple script to test the `check_policy_compliance` command line tool.
 ROOT_DIR=${TEST_SRCDIR}/${TEST_WORKSPACE}
 CMD=${ROOT_DIR}/${CMD_ARG}
-IR_FILE=${ROOT_DIR}/${IR_FILE_ARG}
+FILE=${ROOT_DIR}/${FILE_ARG}
 SQL_POLICY_RULES_FILE=${ROOT_DIR}/${SQL_POLICY_RULES_FILE_ARG}
-$CMD --ir=$IR_FILE --sql_policy_rules=$SQL_POLICY_RULES_FILE --policy_engine=$POLICY_ENGINE
+
+$CMD --$TYPE_ARG=$FILE --sql_policy_rules=$SQL_POLICY_RULES_FILE --policy_engine=$POLICY_ENGINE
 CMD_RESULT=$?
 if [ ${CMD_RESULT} -eq 0 ]; then
   ACTUAL_RESULT="${PASS_RESULT}"

--- a/src/backends/policy_engine/souffle/testdata/BUILD
+++ b/src/backends/policy_engine/souffle/testdata/BUILD
@@ -23,6 +23,7 @@ package(
 exports_files([
     "sql_policy_rules.txt",
     "simple_passing_sql.ir",
+    "simple_passing_sql.json",
     "simple_failing_sql.ir",
     "empty_policy.txt",
     "simple_passing_policy.txt",

--- a/src/backends/policy_engine/souffle/testdata/simple_passing_sql.json
+++ b/src/backends/policy_engine/souffle/testdata/simple_passing_sql.json
@@ -1,0 +1,115 @@
+{
+  "topLevelModule": {
+    "blocks": [
+      {
+        "id": "6",
+        "block": {
+          "operations": [
+            {
+              "id": "1",
+              "operation": {
+                "operatorName": "sql.merge",
+                "attributes": {
+                  "attributes": {
+                    "control_input_start_index": {
+                      "int64Payload": "0"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "2",
+              "operation": {
+                "operatorName": "sql.tag_transform",
+                "inputs": [
+                  {
+                    "operationResultValue": {
+                      "operationId": "1",
+                      "outputName": "out"
+                    }
+                  }
+                ],
+                "attributes": {
+                  "attributes": {
+                    "rule_name": {
+                      "stringPayload": "set_restricted"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "3",
+              "operation": {
+                "operatorName": "sql.tag_transform",
+                "inputs": [
+                  {
+                    "operationResultValue": {
+                      "operationId": "2",
+                      "outputName": "out"
+                    }
+                  }
+                ],
+                "attributes": {
+                  "attributes": {
+                    "rule_name": {
+                      "stringPayload": "set_ssn_integrity"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "4",
+              "operation": {
+                "operatorName": "sql.tag_transform",
+                "inputs": [
+                  {
+                    "operationResultValue": {
+                      "operationId": "3",
+                      "outputName": "out"
+                    }
+                  }
+                ],
+                "attributes": {
+                  "attributes": {
+                    "rule_name": {
+                      "stringPayload": "remove_restricted_for_ssn"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "5",
+              "operation": {
+                "operatorName": "sql.sql_output",
+                "inputs": [
+                  {
+                    "operationResultValue": {
+                      "operationId": "4",
+                      "outputName": "out"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "frontend": "Raksha.IRToProto",
+  "operators": [
+    {
+      "name": "sql.merge"
+    },
+    {
+      "name": "sql.tag_transform"
+    },
+    {
+      "name": "sql.sql_output"
+    }
+  ]
+}

--- a/src/common/proto/BUILD
+++ b/src/common/proto/BUILD
@@ -30,6 +30,11 @@ alias(
 )
 
 alias(
+    name = "json_util",
+    actual = "@com_google_protobuf//:protobuf_headers",
+)
+
+alias(
     name = "proto_message_differencer",
     actual = "@com_google_protobuf//:protobuf_headers",
 )

--- a/src/ir/BUILD
+++ b/src/ir/BUILD
@@ -342,11 +342,14 @@ cc_library(
         ":module",
         ":ssa_names",
         ":value",
+        "//src/common/proto:json_util",
+        "//src/common/proto:protobuf",
         "//src/ir/attributes:attribute",
         "//src/ir/attributes:int_attribute",
         "//src/ir/attributes:string_attribute",
         "//src/ir/proto:ir_cc_proto",
         "@absl//absl/container:flat_hash_map",
+        "@absl//absl/status:statusor",
     ],
 )
 

--- a/src/ir/proto_to_ir.h
+++ b/src/ir/proto_to_ir.h
@@ -16,6 +16,7 @@
 #ifndef SRC_IR_PROTO_TO_IR_H_
 #define SRC_IR_PROTO_TO_IR_H_
 
+#include "google/protobuf/util/json_util.h"
 #include "src/ir/attributes/attribute.h"
 #include "src/ir/block_builder.h"
 #include "src/ir/ir_context.h"
@@ -23,6 +24,7 @@
 #include "src/ir/proto/raksha_ir.pb.h"
 #include "src/ir/ssa_names.h"
 #include "src/ir/value.h"
+#include "absl/status/statusor.h"
 
 namespace raksha::ir {
 
@@ -33,6 +35,20 @@ class ProtoToIR {
     std::unique_ptr<Module> module;
     std::unique_ptr<SsaNames> ssa_names;
   };
+
+  static absl::StatusOr<Result> Convert(IRContext& context,
+                        absl::string_view irTranslationUnitJsonProto) {
+      proto::IrTranslationUnit irTranslationUnit;
+      auto status = google::protobuf::util::JsonStringToMessage(irTranslationUnitJsonProto,
+                                                                &irTranslationUnit);
+      if (!status.ok()) {
+          LOG(ERROR) << "Json IR proto is corrupt " << status;
+          return absl::InvalidArgumentError("Json IR proto is corrupt");
+      }
+
+      return Convert(context, irTranslationUnit);
+  }
+
   static Result Convert(IRContext& context,
                         const proto::IrTranslationUnit& root) {
     // Store the operators in the context.


### PR DESCRIPTION
Add --proto to check_policy_compliance
Adds ProtoToIR::Convert(context, textproto)
    
    Allows running a policy check against a text proto
    instead of parsing IR.
