### PR TITLE
Turn on `external_include_paths` feature.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,10 @@ try-import %workspace%/gcb/rbe/remote.bazelrc
 
 build --cxxopt='-std=c++17'
 build --cxxopt='-Werror' --cxxopt='-Wall'
+# This feature disables warnings in include paths from external repos. This is
+# useful because it allows us to ignore non-serious flaws in code for which we
+# are not directly responsible.
+build --features=external_include_paths
 build --cxxopt='-Wno-deprecated-declarations'
 # Why are we doing this when Souffle-generated C++ clearly uses exceptions?
 # Well, Google famously does not like C++ exceptions in its internal codebase,


### PR DESCRIPTION
The [`external_include_paths`
feature](https://www.buildbuddy.io/blog/whats-new-in-bazel-5-0/) makes include paths considered by Bazel to be "external" be compiled with more permissive warning flags than those in the regular project. This is helpful because this allows code that is not our direct responsibility to not have its warnings upgraded to errors. Hopefully will allow including external code more smoothly.