### PR TITLE
Import ZetaSQL into Raksha's `WORKSPACE`.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -267,19 +267,16 @@ http_archive(
     urls = ["https://github.com/antlr/antlr4/archive/4.9.3.tar.gz"],
 )
 
+re2_commit_hash = "e8cb5ecb8ee1066611aa937a42fa10514edf30fb"
+
 # RE2
 http_archive(
-    name = "re2",
-    sha256 = "f89c61410a072e5cbcf8c27e3a778da7d6fd2f2b5b1445cd4f4508bee946ab0f",
-    strip_prefix = "re2-2022-06-01",
-    urls = ["https://github.com/google/re2/archive/refs/tags/2022-06-01.tar.gz"],
-)
-
-http_archive(
     name = "com_googlesource_code_re2",
-    sha256 = "f89c61410a072e5cbcf8c27e3a778da7d6fd2f2b5b1445cd4f4508bee946ab0f",
-    strip_prefix = "re2-2022-06-01",
-    urls = ["https://github.com/google/re2/archive/refs/tags/2022-06-01.tar.gz"],
+    sha256 = "c5f46950cdf33175f0668f454d9b6b4fe1b5a71ffd9283213e77fb04461af099",
+    strip_prefix = "re2-" + re2_commit_hash,
+    urls = [
+        "https://github.com/google/re2/archive/" + re2_commit_hash + ".tar.gz",
+    ],
 )
 
 fuzztest_commit_hash = "4a8253b7299cf1764550054fae55f1b58a65bbaa"
@@ -291,3 +288,31 @@ http_archive(
     strip_prefix = "fuzztest-" + fuzztest_commit_hash,
     urls = ["https://github.com/google/fuzztest/archive/" + fuzztest_commit_hash + ".zip"],
 )
+
+#zetasql
+zetasql_commit_hash = "177d495a064e38684c462cf883e22428273bd996"
+
+http_archive(
+    name = "com_google_zetasql",
+    sha256 = "5dc8f45b5d2b6d7ed39546d1c43c1a7cc341e6c1ae36aa93d8663f9c3a475aee",
+    strip_prefix = "zetasql-" + zetasql_commit_hash,
+    urls = [
+        "https://github.com/google/zetasql/archive/" + zetasql_commit_hash + ".zip",
+    ],
+)
+
+load("@com_google_zetasql//bazel:zetasql_deps_step_1.bzl", "zetasql_deps_step_1")
+
+zetasql_deps_step_1()
+
+load("@com_google_zetasql//bazel:zetasql_deps_step_2.bzl", "zetasql_deps_step_2")
+
+zetasql_deps_step_2()
+
+load("@com_google_zetasql//bazel:zetasql_deps_step_3.bzl", "zetasql_deps_step_3")
+
+zetasql_deps_step_3()
+
+load("@com_google_zetasql//bazel:zetasql_deps_step_4.bzl", "zetasql_deps_step_4")
+
+zetasql_deps_step_4()


### PR DESCRIPTION
This commit imports ZetaSQL into Raksha's `WORKSPACE`, laying the groundwork for it to be used as a SQL frontend. This also required downgrading re2 to a previous version to keep in sync with ZetaSQL.