### PR TITLE
Small improvements to Auth Logic ToString

### DIFF
--- a/src/ir/auth_logic/BUILD
+++ b/src/ir/auth_logic/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "//src/ir/datalog:program",
         "@absl//absl/hash",
         "@absl//absl/strings:str_format",
+        "@absl//absl/strings:str_join",
     ],
 )
 

--- a/src/ir/auth_logic/BUILD
+++ b/src/ir/auth_logic/BUILD
@@ -35,8 +35,7 @@ cc_library(
         "//src/common/utils:types",
         "//src/ir/datalog:program",
         "@absl//absl/hash",
-        "@absl//absl/strings:str_format",
-        "@absl//absl/strings:str_join",
+        "@absl//absl/strings",
     ],
 )
 

--- a/src/ir/auth_logic/ast.h
+++ b/src/ir/auth_logic/ast.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "absl/hash/hash.h"
+#include "absl/strings/str_join.h"
 #include "src/common/utils/map_iter.h"
 #include "src/ir/auth_logic/auth_logic_ast_visitor.h"
 #include "src/ir/datalog/program.h"
@@ -452,10 +453,12 @@ class Program {
     for (const Query& query : queries_) {
       query_strings.push_back(query.ToString());
     }
-    return absl::StrCat("Program(\n",
-                        absl::StrJoin(relation_decl_strings, "\n"),
-                        absl::StrJoin(says_assertion_strings, "\n"),
-                        absl::StrJoin(query_strings, "\n"), ")");
+    return absl::StrJoin(
+        std::vector<std::string>({"Program(",
+                                  absl::StrJoin(relation_decl_strings, "\n"),
+                                  absl::StrJoin(says_assertion_strings, "\n"),
+                                  absl::StrJoin(query_strings, "\n")}),
+        "\n");
   }
 
   bool operator==(const Program& rhs) const {

--- a/src/ir/datalog/program.h
+++ b/src/ir/datalog/program.h
@@ -155,8 +155,10 @@ class RelationDeclaration {
     for (const Argument& arg : arguments_) {
       arg_strings.push_back(arg.ToString());
     }
-    return absl::StrCat(".decl ", relation_name_, is_attribute_,
-                        absl::StrJoin(arg_strings, ", "));
+    return absl::StrCat(".decl ", 
+            is_attribute_ ? " attribute " : "",
+            relation_name_, "(",
+                        absl::StrJoin(arg_strings, ", "), ")");
   }
 
  private:


### PR DESCRIPTION
These were originally made as part of #654, but
are split into this separate PR in order to
keep PRs more singular in purpose.

Tests of ToString will still be added later in a
separate PR in order to satisfy #720.