### PR TITLE
Fix AuthLogic Visitor to not depend on evaluation order of arguments

### DIFF
--- a/src/ir/auth_logic/auth_logic_ast_traversing_visitor.h
+++ b/src/ir/auth_logic/auth_logic_ast_traversing_visitor.h
@@ -188,10 +188,14 @@ class AuthLogicAstTraversingVisitor
 
   Result Visit(CopyConst<IsConst, CanActAs>& can_act_as) final override {
     Result pre_visit_result = PreVisit(can_act_as);
+    Result left_principal_result = can_act_as.left_principal().Accept(*this);
+    Result right_principal_result = can_act_as.right_principal().Accept(*this);
+    // Run the child visitors before hand so that the results are not affected
+    // by the order of evaluation of arguments to CombineResult.
     Result fold_result =
         CombineResult(CombineResult(std::move(pre_visit_result),
-                                    can_act_as.left_principal().Accept(*this)),
-                      can_act_as.right_principal().Accept(*this));
+                                    std::move(left_principal_result)),
+                      std::move(right_principal_result));
     return PostVisit(can_act_as, std::move(fold_result));
   }
 
@@ -257,10 +261,13 @@ class AuthLogicAstTraversingVisitor
 
   Result Visit(CopyConst<IsConst, Query>& query) final override {
     Result pre_visit_result = PreVisit(query);
-    Result fold_result =
-        CombineResult(std::move(pre_visit_result),
-                      CombineResult(query.principal().Accept(*this),
-                                    query.fact().Accept(*this)));
+    Result principal_result = query.principal().Accept(*this);
+    Result fact_result = query.fact().Accept(*this);
+    // Run the child visitors before hand so that the results are not affected
+    // by the order of evaluation of arguments to CombineResult.
+    Result fold_result = CombineResult(
+        std::move(pre_visit_result),
+        CombineResult(std::move(principal_result), std::move(fact_result)));
     return PostVisit(query, fold_result);
   }
 


### PR DESCRIPTION
If the visitor has side effects, this was causing different test results depending upon the compiler. 