### PR TITLE
Update the release used for rules_m4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,15 +55,17 @@ rules_foreign_cc_dependencies()
 #--------------------
 # Rules_m4
 #--------------------
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "rules_m4",
-    sha256 = "c67fa9891bb19e9e6c1050003ba648d35383b8cb3c9572f397ad24040fb7f0eb",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2/rules_m4-v0.2.tar.xz"],
+    sha256 = "b0309baacfd1b736ed82dc2bb27b0ec38455a31a3d5d20f8d05e831ebeef1a8e",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.2/rules_m4-v0.2.2.tar.xz"],
 )
 
 load("@rules_m4//m4:m4.bzl", "m4_register_toolchains")
 
-m4_register_toolchains()
+m4_register_toolchains(version = "1.4.18")
 
 #--------------------
 # flex


### PR DESCRIPTION
This is needed to make m4 (and Raksha) buildable with systems that have glibc 2.34 or higher (including my cloudtop) as described
here: https://github.com/beancount/beancount/issues/683 and
here: https://github.com/chipsalliance/verible/issues/1122