### PR TITLE
Convenience Factories for datalog::ArgumentType

### DIFF
--- a/src/ir/auth_logic/ast_construction.cc
+++ b/src/ir/auth_logic/ast_construction.cc
@@ -154,19 +154,16 @@ static datalog::ArgumentType ConstructArgumentType(
   if (auto* number_type_context =
           dynamic_cast<AuthLogicParser::NumberTypeContext*>(
               &auth_logic_type_context)) {
-    return datalog::ArgumentType(datalog::ArgumentType::Kind::kNumber,
-                                 number_type_context->NUMBERTYPE()->getText());
+    return datalog::ArgumentType::MakeNumberType();
   } else if (auto* principal_type_context =
                  dynamic_cast<AuthLogicParser::PrincipalTypeContext*>(
                      &auth_logic_type_context)) {
-    return datalog::ArgumentType(
-        datalog::ArgumentType::Kind::kPrincipal,
-        principal_type_context->PRINCIPALTYPE()->getText());
+    return datalog::ArgumentType::MakePrincipalType();
   }
   auto& custom_type_context =
       *CHECK_NOTNULL(dynamic_cast<AuthLogicParser::CustomTypeContext*>(
           &auth_logic_type_context));
-  return datalog::ArgumentType(datalog::ArgumentType::Kind::kCustom,
+  return datalog::ArgumentType::MakeCustomType(
                                custom_type_context.VARIABLE()->getText());
 }
 

--- a/src/ir/auth_logic/ast_construction.cc
+++ b/src/ir/auth_logic/ast_construction.cc
@@ -164,7 +164,7 @@ static datalog::ArgumentType ConstructArgumentType(
       *CHECK_NOTNULL(dynamic_cast<AuthLogicParser::CustomTypeContext*>(
           &auth_logic_type_context));
   return datalog::ArgumentType::MakeCustomType(
-                               custom_type_context.VARIABLE()->getText());
+      custom_type_context.VARIABLE()->getText());
 }
 
 static datalog::RelationDeclaration ConstructRelationDeclaration(

--- a/src/ir/auth_logic/lowering_ast_datalog.cc
+++ b/src/ir/auth_logic/lowering_ast_datalog.cc
@@ -292,9 +292,8 @@ LoweringToDatalogPass::TransformAttributeDeclarations(
       [](const datalog::RelationDeclaration& declaration) {
         if (!declaration.is_attribute()) return declaration;
         std::vector<datalog::Argument> transformed_arguments = {
-            datalog::Argument(
-                "attribute_prin",
-                datalog::ArgumentType::MakePrincipalType())};
+            datalog::Argument("attribute_prin",
+                              datalog::ArgumentType::MakePrincipalType())};
         absl::c_copy(declaration.arguments(),
                      std::back_inserter(transformed_arguments));
 
@@ -327,9 +326,9 @@ LoweringToDatalogPass::GetCanSayDeclarations(
     if (type_iterator == type_environment.end()) continue;
     // Adds new relation declaration for each can say delegation
     for (uint64_t i = 1; i <= depth; ++i) {
-      std::vector<datalog::Argument> arguments = {datalog::Argument(
-          absl::StrCat("delegatee", i),
-          datalog::ArgumentType::MakePrincipalType())};
+      std::vector<datalog::Argument> arguments = {
+          datalog::Argument(absl::StrCat("delegatee", i),
+                            datalog::ArgumentType::MakePrincipalType())};
       // for a depth of 1, we add a new can say declaration to the vector of can
       // say declarations by looking at the type_environment mappings (This will
       // give us the relation declaration for the base fact of can_say). Ex: To
@@ -379,8 +378,7 @@ LoweringToDatalogPass::GetSaysExtendRelationDeclarations(
       transformed_declarations,
       [](const datalog::RelationDeclaration& declaration) {
         std::vector<datalog::Argument> arguments = {datalog::Argument(
-            "speaker",
-            datalog::ArgumentType::MakePrincipalType())};
+            "speaker", datalog::ArgumentType::MakePrincipalType())};
         absl::c_copy(declaration.arguments(), std::back_inserter(arguments));
         return datalog::RelationDeclaration(
             absl::StrCat("says_", declaration.relation_name()), false,
@@ -414,18 +412,15 @@ LoweringToDatalogPass::RelationDeclarationToDLIR(
   //.decl canActAs(p1 : Principal, p2 : Principal)
   transformed_declarations.push_back(datalog::RelationDeclaration(
       "canActAs", false,
-      {datalog::Argument(
-           "p1", datalog::ArgumentType::MakePrincipalType()),
-       datalog::Argument(
-           "p2", datalog::ArgumentType::MakePrincipalType())}));
+      {datalog::Argument("p1", datalog::ArgumentType::MakePrincipalType()),
+       datalog::Argument("p2", datalog::ArgumentType::MakePrincipalType())}));
   // Another declaration "isNumber" added aa a work around for
   // universe_translations. To be removed after adding parser for
   // universe_translations. Declaration being added is
   //.decl isNumber(x : Number)
   transformed_declarations.push_back(datalog::RelationDeclaration(
       "isNumber", false,
-      {datalog::Argument(
-          "x", datalog::ArgumentType::MakeNumberType())}));
+      {datalog::Argument("x", datalog::ArgumentType::MakeNumberType())}));
   // The translated declarations are all extended with "says_" and a speaker
   // argument
   std::vector<datalog::RelationDeclaration>
@@ -453,9 +448,8 @@ LoweringToDatalogPass::QueryRelationDeclarationToDLIR(
   //.decl "grounded_dummy"(dummy_param : DummyType)
   query_declarations.push_back(datalog::RelationDeclaration(
       "grounded_dummy", false,
-      {datalog::Argument(
-          "dummy_param",
-          datalog::ArgumentType::MakeCustomType("DummyType"))}));
+      {datalog::Argument("dummy_param",
+                         datalog::ArgumentType::MakeCustomType("DummyType"))}));
   return query_declarations;
 }
 

