### PR TITLE
Add duplicate `http_archive`s for absl and re2 with official names.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,6 +148,13 @@ http_archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.0.tar.gz"],
 )
 
+http_archive(
+    name = "com_google_absl",
+    sha256 = "4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602",
+    strip_prefix = "abseil-cpp-20220623.0",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.0.tar.gz"],
+)
+
 # Bazel platform rules.
 http_archive(
     name = "platforms",
@@ -282,6 +289,13 @@ http_archive(
 # RE2
 http_archive(
     name = "re2",
+    sha256 = "f89c61410a072e5cbcf8c27e3a778da7d6fd2f2b5b1445cd4f4508bee946ab0f",
+    strip_prefix = "re2-2022-06-01",
+    urls = ["https://github.com/google/re2/archive/refs/tags/2022-06-01.tar.gz"],
+)
+
+http_archive(
+    name = "com_googlesource_code_re2",
     sha256 = "f89c61410a072e5cbcf8c27e3a778da7d6fd2f2b5b1445cd4f4508bee946ab0f",
     strip_prefix = "re2-2022-06-01",
     urls = ["https://github.com/google/re2/archive/refs/tags/2022-06-01.tar.gz"],


### PR DESCRIPTION
Although Bazel gives you the option of naming your http_archive repositories whatever you want, it apparently would really prefer if everyone chose the same name everywhere. This becomes apparent where fuzztest really wants the top level `WORKSPACE` to call absl `com_google_absl`, and Bazel will not allow me to use the shorter name `absl`. This is especially annoying because both `WORKSPACE`s describe `absl` using the same URL and sha256 hash, so you'd hope it would identify them as the same dependency? Discussions online do not give me great hope in flexibility from Bazel devs on this point:
https://github.com/bazelbuild/bazel/issues/3219

In any case, for now I am duplicating the dependency in two different `http_archive`s. I will remove the shorter, more readable `absl` and `re2` in the future once I have cut over to the new dependency.