### PR TITLE
Fix for use of parser without exception support

### DIFF
--- a/src/backends/policy_engine/souffle/BUILD
+++ b/src/backends/policy_engine/souffle/BUILD
@@ -246,6 +246,8 @@ cc_library(
 cc_test(
     name = "souffle_policy_checker_test",
     srcs = ["souffle_policy_checker_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],
     deps = [
         ":souffle_policy_checker",
         "//src/backends/policy_engine:dp_parameter_policy",


### PR DESCRIPTION
Fixes build breakage from 7b3011c `Connect the IR translator to the DP analysis.`