--- a/src/ir/auth_logic/lowering_ast_datalog.cc
+++ b/src/ir/auth_logic/lowering_ast_datalog.cc
@@ -294,8 +294,7 @@ LoweringToDatalogPass::TransformAttributeDeclarations(
         std::vector<datalog::Argument> transformed_arguments = {
             datalog::Argument(
                 "attribute_prin",
-                datalog::ArgumentType(datalog::ArgumentType::Kind::kPrincipal,
-                                      "Principal"))};
+                datalog::ArgumentType::MakePrincipalType())};
         absl::c_copy(declaration.arguments(),
                      std::back_inserter(transformed_arguments));
 
@@ -330,8 +329,7 @@ LoweringToDatalogPass::GetCanSayDeclarations(
     for (uint64_t i = 1; i <= depth; ++i) {
       std::vector<datalog::Argument> arguments = {datalog::Argument(
           absl::StrCat("delegatee", i),
-          datalog::ArgumentType(datalog::ArgumentType::Kind::kPrincipal,
-                                "Principal"))};
+          datalog::ArgumentType::MakePrincipalType())};
       // for a depth of 1, we add a new can say declaration to the vector of can
       // say declarations by looking at the type_environment mappings (This will
       // give us the relation declaration for the base fact of can_say). Ex: To
@@ -382,8 +380,7 @@ LoweringToDatalogPass::GetSaysExtendRelationDeclarations(
       [](const datalog::RelationDeclaration& declaration) {
         std::vector<datalog::Argument> arguments = {datalog::Argument(
             "speaker",
-            datalog::ArgumentType(datalog::ArgumentType::Kind::kPrincipal,
-                                  "Principal"))};
+            datalog::ArgumentType::MakePrincipalType())};
         absl::c_copy(declaration.arguments(), std::back_inserter(arguments));
         return datalog::RelationDeclaration(
             absl::StrCat("says_", declaration.relation_name()), false,
@@ -418,11 +415,9 @@ LoweringToDatalogPass::RelationDeclarationToDLIR(
   transformed_declarations.push_back(datalog::RelationDeclaration(
       "canActAs", false,
       {datalog::Argument(
-           "p1", datalog::ArgumentType(datalog::ArgumentType::Kind::kPrincipal,
-                                       "Principal")),
+           "p1", datalog::ArgumentType::MakePrincipalType()),
        datalog::Argument(
-           "p2", datalog::ArgumentType(datalog::ArgumentType::Kind::kPrincipal,
-                                       "Principal"))}));
+           "p2", datalog::ArgumentType::MakePrincipalType())}));
   // Another declaration "isNumber" added aa a work around for
   // universe_translations. To be removed after adding parser for
   // universe_translations. Declaration being added is
@@ -430,8 +425,7 @@ LoweringToDatalogPass::RelationDeclarationToDLIR(
   transformed_declarations.push_back(datalog::RelationDeclaration(
       "isNumber", false,
       {datalog::Argument(
-          "x", datalog::ArgumentType(datalog::ArgumentType::Kind::kNumber,
-                                     "Number"))}));
+          "x", datalog::ArgumentType::MakeNumberType())}));
   // The translated declarations are all extended with "says_" and a speaker
   // argument
   std::vector<datalog::RelationDeclaration>
@@ -453,8 +447,7 @@ LoweringToDatalogPass::QueryRelationDeclarationToDLIR(
                 query.name(), false,
                 {datalog::Argument(
                     "dummy_param",
-                    datalog::ArgumentType(datalog::ArgumentType::Kind::kCustom,
-                                          "DummyType"))});
+                    datalog::ArgumentType::MakeCustomType("DummyType"))});
           });
   // Adding a relation declaration statement for grounded_dummy
   //.decl "grounded_dummy"(dummy_param : DummyType)
@@ -462,8 +455,7 @@ LoweringToDatalogPass::QueryRelationDeclarationToDLIR(
       "grounded_dummy", false,
       {datalog::Argument(
           "dummy_param",
-          datalog::ArgumentType(datalog::ArgumentType::Kind::kCustom,
-                                "DummyType"))}));
+          datalog::ArgumentType::MakeCustomType("DummyType"))}));
   return query_declarations;
 }
 

--- a/src/ir/auth_logic/souffle_emitter_test.cc
+++ b/src/ir/auth_logic/souffle_emitter_test.cc
@@ -51,8 +51,7 @@ Program BuildRelationDeclarationProgram(SaysAssertion assertion) {
   std::vector<datalog::RelationDeclaration> relation_declaration = {
       datalog::RelationDeclaration(
           "grantAccess", false,
-          {datalog::Argument(
-               "x0", datalog::ArgumentType::MakePrincipalType()),
+          {datalog::Argument("x0", datalog::ArgumentType::MakePrincipalType()),
            datalog::Argument(
                "x1", datalog::ArgumentType::MakeCustomType("FileName"))})};
   return Program(std::move(relation_declaration), std::move(assertion_list),

--- a/src/ir/auth_logic/souffle_emitter_test.cc
+++ b/src/ir/auth_logic/souffle_emitter_test.cc
@@ -52,11 +52,9 @@ Program BuildRelationDeclarationProgram(SaysAssertion assertion) {
       datalog::RelationDeclaration(
           "grantAccess", false,
           {datalog::Argument(
-               "x0", datalog::ArgumentType(
-                         datalog::ArgumentType::Kind::kPrincipal, "Principal")),
+               "x0", datalog::ArgumentType::MakePrincipalType()),
            datalog::Argument(
-               "x1", datalog::ArgumentType(datalog::ArgumentType::Kind::kCustom,
-                                           "FileName"))})};
+               "x1", datalog::ArgumentType::MakeCustomType("FileName"))})};
   return Program(std::move(relation_declaration), std::move(assertion_list),
                  {});
 }

--- a/src/ir/datalog/BUILD
+++ b/src/ir/datalog/BUILD
@@ -38,6 +38,15 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "argument_type_factory_test",
+    srcs = ["argument_type_factory_test.cc"],
+    deps = [
+        ":program",
+        "//src/common/testing:gtest",
+    ],
+)
+
 # This library contains our C++ model of the value types of Souffle.
 cc_library(
     name = "value",

--- a/src/ir/datalog/argument_type_factory_test.cc
+++ b/src/ir/datalog/argument_type_factory_test.cc
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------------
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------------
+
+#include "src/common/testing/gtest.h"
+#include "src/ir/datalog/program.h"
+
+namespace raksha::ir::datalog {
+
+TEST(ArgumentTypeFactoryTest, SimpleFactoryTest) {
+  ArgumentType number = ArgumentType::MakeNumberType();
+  ArgumentType principal = ArgumentType::MakePrincipalType();
+  ArgumentType custom1 = ArgumentType::MakeCustomType("Custom1");
+  ArgumentType custom2 = ArgumentType::MakeCustomType("Custom2");
+  EXPECT_EQ(number.name(), "Number");
+  EXPECT_EQ(principal.name(), "Principal");
+  EXPECT_EQ(custom1.name(), "Custom1");
+  EXPECT_EQ(custom2.name(), "Custom2");
+  EXPECT_EQ(number.kind(), ArgumentType::Kind::kNumber);
+  EXPECT_EQ(principal.kind(), ArgumentType::Kind::kPrincipal);
+  EXPECT_EQ(custom1.kind(), ArgumentType::Kind::kCustom);
+  EXPECT_EQ(custom2.kind(), ArgumentType::Kind::kCustom);
+}
+
+}  // namespace raksha::ir::datalog

--- a/src/ir/datalog/argument_type_factory_test.cc
+++ b/src/ir/datalog/argument_type_factory_test.cc
@@ -19,17 +19,23 @@
 
 namespace raksha::ir::datalog {
 
-TEST(ArgumentTypeFactoryTest, SimpleFactoryTest) {
+TEST(MakeNumberTypeTest, SimpleMakeNumberTypeTest) {
   ArgumentType number = ArgumentType::MakeNumberType();
+  EXPECT_EQ(number.name(), "Number");
+  EXPECT_EQ(number.kind(), ArgumentType::Kind::kNumber);
+}
+
+TEST(MakePrincipalTypeTest, SimpleMakePrincipalTypeTest) {
   ArgumentType principal = ArgumentType::MakePrincipalType();
+  EXPECT_EQ(principal.name(), "Principal");
+  EXPECT_EQ(principal.kind(), ArgumentType::Kind::kPrincipal);
+}
+
+TEST(MakeCustomTypeTest, SimpleMakeCustomTypeTest) {
   ArgumentType custom1 = ArgumentType::MakeCustomType("Custom1");
   ArgumentType custom2 = ArgumentType::MakeCustomType("Custom2");
-  EXPECT_EQ(number.name(), "Number");
-  EXPECT_EQ(principal.name(), "Principal");
   EXPECT_EQ(custom1.name(), "Custom1");
   EXPECT_EQ(custom2.name(), "Custom2");
-  EXPECT_EQ(number.kind(), ArgumentType::Kind::kNumber);
-  EXPECT_EQ(principal.kind(), ArgumentType::Kind::kPrincipal);
   EXPECT_EQ(custom1.kind(), ArgumentType::Kind::kCustom);
   EXPECT_EQ(custom2.kind(), ArgumentType::Kind::kCustom);
 }

--- a/src/ir/datalog/program.h
+++ b/src/ir/datalog/program.h
@@ -85,8 +85,6 @@ class Predicate {
 class ArgumentType {
  public:
   enum class Kind { kNumber, kPrincipal, kCustom };
-  explicit ArgumentType(Kind kind, absl::string_view name)
-      : kind_(kind), name_(name) {}
   Kind kind() const { return kind_; }
   absl::string_view name() const { return name_; }
   static ArgumentType MakePrincipalType() {
@@ -110,6 +108,8 @@ class ArgumentType {
   }
 
  private:
+  explicit ArgumentType(Kind kind, absl::string_view name)
+      : kind_(kind), name_(name) {}
   Kind kind_;
   std::string name_;
 };

--- a/src/ir/datalog/program.h
+++ b/src/ir/datalog/program.h
@@ -89,6 +89,15 @@ class ArgumentType {
       : kind_(kind), name_(name) {}
   Kind kind() const { return kind_; }
   absl::string_view name() const { return name_; }
+  static ArgumentType MakePrincipalType() {
+    return ArgumentType(Kind::kPrincipal, "Principal");
+  }
+  static ArgumentType MakeNumberType() {
+    return ArgumentType(Kind::kNumber, "Number");
+  }
+  static ArgumentType MakeCustomType(absl::string_view name) {
+    return ArgumentType(Kind::kCustom, std::move(name));
+  }
 
   std::string ToString() const { return absl::StrCat(kind_, name_); }
 

--- a/src/ir/datalog/program.h
+++ b/src/ir/datalog/program.h
@@ -94,7 +94,7 @@ class ArgumentType {
     return ArgumentType(Kind::kNumber, "Number");
   }
   static ArgumentType MakeCustomType(absl::string_view name) {
-    return ArgumentType(Kind::kCustom, std::move(name));
+    return ArgumentType(Kind::kCustom, name);
   }
 
   std::string ToString() const { return absl::StrCat(kind_, name_); }


### PR DESCRIPTION
This was originally done as part of #654 but has
been split into a separate PR in the interest
of keeping PRs more singular.

Note that because #654 uses these methods, #654 depends on this PR.